### PR TITLE
Donations: Allow creation with line items and no more 'completed' attr

### DIFF
--- a/app/assets/javascripts/transfers.coffee
+++ b/app/assets/javascripts/transfers.coffee
@@ -24,6 +24,3 @@ $ ->
         $.each data, (index) ->
           options += "<option value=\"" + data[index].item_id + "\">" + data[index].item_name + "</option>\n"
         $("select", insertedItem).find('option').remove().end().append(options)
-
-
-

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -1,7 +1,7 @@
 class DonationsController < ApplicationController
   # We load the resources in before_filters so that they are not re-loaded
   # by Cancan, which won't use the correct methods.
-  #before_filter :simple_load, only: [:track, :remove_item, :complete, :edit, :update, :destroy]
+  #before_filter :simple_load, only: [:track, :remove_item, :edit, :update, :destroy]
   #before_filter :eager_load_single, only: [:show]
   #before_filter :load_collection, only: [:index]
   #before_filter :load_new, only: [:new]
@@ -24,16 +24,8 @@ class DonationsController < ApplicationController
     @donation.remove(donation_item_params[:item_id])
   end
 
-  def complete
-    @donation = current_organization.donations.find(params[:id])
-    @donation.complete
-    redirect_to donations_path, notice: "Completed!"
-  end
-
   def index
     @donations = Donation.includes(:line_items, :storage_location, :dropoff_location)
-    @completed = @donations.completed
-    @incomplete = @donations.incomplete
   end
 
   def create
@@ -82,7 +74,7 @@ class DonationsController < ApplicationController
 
 private
   def donation_params
-    params.require(:donation).permit(:source, :storage_location_id, :dropoff_location_id, line_items_attributes: [:item_id, :quantity, :_destroy])
+    params.require(:donation).permit(:source, :storage_location_id, :dropoff_location_id, line_items_attributes: [:item_id, :quantity, :_destroy]).merge(organization: current_organization)
   end
 
   def donation_item_params

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -39,7 +39,7 @@ class DonationsController < ApplicationController
   def create
     @donation = Donation.new(donation_params.merge(organization: current_organization))
     if (@donation.save)
-      redirect_to(donations_path)
+      redirect_to donations_path
     else
       @storage_locations = StorageLocation.all
       @dropoff_locations = DropoffLocation.all

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -39,7 +39,7 @@ class DonationsController < ApplicationController
   def create
     @donation = Donation.new(donation_params.merge(organization: current_organization))
     if (@donation.save)
-      redirect_to(edit_donation_path(@donation))
+      redirect_to(donations_path)
     else
       @storage_locations = StorageLocation.all
       @dropoff_locations = DropoffLocation.all
@@ -50,16 +50,17 @@ class DonationsController < ApplicationController
 
   def new
     @donation = Donation.new
+    @donation.line_items.build
     @storage_locations = StorageLocation.all
     @dropoff_locations = DropoffLocation.all
-
+    @items = Item.alphabetized
   end
 
   def edit
-    @donation = current_organization.donations.find(params[:id])    
+    @donation = Donation.find(params[:id])
+    @donation.line_items.build
     @storage_locations = StorageLocation.all
     @dropoff_locations = DropoffLocation.all
-
   end
 
   def show
@@ -81,11 +82,10 @@ class DonationsController < ApplicationController
 
 private
   def donation_params
-    params.require(:donation).permit(:source, :storage_location_id, :dropoff_location_id).merge(organization: current_organization)
+    params.require(:donation).permit(:source, :storage_location_id, :dropoff_location_id, line_items_attributes: [:item_id, :quantity, :_destroy])
   end
 
   def donation_item_params
     params.require(:donation).permit(:barcode_id, :item_id, :quantity)
   end
 end
-

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -25,10 +25,8 @@ class Donation < ApplicationRecord
   accepts_nested_attributes_for :line_items,
     allow_destroy: true
 
-  validates :dropoff_location, :storage_location, :source, :line_items, :organization, presence: true
+  validates :dropoff_location, :storage_location, :source, :organization, presence: true
 
