### PR TITLE
Rename containers table to line_items & Container model to LineItem

### DIFF
--- a/TODO
+++ b/TODO
@@ -6,21 +6,21 @@ app/controllers/inventories_controller.rb:
   * [ 23] - the distribute! method needs to be worked into this controller somehow
 
 app/models/admin_user.rb:
-  * [  2] AdminUser should be rebuilt from scratch! 
+  * [  2] AdminUser should be rebuilt from scratch!
 
 app/models/barcode_item.rb:
-  * [ 21] - this should be renamed to something more specific -- it produces a hash, not a container object
+  * [ 21] - this should be renamed to something more specific -- it produces a hash, not a line_item object
 
 app/models/donation.rb:
   * [ 26] - change this to "by_source()" with an argument that accepts a source name
   * [ 33] - Can this be simplified so that we can just pass it the donation_item_params hash?
   * [ 42] - Test coverage for this method
   * [ 50] - Could this be made a member method "count" of the `items` association?
-  * [ 55] - This should check for existence of the item first. Also, I think there's a to_container method in Barcode, isn't there?
+  * [ 55] - This should check for existence of the item first. Also, I think there's a to_line_item method in Barcode, isn't there?
   * [ 60] - This can be refactored to just the find_by query; should also be made a predicate [contains_item_id?()]
   * [ 69] - Refactor this. "update" doesn't reflect that this "adds only"
 
-app/models/holding.rb:
+app/models/inventory_item.rb:
   * [ 24] - is there a reason for doing this instead of setting a DB default?
 
 app/models/inventory.rb:
@@ -28,8 +28,7 @@ app/models/inventory.rb:
   * [105] - this action is happening in the DistributionsController. Is this model the correct place for this method?
 
 app/models/transfer.rb:
-  * [ 26] - this could probably be made an association method for the `containers` association
-  * [ 31] - this could probably be made an association method for the `containers` association
-  * [ 36] - this could probably be made an association method for the `containers` association
-  * [ 43] - this could probably be made an association method for the `containers` association
-
+  * [ 26] - this could probably be made an association method for the `line_items` association
+  * [ 31] - this could probably be made an association method for the `line_items` association
+  * [ 36] - this could probably be made an association method for the `line_items` association
+  * [ 43] - this could probably be made an association method for the `line_items` association

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -9,7 +9,7 @@ class DistributionsController < ApplicationController
   end
 
   def index
-    @distributions = Distribution.includes(:containers).includes(:inventory).includes(:items).all
+    @distributions = Distribution.includes(:line_items).includes(:inventory).includes(:items).all
   end
 
   def create
@@ -27,7 +27,7 @@ class DistributionsController < ApplicationController
   end
 
   def show
-    @distribution = Distribution.includes(:containers).includes(:inventory).find(params[:id])
+    @distribution = Distribution.includes(:line_items).includes(:inventory).find(params[:id])
   end
 
   private

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -3,7 +3,7 @@ class DonationsController < ApplicationController
   def track
     @donation = Donation.find(params[:id])
     if (donation_item_params.has_key?(:barcode_id))
-      @donation.track_from_barcode(Barcode.find(donation_item_params[:barcode_id]).to_container)
+      @donation.track_from_barcode(Barcode.find(donation_item_params[:barcode_id]).to_line_item)
     else
       @donation.track(donation_item_params[:item_id], donation_item_params[:quantity])
     end
@@ -21,8 +21,8 @@ class DonationsController < ApplicationController
   end
 
   def index
-    @completed = Donation.includes(:containers).includes(:inventory).includes(:dropoff_location).completed
-    @incomplete = Donation.includes(:containers).includes(:inventory).includes(:dropoff_location).incomplete
+    @completed = Donation.includes(:line_items).includes(:inventory).includes(:dropoff_location).completed
+    @incomplete = Donation.includes(:line_items).includes(:inventory).includes(:dropoff_location).incomplete
   end
 
   def create
@@ -50,8 +50,8 @@ class DonationsController < ApplicationController
   end
 
   def show
-    @donation = Donation.includes(:containers).find(params[:id])
-    @containers = @donation.containers
+    @donation = Donation.includes(:line_items).find(params[:id])
+    @line_items = @donation.line_items
   end
 
   def update

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -1,6 +1,6 @@
 class TransfersController < ApplicationController
   def index
-  	@transfers = Transfer.includes(:containers).includes(:from).includes(:to).all
+  	@transfers = Transfer.includes(:line_items).includes(:from).includes(:to).all
   end
 
   def create
@@ -20,9 +20,9 @@ class TransfersController < ApplicationController
   end
 
   def show
-  	@transfer = Transfer.includes(:containers).includes(:from).includes(:to).includes(:items).find(params[:id])
+  	@transfer = Transfer.includes(:line_items).includes(:from).includes(:to).includes(:items).find(params[:id])
     @total = @transfer.total_quantity
-    @containers = @transfer.sorted_containers
+    @line_items = @transfer.sorted_line_items
   end
 
 private

--- a/app/models/barcode_item.rb
+++ b/app/models/barcode_item.rb
@@ -25,8 +25,8 @@ class BarcodeItem < ApplicationRecord
     Item.joins(:barcode_items).group(:id)
   end
 
-  # TODO - this should be renamed to something more specific -- it produces a hash, not a container object
-  def to_container
+  # TODO - this should be renamed to something more specific -- it produces a hash, not a line_item object
+  def to_line_item
     {
       item_id: item.id,
       quantity: quantity

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -20,38 +20,38 @@ class Distribution < ApplicationRecord
   belongs_to :partner
 
   # Distributions contain many different items
-  has_many :containers, as: :itemizable, inverse_of: :itemizable
-  has_many :items, through: :containers
-  accepts_nested_attributes_for :containers,
+  has_many :line_items, as: :itemizable, inverse_of: :itemizable
+  has_many :items, through: :line_items
+  accepts_nested_attributes_for :line_items,
     allow_destroy: true
 
   validates :inventory, :partner, presence: true
-  validates_associated :containers
-  validate :container_items_exist_in_inventory
+  validates_associated :line_items
+  validate :line_item_items_exist_in_inventory
 
   def quantities_by_category
-    containers.includes(:item).group("items.category").sum(:quantity)
+    line_items.includes(:item).group("items.category").sum(:quantity)
   end
 
-  def sorted_containers
-    containers.includes(:item).order("items.name")
+  def sorted_line_items
+    line_items.includes(:item).order("items.name")
   end
 
   def total_quantity
-    containers.sum(:quantity)
+    line_items.sum(:quantity)
   end
 
   private
 
 
 
-  def container_items_exist_in_inventory
-    self.containers.each do |container|
-      next unless container.item
-      inventory_item = self.inventory.inventory_items.find_by(item: container.item)
+  def line_item_items_exist_in_inventory
+    self.line_items.each do |line_item|
+      next unless line_item.item
+      inventory_item = self.inventory.inventory_items.find_by(item: line_item.item)
       if inventory_item.nil?
         errors.add(:inventory,
-                   "#{container.item.name} is not available " \
+                   "#{line_item.item.name} is not available " \
                    "at this storage location")
       end
     end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,13 +12,12 @@
 
 class Item < ApplicationRecord
   validates :name, presence: true, uniqueness: true
-
-  has_many :containers
+  has_many :line_items
   has_many :inventory_items
   has_many :barcode_items
   has_many :inventories, through: :inventory_items
-  has_many :donations, through: :containers, source: :itemizable, source_type: Donation
-  has_many :distributions, through: :containers, source: :itemizable, source_type: Distribution
+  has_many :donations, through: :line_items, source: :itemizable, source_type: Donation
+  has_many :distributions, through: :line_items, source: :itemizable, source_type: Distribution
 
   include Filterable
   scope :in_category, ->(category) { where(category: category) }

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: containers
+# Table name: line_items
 #
 #  id              :integer          not null, primary key
 #  quantity        :integer
@@ -11,16 +11,10 @@
 #  itemizable_type :string
 #
 
+class LineItem < ApplicationRecord
+  belongs_to :itemizable, polymorphic: true, inverse_of: :line_items, required: true
+  belongs_to :item
 
-
-RSpec.describe Container, type: :model do
-	context "Validations >" do
-		it "requires an item" do
-			expect(build(:container, item: nil)).not_to be_valid
-		end
-
-		it "requires a quantity" do
-			expect(build(:container, quantity: nil)).not_to be_valid
-		end
-	end
+  validates :item_id, presence: true
+  validates :quantity, presence: true
 end

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -14,40 +14,40 @@ class Transfer < ApplicationRecord
   belongs_to :from, :class_name => 'Inventory', :foreign_key => :from_id
   belongs_to :to, :class_name => 'Inventory', :foreign_key => :to_id
 
-  has_many :containers, as: :itemizable, inverse_of: :itemizable
-  has_many :items, through: :containers
-  accepts_nested_attributes_for :containers,
+  has_many :line_items, as: :itemizable, inverse_of: :itemizable
+  has_many :items, through: :line_items
+  accepts_nested_attributes_for :line_items,
     allow_destroy: true
 
   validates :from, :to, presence: true
-  validates_associated :containers
-  validate :container_items_exist_in_inventory
+  validates_associated :line_items
+  validate :line_item_items_exist_in_inventory
 
-  # TODO - this could probably be made an association method for the `containers` association
+  # TODO - this could probably be made an association method for the `line_items` association
   def quantities_by_category
-    containers.includes(:item).group("items.category").sum(:quantity)
+    line_items.includes(:item).group("items.category").sum(:quantity)
   end
 
-  # TODO - this could probably be made an association method for the `containers` association
-  def sorted_containers
-    containers.includes(:item).order("items.name")
+  # TODO - this could probably be made an association method for the `line_items` association
+  def sorted_line_items
+    line_items.includes(:item).order("items.name")
   end
 
-  # TODO - this could probably be made an association method for the `containers` association
+  # TODO - this could probably be made an association method for the `line_items` association
   def total_quantity
-    containers.sum(:quantity)
+    line_items.sum(:quantity)
   end
 
   private
 
-  # TODO - this could probably be made an association method for the `containers` association
-  def container_items_exist_in_inventory
-    self.containers.each do |container|
-      next unless container.item
-      inventory_item = self.from.inventory_items.find_by(item: container.item)
+  # TODO - this could probably be made an association method for the `line_items` association
+  def line_item_items_exist_in_inventory
+    self.line_items.each do |line_item|
+      next unless line_item.item
+      inventory_item = self.from.inventory_items.find_by(item: line_item.item)
       if inventory_item.nil?
         errors.add(:inventory,
-                   "#{container.item.name} is not available " \
+                   "#{line_item.item.name} is not available " \
                    "at this storage location")
       end
     end

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -7,7 +7,7 @@
 </fieldset>
 
 
-<section id="containers">
+<section id="line_items">
   <table>
     <thead>
       <th>Quantity</th>
@@ -15,7 +15,7 @@
     </thead>
 
     <tbody>
-      <%= render partial: "distribution_item_row", collection: @containers %>
+      <%= render partial: "distribution_item_row", collection: @line_items %>
     </tbody>
   </table>
 

--- a/app/views/donations/_donation_row.html.erb
+++ b/app/views/donations/_donation_row.html.erb
@@ -3,7 +3,7 @@
   <td><%= donation_row.dropoff_location.name %></td>
   <td><%= donation_row.inventory.name %></td>
   <td><%= donation_row.total_items %></td>
-  <td><%= donation_row.containers.size %></td>
+  <td><%= donation_row.line_items.size %></td>
   <td><%= donation_row.completed ? "Completed" : "In Progress" %></td>
   <td><%= link_to(donation_row.completed? ? "View" : "Add Items", donation_path(donation_row)) %> 
       <%= link_to("Edit", edit_donation_path(donation_row)) unless donation_row.completed? %>

--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -11,7 +11,7 @@
 </fieldset>
 
 
-<section id="containers">
+<section id="line_items">
   <table>
     <thead>
       <th>Item</th>
@@ -19,7 +19,7 @@
     </thead>
 
     <tbody>
-      <%= render partial: "donation_item_row", collection: @containers %>
+      <%= render partial: "donation_item_row", collection: @line_items %>
     </tbody>
   </table>
 

--- a/app/views/transfers/show.html.erb
+++ b/app/views/transfers/show.html.erb
@@ -13,10 +13,10 @@
   </thead>
 
   <tbody>
-    <% @containers.each do |container| %>
+    <% @line_items.each do |line_item| %>
       <tr>
-        <td><%= container.item.name %></td>
-        <td><%= container.quantity %></td>
+        <td><%= line_item.item.name %></td>
+        <td><%= line_item.quantity %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/initializers/simple_form_foundation.rb
+++ b/config/initializers/simple_form_foundation.rb
@@ -45,7 +45,7 @@ SimpleForm.setup do |config|
     b.use :html5
     b.optional :readonly
 
-    b.wrapper :container_wrapper, tag: 'div', class: 'small-offset-3 small-9 columns' do |ba|
+    b.wrapper :line_item_wrapper, tag: 'div', class: 'small-offset-3 small-9 columns' do |ba|
       ba.wrapper :tag => 'label', :class => 'checkbox' do |bb|
         bb.use :input
         bb.use :label_text

--- a/db/migrate/20170519144942_rename_containers_to_line_items.rb
+++ b/db/migrate/20170519144942_rename_containers_to_line_items.rb
@@ -1,0 +1,5 @@
+class RenameContainersToLineItems < ActiveRecord::Migration[5.0]
+  def change
+    rename_table :containers, :line_items
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170519134505) do
+ActiveRecord::Schema.define(version: 20170519144942) do
 
   create_table "barcode_items", force: :cascade do |t|
     t.string   "value"