-  scope :completed, -> { where(completed: true) }
-  scope :incomplete, -> { where(completed: false) }
   scope :between, ->(start, stop) { where(donations: { created_at: start..stop }) }
   # TODO - change this to "by_source()" with an argument that accepts a source name
   scope :diaper_drive, -> { where(source: "Diaper Drive") }
@@ -78,11 +76,6 @@ class Donation < ApplicationRecord
     line_item = self.line_items.find_by(item_id: i.id)
     line_item.quantity += q
     line_item.save
-  end
-
-  def complete
-    self.completed = true
-    self.save
   end
 
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -25,7 +25,7 @@ class Donation < ApplicationRecord
   accepts_nested_attributes_for :line_items,
     allow_destroy: true
 
-  validates :dropoff_location, :storage_location, :source, :organization, presence: true
+  validates :dropoff_location, :storage_location, :source, :line_items, :organization, presence: true
 
   scope :completed, -> { where(completed: true) }
   scope :incomplete, -> { where(completed: false) }

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -14,12 +14,16 @@
 #
 
 class Donation < ApplicationRecord
+  SOURCES = ["Diaper Drive", "Purchased Supplies", "Donation Pickup Location", "Misc. Donation"].freeze
+
   belongs_to :organization
 
   belongs_to :dropoff_location
-  has_many :line_items, as: :itemizable, inverse_of: :itemizable
   belongs_to :storage_location
+  has_many :line_items, as: :itemizable, inverse_of: :itemizable
   has_many :items, through: :line_items
+  accepts_nested_attributes_for :line_items,
+    allow_destroy: true
 
   validates :dropoff_location, :storage_location, :source, :organization, presence: true
 

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -1,9 +1,29 @@
-<%= simple_form_for donation_form do |f| %>
+<%= simple_form_for @donation do |f| %>
 
-  <%= f.input :source, label: "Source", error: "What effort or initiative did this donation come from?" %>
+  <%= f.input :source, collection: Donation::SOURCES, label: "Source", error: "What effort or initiative did this donation come from?" %>
   <%= f.association :dropoff_location, collection: @dropoff_locations, label: "Dropoff Location", error: "Where was this donation dropped off?" %>
   <%= f.association :storage_location, collection: @storage_locations, label: "Storage Location", error: "Where is it being stored?" %>
 
-  <%= f.button :submit %>
+  <%= f.simple_fields_for :line_items do |item| %>
+    <div id="transfer_line_items">
+      <%= render 'line_item_fields', f: item %>
+    </div>
+    <div class="row links">
+      <div class="small-offset-3 small-9 columns">
+        <%= link_to_add_association "add line item", f, :line_items,
+        data: {
+          association_insertion_node: "#transfer_line_items",
+          association_insertion_method: "append"
+        }
+        %>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="row">
+    <div class="small-offset-3 small-9 columns">
+      <%= f.button :submit %>
+    </div>
+  </div>
 
 <% end %>

--- a/app/views/donations/_donation_row.html.erb
+++ b/app/views/donations/_donation_row.html.erb
@@ -4,8 +4,4 @@
   <td><%= donation_row.storage_location.name %></td>
   <td><%= donation_row.total_items %></td>
   <td><%= donation_row.line_items.size %></td>
-  <td><%= donation_row.completed ? "Completed" : "In Progress" %></td>
-  <td><%= link_to(donation_row.completed? ? "View" : "Add Items", donation_path(donation_row)) %>
-      <%= link_to("Edit", edit_donation_path(donation_row)) unless donation_row.completed? %>
-      <%= link_to("Cancel", donation_path(donation_row), method: :delete, confirm: "Are you sure?") unless donation_row.completed %></td>
 </tr>

--- a/app/views/donations/_line_item_fields.html.erb
+++ b/app/views/donations/_line_item_fields.html.erb
@@ -1,7 +1,7 @@
 <div class="nested-fields">
   <div class="row">
     <div class="small-3 small-offset-3 columns">
-      <%= f.input_field :item, collection: @items, prompt: "Choose an item" %>
+      <%= f.input_field :item_id, collection: @items, prompt: "Choose an item" %>
     </div>
     <div class="small-2 columns">
       <%= f.input_field :quantity, placeholder: "Quantity" %>