@@ -18,16 +18,6 @@ ActiveRecord::Schema.define(version: 20170519134505) do
     t.integer  "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "containers", force: :cascade do |t|
-    t.integer  "quantity"
-    t.integer  "item_id"
-    t.integer  "itemizable_id"
-    t.string   "itemizable_type"
-    t.datetime "created_at",      null: false
-    t.datetime "updated_at",      null: false
-    t.index ["itemizable_id", "itemizable_type"], name: "index_containers_on_itemizable_id_and_itemizable_type"
   end
 
   create_table "distributions", force: :cascade do |t|
@@ -79,6 +69,16 @@ ActiveRecord::Schema.define(version: 20170519134505) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "barcode_count"
+  end
+
+  create_table "line_items", force: :cascade do |t|
+    t.integer  "quantity"
+    t.integer  "item_id"
+    t.integer  "itemizable_id"
+    t.string   "itemizable_type"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.index ["itemizable_id", "itemizable_type"], name: "index_line_items_on_itemizable_id_and_itemizable_type"
   end
 
   create_table "partners", force: :cascade do |t|

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -29,7 +29,7 @@ FactoryGirl.define do
                else
                  evaluator.item
                end
-        distribution.containers << build(:container, quantity: evaluator.item_quantity, item: item)
+        distribution.line_items << build(:line_item, quantity: evaluator.item_quantity, item: item)
       end
     end
   end

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -26,7 +26,7 @@ FactoryGirl.define do
 		trait :with_item do
 			after(:create) do |instance, evaluator|
 				item_id = (evaluator.item_id.nil?) ? create(:item).id : evaluator.item_id