--- a/app/views/donations/_line_item_fields.html.erb
+++ b/app/views/donations/_line_item_fields.html.erb
@@ -1,0 +1,11 @@
+<div class="nested-fields">
+  <div class="row">
+    <div class="small-3 small-offset-3 columns">
+      <%= f.input_field :item, collection: @items, prompt: "Choose an item" %>
+    </div>
+    <div class="small-2 columns">
+      <%= f.input_field :quantity, placeholder: "Quantity" %>
+    </div>
+    <%= link_to_remove_association "X", f, class: "button tiny alert float-left" %>
+  </div>
+</div>

--- a/app/views/donations/complete.html.erb
+++ b/app/views/donations/complete.html.erb
@@ -1,2 +1,0 @@
-<h1>Donations#complete</h1>
-<p>Find me in app/views/donations/complete.html.erb</p>

--- a/app/views/donations/index.html.erb
+++ b/app/views/donations/index.html.erb
@@ -2,11 +2,9 @@
   <%= link_to "New Donation", new_donation_path(organization_id: current_organization), class: "button float-right" %>
 </div>
 
-<h1>All Donations</h1>
+<h1>Donations</h1>
 
-<h2>Incomplete Donations</h2>
-<p>These donations are not yet completed. Any items in these have not yet been officially added to the records yet.</p>
-<table id="incomplete">
+<table id="donations">
   <thead>
     <tr>
       <th>Source</th>
@@ -14,30 +12,9 @@
       <th>Storage Location</th>
       <th>Quantity of Items</th>
       <th>Variety of Items</th>
-      <th>Status</th>
-      <th>&nbsp;</th>
     </tr>
   </thead>
   <tbody>
-    <%= render partial: "donation_row", collection: @incomplete %>
-  </tbody>
-</table>
-
-<h2>Completed Donations</h2>
-<p>These donations have been completed and are displayed here for historical record purposes only.</p>
-<table id="completed">
-  <thead>
-    <tr>
-      <th>Source</th>
-      <th>Dropoff Location</th>
-      <th>Storage Location</th>
-      <th>Quantity of Items</th>
-      <th>Variety of Items</th>
-      <th>Status</th>
-      <th>&nbsp;</th>
-    </tr>
-  </thead>
-  <tbody>
-    <%= render partial: "donation_row", collection: @completed %>
+    <%= render partial: "donation_row", collection: @donations %>
   </tbody>
 </table>

--- a/app/views/donations/index.html.erb
+++ b/app/views/donations/index.html.erb
@@ -1,3 +1,7 @@
+<div class="header-action">
+  <%= link_to "New Donation", new_donation_path(organization_id: current_organization), class: "button float-right" %>
+</div>
+
 <h1>All Donations</h1>
 
 <h2>Incomplete Donations</h2>

--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -27,7 +27,3 @@
 TODO: What's the best way to do this? Should we use a new workflow?
 -->
 </section>
-
-<% unless @donation.completed? %>
-  <%= link_to "Complete Donation", complete_donation_path(@donation), method: :patch, class: "btn button primary submit" %>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,6 @@ Rails.application.routes.draw do
     resources :donations do
       patch :add_item, on: :member
       patch :remove_item, on: :member
-      patch :complete, on: :member
     end
 
     get 'dashboard', to: 'dashboard#show'

--- a/db/migrate/20170520180940_remove_completed_from_donations.rb
+++ b/db/migrate/20170520180940_remove_completed_from_donations.rb
@@ -1,0 +1,5 @@
+class RemoveCompletedFromDonations < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :donations, :completed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170519192951) do
+ActiveRecord::Schema.define(version: 20170520180940) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,7 +39,6 @@ ActiveRecord::Schema.define(version: 20170519192951) do
 
   create_table "donations", force: :cascade do |t|
     t.string   "source"
-    t.boolean  "completed",           default: false
     t.integer  "dropoff_location_id"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -5,43 +5,47 @@ RSpec.describe DonationsController, type: :controller do
   }
 
   context "While signed in >" do
-  
-  
+
     before do
       sign_in(@user)
     end
-  
+
     describe "GET #index" do
       subject { get :index, params: default_params }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
-  
+
     describe "GET #new" do
       subject { get :new, params: default_params }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
-  
+
     describe "POST#create" do
       let!(:storage_location) { create(:storage_location) }
       let!(:dropoff_location) { create(:dropoff_location) }
-  
+      let(:line_items) { [create(:line_item)] }
+
       it "redirects to GET#edit on success" do
-        post :create, params: default_params.merge(donation: { storage_location_id: storage_location.id, dropoff_location_id: dropoff_location.id, source: "foo" })
+        post :create, params: default_params.merge(
+          donation: { storage_location_id: storage_location.id,
+                      dropoff_location_id: dropoff_location.id,
+                      source: "foo",
+                      line_items: line_items } )
         d = Donation.last
-        expect(response).to redirect_to(edit_donation_path(d))
+        expect(response).to redirect_to(donations_path)
       end
-  
+
       it "renders GET#new with notice on failure" do
         post :create, params: default_params.merge(donation: { storage_location_id: nil, dropoff_location_id: nil, source: nil } )
         expect(response).to be_successful # Will render :new
         expect(flash[:notice]).to match(/error/i)
       end
     end
-  
+
     describe "PUT#update" do
       it "redirects to #show" do
         donation = create(:donation, source: "bar")
@@ -49,21 +53,21 @@ RSpec.describe DonationsController, type: :controller do
         expect(response).to redirect_to(donation_path(donation))
       end
     end
-  
+
     describe "GET #edit" do
       subject { get :edit, params: default_params.merge(id: create(:donation)) }
       it "returns http success" do
         expect(subject).to have_http_status(:success)
       end
     end
-  
+
     describe "GET #show" do
       subject { get :show, params: default_params.merge(id: create(:donation)) }
       it "returns http success" do
         expect(subject).to be_successful
       end
     end
-  
+
     describe "DELETE #destroy" do
       subject { delete :destroy, params: default_params.merge(id: create(:donation)) }
       it "redirects to the index" do
@@ -84,9 +88,6 @@ RSpec.describe DonationsController, type: :controller do
 
         patch :remove_item, params: single_params
         expect(response).to have_http_status(403)
-
-        patch :complete, params: single_params
-        expect(response).to have_http_status(403)
       end
     end
 
@@ -96,7 +97,7 @@ RSpec.describe DonationsController, type: :controller do
     let(:object) { create(:donation) }
 
     include_examples "requiring authentication"
-    
+
     it "redirects the user to the sign-in page for Donation specific actions" do
       single_params = { organization_id: object.organization.to_param, id: object.id }
 
@@ -104,9 +105,6 @@ RSpec.describe DonationsController, type: :controller do
       expect(response).to be_redirect
 
       patch :remove_item, params: single_params
-      expect(response).to be_redirect
-
-      patch :complete, params: single_params
       expect(response).to be_redirect
     end
   end

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -4,7 +4,6 @@
 #
 #  id                  :integer          not null, primary key
 #  source              :string
-#  completed           :boolean          default("false")
 #  dropoff_location_id :integer
 #  created_at          :datetime
 #  updated_at          :datetime
@@ -20,7 +19,6 @@ FactoryGirl.define do
     comment "It's a fine day for diapers."
     storage_location
     organization { Organization.try(:first) || create(:organization) }
-    # completed false
 
     transient do
       item_quantity 10

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -29,8 +29,8 @@ RSpec.feature "Donations", type: :feature do
       select DropoffLocation.first.name, from: "donation_dropoff_location_id"
       select StorageLocation.first.name, from: "donation_storage_location_id"
       select Donation::SOURCES.first, from: "donation_source"