-				instance.containers << create(:container, :donation, quantity: evaluator.item_quantity, item_id: item_id)
+				instance.line_items << create(:line_item, :donation, quantity: evaluator.item_quantity, item_id: item_id)
 			end
 		end
 	end

--- a/spec/factories/line_items.rb
+++ b/spec/factories/line_items.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: containers
+# Table name: line_items
 #
 #  id              :integer          not null, primary key
 #  quantity        :integer
@@ -12,7 +12,7 @@
 #
 
 FactoryGirl.define do
-	factory :container do
+	factory :line_item do
 		quantity 0
 		item
         itemizable_type "Donation"

--- a/spec/models/barcode_item_spec.rb
+++ b/spec/models/barcode_item_spec.rb
@@ -75,10 +75,10 @@ RSpec.describe BarcodeItem, type: :model do
     end
   end
 
-  describe "to_container >" do
-    it "emits a hash for a container" do
+  describe "to_line_item >" do
+    it "emits a hash for a line_item" do
       barcode_item = create :barcode_item
-      expect(barcode_item.to_container).to eq({item_id: barcode_item.item_id, quantity: barcode_item.quantity})
+      expect(barcode_item.to_line_item).to eq({item_id: barcode_item.item_id, quantity: barcode_item.quantity})
     end
   end
 end

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Distribution, type: :model do
   	  expect(build(:distribution, partner: nil)).not_to be_valid
   	end
 
-    xit "ensures the associated containers are valid" do
+    xit "ensures the associated line_items are valid" do
 
   	end
 
@@ -38,23 +38,23 @@ RSpec.describe Distribution, type: :model do
     end
 
   	it "quantities_by_category" do
-      @distribution.containers << create(:container, item: @first, quantity: 5)
-      @distribution.containers << create(:container, item: @last, quantity: 10)
-      @distribution.containers << create(:container, item: create(:item, category: "Foo"), quantity: 10)
+      @distribution.line_items << create(:line_item, item: @first, quantity: 5)
+      @distribution.line_items << create(:line_item, item: @last, quantity: 10)
+      @distribution.line_items << create(:line_item, item: create(:item, category: "Foo"), quantity: 10)
       expect(@distribution.quantities_by_category).to eq({"Bar" => 10, "Foo" => 15})
   	end
 
-  	it "sorted_containers" do
-      c1 = create(:container, item: @first)
-      c2 = create(:container, item: @last)
-      @distribution.containers << c1
-      @distribution.containers << c2
-      expect(@distribution.sorted_containers.to_a).to match_array [c1,c2]
+  	it "sorted_line_items" do
+      c1 = create(:line_item, item: @first)
+      c2 = create(:line_item, item: @last)
+      @distribution.line_items << c1
+      @distribution.line_items << c2
+      expect(@distribution.sorted_line_items.to_a).to match_array [c1,c2]
   	end
     
   	it "total_quantity" do
-  		@distribution.containers << create(:container, item: @first, quantity: 5)
-      @distribution.containers << create(:container, item: @last, quantity: 10)
+  		@distribution.line_items << create(:line_item, item: @first, quantity: 5)
+      @distribution.line_items << create(:line_item, item: @last, quantity: 10)
       expect(@distribution.total_quantity).to eq(15)
   	end
   end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -90,15 +90,15 @@ RSpec.describe Donation, type: :model do
     end
 
     describe "track" do
-      it "does not add a new container unnecessarily, updating existing container instead" do
+      it "does not add a new line_item unnecessarily, updating existing line_item instead" do
         donation = create(:donation)
         item = create :item
         donation.track(item, 5)
         expect {
           donation.track(item, 10)
-        }.not_to change{donation.containers.count}
+        }.not_to change{donation.line_items.count}
 
-        expect(donation.containers.first.quantity).to eq(15)
+        expect(donation.line_items.first.quantity).to eq(15)
       end
     end
 
@@ -107,7 +107,7 @@ RSpec.describe Donation, type: :model do
         donation = create :donation
         barcode_item = create :barcode_item
         expect{
-          donation.track_from_barcode(barcode_item.to_container); 
+          donation.track_from_barcode(barcode_item.to_line_item); 
           donation.reload
         }.to change{donation.items.count}.by(1)
       end
@@ -130,12 +130,12 @@ RSpec.describe Donation, type: :model do
     end
 
     describe "update_quantity" do
-      it "adds an additional quantity to the existing container" do
+      it "adds an additional quantity to the existing line_item" do
         donation = create(:donation, :with_item)
         expect { 
           donation.update_quantity(1, donation.items.first)
           donation.reload
-        }.to change{donation.containers.first.quantity}.by(1)
+        }.to change{donation.line_items.first.quantity}.by(1)
       end
 
       it "works whether you give it an item or an id" do
@@ -144,7 +144,7 @@ RSpec.describe Donation, type: :model do
         expect { 
           donation.update_quantity(1, donation.items.first.id)
           donation.reload
-        }.to change{donation.containers.first.quantity}.by(1)
+        }.to change{donation.line_items.first.quantity}.by(1)
       end
     end
   end

--- a/spec/models/inventory_spec.rb
+++ b/spec/models/inventory_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe Inventory, type: :model do
         inventory.intake!(donation)
 
         expect(inventory.inventory_items.count).to eq(1)
-        expect(inventory.inventory_items.where(item_id: donation.containers.first.item.id).first.quantity).to eq(20)
+        expect(inventory.inventory_items.where(item_id: donation.line_items.first.item.id).first.quantity).to eq(20)
       end
     end
 
@@ -108,7 +108,7 @@ RSpec.describe Inventory, type: :model do
       it "raises error when distribution exceeds inventory" do
         inventory = create :inventory, :with_items, item_quantity: 300
         distribution = build :distribution, :with_items, inventory: inventory, item_quantity: 350
-        item = distribution.containers.first.item
+        item = distribution.line_items.first.item
         expect {
           inventory.distribute!(distribution)
         }.to raise_error do |error|

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -1,6 +1,6 @@
 # == Schema Information
 #
-# Table name: containers
+# Table name: line_items
 #
 #  id              :integer          not null, primary key
 #  quantity        :integer