-      select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item"
-      fill_in "donation_line_items_attributes_0_quantity", with: "0"
+      select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
+      fill_in "donation_line_items_attributes_0_quantity", with: "5"
 
       expect {
         click_button "Create Donation"
@@ -39,68 +39,38 @@ RSpec.feature "Donations", type: :feature do
   end
 
   context "When working with a new donation" do
-    before :each do
-      item = create(:item)
-      @donation = build(:donation, :with_item, item_quantity: 10, item_id: item.id)
-      visit @url_prefix + "/donations/new"
-    end
-
-    scenario "a user wants to manually add items" do
-      # select an item
-      # indicate a quantity
-      # add the item to the donation
-      # the form should update
-      pending("TODO: adding items manually to a donation")
-      raise
-    end
-
-    scenario "a user wants to remove items from the donation" do
-      # click that delete button
-      # the form should update
-      pending("TODO: removing items from a donation")
-      raise
-    end
-
-    scenario "a user can change the quantity of a given item in a donation" do
-      # change the number in an item field
-      # save it
-      # the form should update
-      pending("TODO: changing quantities in a donation")
-      raise
-    end
-
     scenario "a user can create a donation" do
       skip
       click_link_or_button "Create Donation"
       expect(current_path).to eq donations_path(organization_id: @organization)
       expect(page.find('.flash')).to have_content('ompleted')
     end
+  end
 
-    context "when adding things via barcode" do
-      before :each do
-        # create one pre-existing barcode associated with an item
-        @existing_barcode = create(:barcode_item)
-        @item_with_barcode = @existing_barcode.item
-        # create a new item that has no barcode existing for it yet
-        @item_no_barcode = create(:item)
-      end
+  context "when adding things via barcode" do
+    before :each do
+      # create one pre-existing barcode associated with an item
+      @existing_barcode = create(:barcode_item)
+      @item_with_barcode = @existing_barcode.item
+      # create a new item that has no barcode existing for it yet
+      @item_no_barcode = create(:item)
+    end
 
-      scenario "a user can add items via scanning them in by barcode" do
-        # enter the barcode into the barcode field
-        # the form should update
-        pending("TODO: adding items via an existing barcode")
-        raise
-      end
+    scenario "a user can add items via scanning them in by barcode" do
+      # enter the barcode into the barcode field
+      # the form should update
+      pending("TODO: adding items via an existing barcode")
+      raise
+    end
 
-      scenario "a user can add items that do not yet have a barcode" do
-        # enter a new barcode
-        # form finds no barcode and responds by prompting user to choose an item and quantity
-        # fill that in
-        # saves new barcode
-        # form updates
-        pending "TODO: adding items with a new barcode"
-        raise
-      end
+    scenario "a user can add items that do not yet have a barcode" do
+      # enter a new barcode
+      # form finds no barcode and responds by prompting user to choose an item and quantity
+      # fill that in
+      # saves new barcode
+      # form updates
+      pending "TODO: adding items with a new barcode"
+      raise
     end
   end
 end

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -72,5 +72,39 @@ RSpec.feature "Donations", type: :feature do
       pending "TODO: adding items with a new barcode"
       raise
     end
+
+    scenario "a user can complete a donation" do
+      pending "TODO: user can complete a donation with barcodes"
+      click_link "Complete Donation"
+      expect(current_path).to eq donations_path(organization_id: @organization)
+      expect(page.find('.flash')).to have_content('completed')
+    end
+
+    context "when adding things via barcode" do
+      before :each do
+        # create one pre-existing barcode associated with an item
+        @existing_barcode = create(:barcode_item)
+        @item_with_barcode = @existing_barcode.item
+        # create a new item that has no barcode existing for it yet
+        @item_no_barcode = create(:item)
+      end
+
+      scenario "a user can add items via scanning them in by barcode" do
+        # enter the barcode into the barcode field
+        # the form should update
+        pending("TODO: adding items via an existing barcode")
+        raise
+      end
+
+      scenario "a user can add items that do not yet have a barcode" do
+        # enter a new barcode
+        # form finds no barcode and responds by prompting user to choose an item and quantity
+        # fill that in
+        # saves new barcode
+        # form updates
+        pending "TODO: adding items with a new barcode"
+        raise
+      end
+    end
   end
 end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -4,7 +4,6 @@
 #
 #  id                  :integer          not null, primary key
 #  source              :string
-#  completed           :boolean          default("false")
 #  dropoff_location_id :integer
 #  created_at          :datetime
 #  updated_at          :datetime
@@ -29,26 +28,7 @@ RSpec.describe Donation, type: :model do
     end
   end
 
-  it "defaults to incomplete" do
-    expect(build(:donation).completed).to be_falsey
-  end
-
   context "Scopes >" do
-    describe "completed >" do
-      it "shows donations that are flagged complete" do
-        create(:donation, completed: false)
-        create(:donation, completed: true)
-        expect(Donation.completed.count).to eq(1)
-      end
-    end
-
-    describe "incomplete >" do
-      it "shows donations that are flagged incomplete" do
-        create(:donation, completed: false)
-        create(:donation, completed: true)
-        expect(Donation.incomplete.count).to eq(1)
-      end
-    end
     describe "between >" do
       it "returns all donations created between two dates" do
         create(:donation, created_at: 1.year.ago)
@@ -113,15 +93,6 @@ RSpec.describe Donation, type: :model do
           donation.track_from_barcode(barcode_item.to_line_item)
           donation.reload
         }.to change{donation.items.count}.by(1)