@@ -11,10 +11,16 @@
 #  itemizable_type :string
 #
 
-class Container < ApplicationRecord
-  belongs_to :itemizable, polymorphic: true, inverse_of: :containers, required: true
-  belongs_to :item
 
-  validates :item_id, presence: true
-  validates :quantity, presence: true
+
+RSpec.describe LineItem, type: :model do
+	context "Validations >" do
+		it "requires an item" do
+			expect(build(:line_item, item: nil)).not_to be_valid
+		end
+
+		it "requires a quantity" do
+			expect(build(:line_item, quantity: nil)).not_to be_valid
+		end
+	end
 end

--- a/spec/views/distributions/show.html.erb_spec.rb
+++ b/spec/views/distributions/show.html.erb_spec.rb
@@ -5,12 +5,12 @@ RSpec.describe "distributions/show.html.erb", type: :view do
       inventory = create(:inventory, :with_items, item_quantity: 5, item: item)
       @distribution = create(:distribution, :with_items, inventory: inventory, item_quantity: 5, item: item)
       assign(:distribution, @distribution)
-      assign(:containers, @distribution.containers)
+      assign(:line_items, @distribution.line_items)
       render
     end
 
     it "DOES list the items found in the distribution, along with quantities" do
-    	expect(rendered).to have_xpath("//section[@id='containers']/table/tbody/tr", count: 1)
+    	expect(rendered).to have_xpath("//section[@id='line_items']/table/tbody/tr", count: 1)
     end
   end
 end

--- a/spec/views/donations/show.html.erb_spec.rb
+++ b/spec/views/donations/show.html.erb_spec.rb
@@ -29,17 +29,17 @@ RSpec.describe "donations/show.html.erb", type: :view do
     before :each do
       @complete = create(:donation, :with_item, item_quantity: 5, item_id: create(:item).id, completed: true)
       assign(:donation, @complete)
-      assign(:containers, @complete.containers)
+      assign(:line_items, @complete.line_items)
       render
     end
 
     it "DOES list the items found in the donation, along with quantities" do
-    	expect(rendered).to have_xpath("//section[@id='containers']/table/tbody/tr", count: 1)
+    	expect(rendered).to have_xpath("//section[@id='line_items']/table/tbody/tr", count: 1)
     end
 
     it "does NOT show any forms for doing anything" do
-    	expect(rendered).not_to have_xpath("//section[@id='containers']/select")
-    	expect(rendered).not_to have_xpath("//section[@id='containers']/input")
+    	expect(rendered).not_to have_xpath("//section[@id='line_items']/select")
+    	expect(rendered).not_to have_xpath("//section[@id='line_items']/input")
     end
 
     it "does NOT show a 'Complete' link" do

--- a/spec/views/transfers/index.html.erb_spec.rb
+++ b/spec/views/transfers/index.html.erb_spec.rb
@@ -3,11 +3,11 @@
 RSpec.describe "transfers/index.html.erb", type: :view do
   before(:each) do
   	t1 = create(:transfer, comment: "MOVES STUFF", from: create(:inventory, name: "From1"), to: create(:inventory, name: "To1"))
-  	t1.containers << create(:container, quantity: 10)
-  	t1.containers << create(:container, quantity: 20)
+  	t1.line_items << create(:line_item, quantity: 10)
+  	t1.line_items << create(:line_item, quantity: 20)
 
   	t2 = create(:transfer)
-  	t2.containers << create(:container)
+  	t2.line_items << create(:line_item)
 
     assign(:transfers, Transfer.all)
 

--- a/spec/views/transfers/show.html.erb_spec.rb
+++ b/spec/views/transfers/show.html.erb_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe "transfers/show.html.erb", type: :view do
   	@from = create(:inventory, name: "Bar")
 
   	@transfer = create(:transfer, from: @from, to: @to)
-  	@transfer.containers << create(:container, item: @item, quantity: 10)
+  	@transfer.line_items << create(:line_item, item: @item, quantity: 10)
 
     assign(:transfer, @transfer)
     assign(:total, @transfer.total_quantity)
-    assign(:containers, @transfer.sorted_containers)
+    assign(:line_items, @transfer.sorted_line_items)
 
   	render
   end


### PR DESCRIPTION
For Issue #35 and a follow up to PR #32, renames `containers` to `line_items` throughout app.