-      end
-    end
-
-    describe "complete" do
-      it "sets the `completed` field to true" do
-        donation = create(:donation)
-        expect {
-          donation.complete
-        }.to change{donation.completed}.from(false).to(true)
       end
     end
 

--- a/spec/views/donations/index.html.erb_spec.rb
+++ b/spec/views/donations/index.html.erb_spec.rb
@@ -1,52 +1,27 @@
 RSpec.describe "donations/index.html.erb", type: :view do
   before :each do
     item = create(:item)
-    # create a completed donation
-    @completed = create(:donation, :with_item, item_quantity: 10, item_id: item.id, completed: true)
-    assign(:completed, [@completed])
-    # create an incomplete donation
-    @incomplete = create(:donation, :with_item, item_quantity: 5, item_id: item.id, completed: false)
-    assign(:incomplete, [@incomplete])
+    @donation = create(:donation, :with_item, item_quantity: 10, item_id: item.id)
 
     render
   end
 
-  it "shows the incomplete donations displayed separately from completed donations" do
-    # The incomplete table
-    expect(rendered).to have_xpath("//table[@id='incomplete']/tbody/tr", count: 1)
-    # The completed table
-    expect(rendered).to have_xpath("//table[@id='completed']/tbody/tr", count: 1)
-  end
-
   it "shows summary information about the donations, including CRUD controls" do
     # The Dropoff Name
-    expect(rendered).to have_xpath("//table[@id='incomplete']/tbody/tr/td", text: @incomplete.dropoff_location.name)
+    expect(rendered).to have_xpath("//table[@id='donations']/tbody/tr/td", text: @donation.dropoff_location.name)
     # The donation source
-    expect(rendered).to have_xpath("//table[@id='incomplete']/tbody/tr/td", text: @incomplete.source)
+    expect(rendered).to have_xpath("//table[@id='donations']/tbody/tr/td", text: @donation.source)
     # The storage location
-    expect(rendered).to have_xpath("//table[@id='incomplete']/tbody/tr/td", text: @incomplete.storage_location.name)
+    expect(rendered).to have_xpath("//table[@id='donations']/tbody/tr/td", text: @donation.storage_location.name)
     # The link for adding more items
-    expect(rendered).to have_xpath("//table[@id='incomplete']/tbody/tr/td/a[@href='#{edit_donation_path(@incomplete)}']")
+    expect(rendered).to have_xpath("//table[@id='donations']/tbody/tr/td/a[@href='#{edit_donation_path(@donation)}']")
     # The link to cancel it
-    expect(rendered).to have_xpath("//table[@id='incomplete']/tbody/tr/td/a", text: "Cancel")
+    expect(rendered).to have_xpath("//table[@id='donations']/tbody/tr/td/a", text: "Cancel")
     # The donation status
-    expect(rendered).to have_xpath("//table[@id='incomplete']/tbody/tr/td", text: "In Progress")
+    expect(rendered).to have_xpath("//table[@id='donations']/tbody/tr/td", text: "In Progress")
     # The total quantity of items in this donation so far
-    expect(rendered).to have_xpath("//table[@id='incomplete']/tbody/tr/td", text: "5")
+    expect(rendered).to have_xpath("//table[@id='donations']/tbody/tr/td", text: "5")
     # The total number of different types of items in this donation so far
-    expect(rendered).to have_xpath("//table[@id='incomplete']/tbody/tr/td", text: "1")
-
-    # The donation status
-    expect(rendered).to have_xpath("//table[@id='completed']/tbody/tr/td", text: "Completed")
-    # The link for viewing the donation
-    expect(rendered).to have_xpath("//table[@id='completed']/tbody/tr/td/a", text: "View")
-    # Shouldn't have a cancel link anymore
-    expect(rendered).not_to have_xpath("//table[@id='completed']/tbody/tr/td/a", text: "Cancel")
-    # Shouldn't be able to add new items to it
-    expect(rendered).not_to have_xpath("//table[@id='completed']/tbody/tr/td/a[@href='#{edit_donation_path(@completed)}']")
-    # The total quantity of items in this donation
-    expect(rendered).to have_xpath("//table[@id='completed']/tbody/tr/td", text: "10")
-    # The total different types of items in this donation
-    expect(rendered).to have_xpath("//table[@id='completed']/tbody/tr/td", text: "1")
+    expect(rendered).to have_xpath("//table[@id='donations']/tbody/tr/td", text: "1")
   end
 end

--- a/spec/views/donations/new.html.erb_spec.rb
+++ b/spec/views/donations/new.html.erb_spec.rb
@@ -1,10 +1,12 @@
 RSpec.describe "donations/new.html.erb", type: :view do
   before(:each) do
+    @organization     = create(:organization)
     @dropoff_location = create(:dropoff_location)
     @storage_location = create(:storage_location)
 
     assign(:dropoff_locations, [@dropoff_location])
     assign(:storage_locations, [@storage_location])
+    assign(:organization_id,   @organzation.id)
     assign(:donation, Donation.new)
 
     render

--- a/spec/views/donations/show.html.erb_spec.rb
+++ b/spec/views/donations/show.html.erb_spec.rb
@@ -1,48 +1,14 @@
 RSpec.describe "donations/show.html.erb", type: :view do
-  context "when viewing an incomplete donation" do
+  context "when viewing a donation" do
     before :each do
-      # create an incomplete donation
-      @incomplete = create(:donation, :with_item, item_quantity: 5, item_id: create(:item).id, completed: false)
-      assign(:donation, @incomplete)
-
+      @donation = create(:donation, :with_item, item_quantity: 5, item_id: create(:item).id, donationd: true)
+      assign(:donation, @donation)
+      assign(:line_items, @donation.line_items)
       render
     end
 
-    xit "shows a form for adding items to this donation" do
-      # TODO: what's the workflow for this?
-    end
-
-    it "shows the details of the donation" do
-      expect(rendered).to have_content(@incomplete.source)
-      expect(rendered).to have_content(@incomplete.dropoff_location.name)
-      expect(rendered).to have_content(@incomplete.storage_location.name)
-    end
-
-    it "shows a 'Complete' link" do
-      expect(rendered).to have_xpath("//a[@href='#{complete_donation_path(@incomplete)}']")
-    end
-  end
-
-  context "when viewing a completed donation" do
-    before :each do
-      @complete = create(:donation, :with_item, item_quantity: 5, item_id: create(:item).id, completed: true)
-      assign(:donation, @complete)
-      assign(:line_items, @complete.line_items)
-      render
-    end
-
-    it "DOES list the items found in the donation, along with quantities" do
+    it "Lists the items found in the donation, along with quantities" do
       expect(rendered).to have_xpath("//section[@id='line_items']/table/tbody/tr", count: 1)
     end
-
-    it "does NOT show any forms for doing anything" do
-      expect(rendered).not_to have_xpath("//section[@id='line_items']/select")
-      expect(rendered).not_to have_xpath("//section[@id='line_items']/input")
-    end
-
-    it "does NOT show a 'Complete' link" do
-      expect(rendered).not_to have_xpath("//a[@href='#{complete_donation_path(@complete)}']")
-    end
-
   end
 end


### PR DESCRIPTION
closes #22, #23, #24 

Users now have the ability to add line items to donations as the donations are being created. Additionally, because donations are now only created all at once after all line items have been entered, there is no longer any need to split donations up based on whether they've been completed or not. As such, I've torn out the `completed` attribute on the model and updated/remove any related outdated tests.