### PR TITLE
Diaper drives

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,6 +96,7 @@ group :test do
   gem 'rails-controller-testing'
   gem 'launchy'
   gem 'poltergeist'
+  gem 'phantomjs', require: "phantomjs/poltergeist"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -87,16 +87,15 @@ group :development do
   gem 'capistrano-rbenv'
   gem 'capistrano-bundler'
   gem 'capistrano3-puma'
-#  gem 'quiet_assets' # Is this necessary? It's locked to rails 3.1
 end
 
 group :test do
-  # Inherited Gems
   gem 'capybara'
   gem 'factory_girl_rails'
   gem 'database_cleaner'
   gem 'rails-controller-testing'
   gem 'launchy'
+  gem 'poltergeist'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       xpath (~> 2.0)
     chartkick (2.2.3)
     climate_control (0.2.0)
+    cliver (0.3.2)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     cocoon (1.2.10)
@@ -199,6 +200,10 @@ GEM
       mimemagic (~> 0.3.0)
     pdf-core (0.7.0)
     pg (0.20.0)
+    poltergeist (1.15.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     prawn (2.2.2)
       pdf-core (~> 0.7.0)
       ttfunk (~> 1.5)
@@ -368,6 +373,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   paperclip (= 5.1.0)
   pg (~> 0.18)
+  poltergeist
   prawn-rails
   pry
   puma (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ GEM
       mimemagic (~> 0.3.0)
     pdf-core (0.7.0)
     pg (0.20.0)
+    phantomjs (2.1.1.0)
     poltergeist (1.15.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -373,6 +374,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   paperclip (= 5.1.0)
   pg (~> 0.18)
+  phantomjs
   poltergeist
   prawn-rails
   pry

--- a/TODO
+++ b/TODO
@@ -3,6 +3,7 @@ app/controllers/application_controller.rb:
 
 app/controllers/donations_controller.rb:
   * [ 12] [TODO] - needs to be able to handle barcodes too
+  * [ 88] [FIXME] "magic string" for source field should be DRYed out.
 
 app/controllers/organizations_controller.rb:
   * [ 17] [TODO] who should be able to arrive here and how?

--- a/TODO
+++ b/TODO
@@ -1,38 +1,50 @@
 app/controllers/application_controller.rb:
-  * [  7] [FIXME] should be short_name so that we get "/pdx/blah" rather than "/123/blah"
+  * [ 12] [FIXME] should be short_name so that we get "/pdx/blah" rather than "/123/blah"
 
 app/controllers/donations_controller.rb:
   * [ 12] [TODO] - needs to be able to handle barcodes too
+
+app/controllers/organizations_controller.rb:
+  * [ 17] [TODO] who should be able to arrive here and how?
+  * [ 21] [TODO] who should be able to arrive here and how?
 
 app/controllers/storage_locations_controller.rb:
   * [ 24] [TODO] - the intake! method needs to be worked into this controller somehow.
   * [ 25] [TODO] - the distribute! method needs to be worked into this controller somehow
 
+app/models/adjustment.rb:
+  * [ 36] [TODO] - this could probably be made an association method for the `line_items` association
+
 app/models/admin_user.rb:
   * [  2] [TODO] AdminUser should be rebuilt from scratch! 
 
 app/models/barcode_item.rb:
-  * [ 29] [TODO] - this should be renamed to something more specific -- it produces a hash, not a line_item object
+  * [ 25] [TODO] - this should be renamed to something more specific -- it produces a hash, not a line_item object
 
 app/models/donation.rb:
-  * [ 29] [TODO] - change this to "by_source()" with an argument that accepts a source name
-  * [ 36] [TODO] - Can this be simplified so that we can just pass it the donation_item_params hash?
-  * [ 45] [TODO] - Test coverage for this method
-  * [ 53] [TODO] - Could this be made a member method "count" of the `items` association?
-  * [ 58] [TODO] - This should check for existence of the item first. Also, I think there's a to_line_item method in Barcode, isn't there?
-  * [ 63] [TODO] - This can be refactored to just the find_by query; should also be made a predicate [contains_item_id?()]
-  * [ 72] [TODO] - Refactor this. "update" doesn't reflect that this "adds only"
+  * [ 32] [FIXME] - This validation can be removed because it's implicit in belongs_to as of Rails 5
+  * [ 37] [TODO] - change this to "by_source()" with an argument that accepts a source name
+  * [ 57] [TODO] - Can this be simplified so that we can just pass it the donation_item_params hash?
+  * [ 66] [TODO] - Test coverage for this method
+  * [ 78] [TODO] - Could this be made a member method "count" of the `items` association?
+  * [ 83] [TODO] - This should check for existence of the item first. Also, I think there's a to_line_item method in Barcode, isn't there?
+  * [ 88] [TODO] - This can be refactored to just the find_by query; should also be made a predicate [contains_item_id?()]
+  * [ 97] [TODO] - Refactor this. "update" doesn't reflect that this "adds only"
 
 app/models/inventory_item.rb:
-  * [ 24] [TODO] - is there a reason for doing this instead of setting a DB default?
+  * [ 30] [TODO] - is there a reason for doing this instead of setting a DB default?
 
 app/models/storage_location.rb:
-  * [ 81] [TODO] - this action is happening in the Transfer model/controller - does this method belong here?
-  * [113] [TODO] - this action is happening in the DistributionsController. Is this model the correct place for this method?
+  * [ 82] [TODO] - this action is happening in the Transfer model/controller - does this method belong here?
+  * [115] [TODO] - this is called from the AdjustmentsController, should probably be in a service, not this model
+  * [147] [TODO] - this action is happening in the DistributionsController. Is this model the correct place for this method?
 
 app/models/transfer.rb:
-  * [ 28] [TODO] - this could probably be made an association method for the `line_items` association
-  * [ 33] [TODO] - this could probably be made an association method for the `line_items` association
-  * [ 38] [TODO] - this could probably be made an association method for the `line_items` association
-  * [ 45] [TODO] - this could probably be made an association method for the `line_items` association
+  * [ 29] [TODO] - this could probably be made an association method for the `line_items` association
+  * [ 34] [TODO] - this could probably be made an association method for the `line_items` association
+  * [ 39] [TODO] - this could probably be made an association method for the `line_items` association
+  * [ 58] [TODO] - this could probably be made an association method for the `line_items` association
+
+app/views/donations/_donation_form.html.erb:
+  * [ 10] [FIXME] - This isn't a transfer -- the id should be changed to "donation"
 

--- a/app/assets/javascripts/donations.coffee
+++ b/app/assets/javascripts/donations.coffee
@@ -1,3 +1,28 @@
 # Place all the behaviors and hooks related to the matching controller here.
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
+
+
+
+$(document).on 'turbolinks:load', () ->
+  control_id = "#donation_source"
+  # TODO: This is tightly coupled to the Donation::SOURCES and that's not too shiny.
+  ddp_text = "Diaper Drive"
+  dpl_text = "Donation Pickup Location"
+  ddp_container_id = "div.donation_diaper_drive_participant"
+  dpl_container_id = "div.donation_dropoff_location"
+  $(ddp_container_id).hide()
+  $(dpl_container_id).hide()
+
+  $(document).on "change", control_id, (evt) ->
+    selection = $(control_id + " option").filter(':selected').text()
+    
+    if (selection is ddp_text)
+      $(ddp_container_id).show()
+      $(dpl_container_id).hide()
+    else if (selection is dpl_text)
+      $(ddp_container_id).hide()
+      $(dpl_container_id).show()
+    else
+      $(ddp_container_id).hide()
+      $(dpl_container_id).hide()

--- a/app/assets/javascripts/transfers.coffee
+++ b/app/assets/javascripts/transfers.coffee
@@ -2,6 +2,7 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
+# FIXME - This file is generating --> undefined is not an object (evaluating 'control.data("storage-location-inventory-path").replace')
 item_option = (item) ->
   "<option value='#{item.item_id}'>
      #{ item.item_name }  (#{ item.quantity })

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -44,9 +44,9 @@ class DonationsController < ApplicationController
   def new
     @donation = Donation.new
     @donation.line_items.build
-    @storage_locations = current_organization.storage_locations.all
-    @dropoff_locations = current_organization.dropoff_locations.all
-    @diaper_drive_participants = current_organization.diaper_drive_participants.all
+    @storage_locations = current_organization.storage_locations
+    @dropoff_locations = current_organization.dropoff_locations
+    @diaper_drive_participants = current_organization.diaper_drive_participants
     @items = current_organization.items.alphabetized
   end
 

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -33,8 +33,9 @@ class DonationsController < ApplicationController
     if (@donation.save)
       redirect_to donations_path
     else
-      @storage_locations = StorageLocation.all
-      @dropoff_locations = DropoffLocation.all
+      @storage_locations = current_organization.storage_locations.all
+      @dropoff_locations = current_organization.dropoff_locations.all
+      @diaper_drive_participants = current_organization.diaper_drive_participants.all
       flash[:notice] = "There was an error starting this donation, try again?"
       render action: :new
     end
@@ -45,7 +46,7 @@ class DonationsController < ApplicationController
     @donation.line_items.build
     @storage_locations = current_organization.storage_locations.all
     @dropoff_locations = current_organization.dropoff_locations.all
-    @diaper_drive_participants = DiaperDriveParticipant.all #current_organization.diaper_drive_participants.all
+    @diaper_drive_participants = current_organization.diaper_drive_participants.all
     @items = current_organization.items.alphabetized
   end
 
@@ -75,7 +76,7 @@ class DonationsController < ApplicationController
 
 private
   def donation_params
-    params.require(:donation).permit(:source, :storage_location_id, :dropoff_location_id, line_items_attributes: [:item_id, :quantity, :_destroy]).merge(organization: current_organization)
+    params.require(:donation).permit(:source, :storage_location_id, :dropoff_location_id, :diaper_drive_participant_id, line_items_attributes: [:item_id, :quantity, :_destroy]).merge(organization: current_organization)
   end
 
   def donation_item_params

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -76,10 +76,19 @@ class DonationsController < ApplicationController
 
 private
   def donation_params
+    params = strip_unnecessary_params
     params.require(:donation).permit(:source, :storage_location_id, :dropoff_location_id, :diaper_drive_participant_id, line_items_attributes: [:item_id, :quantity, :_destroy]).merge(organization: current_organization)
   end
 
   def donation_item_params
     params.require(:donation).permit(:barcode_id, :item_id, :quantity)
+  end
+
+  # Omits dropoff_location_id or diaper_drive_participant_id if those aren't selected as source
+  # FIXME "magic string" for source field should be DRYed out.
+  def strip_unnecessary_params
+    params[:donation].delete(:dropoff_location_id) unless params[:donation][:source] == "Donation Pickup Location"
+    params[:donation].delete(:diaper_drive_participant_id) unless params[:donation][:source] == "Diaper Drive"
+    params
   end
 end

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -43,9 +43,10 @@ class DonationsController < ApplicationController
   def new
     @donation = Donation.new
     @donation.line_items.build
-    @storage_locations = StorageLocation.all
-    @dropoff_locations = DropoffLocation.all
-    @items = Item.alphabetized
+    @storage_locations = current_organization.storage_locations.all
+    @dropoff_locations = current_organization.dropoff_locations.all
+    @diaper_drive_participants = DiaperDriveParticipant.all #current_organization.diaper_drive_participants.all
+    @items = current_organization.items.alphabetized
   end
 
   def edit

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: adjustments
+#
+#  id                  :integer          not null, primary key
+#  organization_id     :integer
+#  storage_location_id :integer
+#  comment             :text
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
 class Adjustment < ApplicationRecord
   belongs_to :organization
   belongs_to :storage_location

--- a/app/models/diaper_drive_participant.rb
+++ b/app/models/diaper_drive_participant.rb
@@ -1,0 +1,23 @@
+# == Schema Information
+#
+# Table name: diaper_drive_participants
+#
+#  id              :integer          not null, primary key
+#  name            :string
+#  contact_name    :string
+#  email           :string
+#  phone           :string
+#  comment         :string
+#  organization_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
+class DiaperDriveParticipant < ApplicationRecord
+  belongs_to :organization  # Automatically validates presence as of Rails 5
+  has_many :donations, inverse_of: :diaper_drive_participant
+
+  validates :name, presence: true
+  validates :phone, presence: { message: "Must provide a phone or an e-mail" }, if: Proc.new { |ddp| ddp.email.blank? }
+  validates :email, presence: { message: "Must provide a phone or an e-mail" }, if: Proc.new { |ddp| ddp.phone.blank? }
+end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -2,15 +2,15 @@
 #
 # Table name: donations
 #
-#  id                  :integer          not null, primary key
-#  source              :string
-#  completed           :boolean          default("false")
-#  dropoff_location_id :integer
-#  created_at          :datetime
-#  updated_at          :datetime
-#  comment             :text
-#  organization_id     :integer
-#  storage_location_id :integer
+#  id                          :integer          not null, primary key
+#  source                      :string
+#  dropoff_location_id         :integer
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  storage_location_id         :integer
+#  comment                     :text
+#  organization_id             :integer
+#  diaper_drive_participant_id :integer
 #
 
 class Donation < ApplicationRecord
@@ -19,13 +19,15 @@ class Donation < ApplicationRecord
   belongs_to :organization
 
   belongs_to :dropoff_location, optional: true              # Validation is conditionally handled below.
+  belongs_to :diaper_drive_participant, optional: true      # Validation is conditionally handled below.
   belongs_to :storage_location
   has_many :line_items, as: :itemizable, inverse_of: :itemizable
   has_many :items, through: :line_items
   accepts_nested_attributes_for :line_items,
     allow_destroy: true
 
-  validates :dropoff_location, presence: { message: "must be specified" }, if: :from_dropoff_location?
+  validates :dropoff_location, presence: { message: "must be specified since you chose 'Donation Pickup Location'" }, if: :from_dropoff_location?
+  validates :diaper_drive_participant, presence: { message: "must be specified since you chose 'Diaper Drive'" }, if: :from_diaper_drive?
   validates :source, presence: true, inclusion: { in: SOURCES, message: "Must be a valid source." }
   validates :storage_location, :organization, presence: true
 
@@ -34,6 +36,10 @@ class Donation < ApplicationRecord
   # TODO - change this to "by_source()" with an argument that accepts a source name
   scope :diaper_drive, -> { where(source: "Diaper Drive") }
   scope :recent, ->(count=3) { order(:created_at).limit(count) }
+
+  def from_diaper_drive?
+    source == "Diaper Drive"
+  end
 
   def from_dropoff_location?
     source == "Donation Pickup Location"

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -29,6 +29,7 @@ class Donation < ApplicationRecord
   validates :dropoff_location, presence: { message: "must be specified since you chose 'Donation Pickup Location'" }, if: :from_dropoff_location?
   validates :diaper_drive_participant, presence: { message: "must be specified since you chose 'Diaper Drive'" }, if: :from_diaper_drive?
   validates :source, presence: true, inclusion: { in: SOURCES, message: "Must be a valid source." }
+  # FIXME - This validation can be removed because it's implicit in belongs_to as of Rails 5
   validates :storage_location, :organization, presence: true
 
   scope :between, ->(start, stop) { where(donations: { created_at: start..stop }) }

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -18,20 +18,26 @@ class Donation < ApplicationRecord
 
   belongs_to :organization
 
-  belongs_to :dropoff_location
+  belongs_to :dropoff_location, optional: true              # Validation is conditionally handled below.
   belongs_to :storage_location
   has_many :line_items, as: :itemizable, inverse_of: :itemizable
   has_many :items, through: :line_items
   accepts_nested_attributes_for :line_items,
     allow_destroy: true
 
-  validates :dropoff_location, :storage_location, :source, :organization, presence: true
+  validates :dropoff_location, presence: { message: "must be specified" }, if: :from_dropoff_location?
+  validates :source, presence: true, inclusion: { in: SOURCES, message: "Must be a valid source." }
+  validates :storage_location, :organization, presence: true
 
   scope :between, ->(start, stop) { where(donations: { created_at: start..stop }) }
   scope :during, ->(range) { where(donations: { created_at: range }) }
   # TODO - change this to "by_source()" with an argument that accepts a source name
   scope :diaper_drive, -> { where(source: "Diaper Drive") }
   scope :recent, ->(count=3) { order(:created_at).limit(count) }
+
+  def from_dropoff_location?
+    source == "Donation Pickup Location"
+  end
 
   def self.daily_quantities_by_source(start, stop)
     joins(:line_items).includes(:line_items).between(start, stop).group(:source).group_by_day("donations.created_at").sum("line_items.quantity")

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,14 +2,18 @@
 #
 # Table name: organizations
 #
-#  id         :integer          not null, primary key
-#  name       :string
-#  short_name :string
-#  address    :text
-#  email      :string
-#  url        :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :integer          not null, primary key
+#  name              :string
+#  short_name        :string
+#  address           :text
+#  email             :string
+#  url               :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  logo_file_name    :string
+#  logo_content_type :string
+#  logo_file_size    :integer
+#  logo_updated_at   :datetime
 #
 
 class Organization < ApplicationRecord

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -27,6 +27,7 @@ class Organization < ApplicationRecord
   has_many :distributions
   has_many :donations
   has_many :dropoff_locations
+  has_many :diaper_drive_participants
   has_many :storage_locations
   has_many :items
   has_many :partners

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -4,6 +4,7 @@
   <%= f.association :dropoff_location, collection: @dropoff_locations, label: "Dropoff Location", error: "Where was this donation dropped off?" %>
   <%= f.association :diaper_drive_participant, collection: @diaper_drive_participants, label_method: :name, label: "Diaper Drive Participant", error: "Which diaper drive was this from?" %>
   <%= f.association :storage_location, collection: @storage_locations, label: "Storage Location", error: "Where is it being stored?" %>
+  <%= f.input :comment %>
 
   <%= f.simple_fields_for :line_items do |item| %>
     <% # FIXME - This isn't a transfer -- the id should be changed to "donation"  %>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -2,9 +2,12 @@
 
   <%= f.input :source, collection: Donation::SOURCES, label: "Source", error: "What effort or initiative did this donation come from?" %>
   <%= f.association :dropoff_location, collection: @dropoff_locations, label: "Dropoff Location", error: "Where was this donation dropped off?" %>
+  <%= @diaper_drive_participants.inspect %>
+  <%= f.association :diaper_drive_participant, collection: @diaper_drive_participants, label_method: :name, label: "Diaper Drive Participant", error: "Which diaper drive was this from?" %>
   <%= f.association :storage_location, collection: @storage_locations, label: "Storage Location", error: "Where is it being stored?" %>
 
   <%= f.simple_fields_for :line_items do |item| %>
+    <% # FIXME - This isn't a transfer -- the id should be changed to "donation"  %>
     <div id="transfer_line_items">
       <%= render 'line_item_fields', f: item %>
     </div>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -2,7 +2,6 @@
 
   <%= f.input :source, collection: Donation::SOURCES, label: "Source", error: "What effort or initiative did this donation come from?" %>
   <%= f.association :dropoff_location, collection: @dropoff_locations, label: "Dropoff Location", error: "Where was this donation dropped off?" %>
-  <%= @diaper_drive_participants.inspect %>
   <%= f.association :diaper_drive_participant, collection: @diaper_drive_participants, label_method: :name, label: "Diaper Drive Participant", error: "Which diaper drive was this from?" %>
   <%= f.association :storage_location, collection: @storage_locations, label: "Storage Location", error: "Where is it being stored?" %>
 

--- a/app/views/donations/_donation_row.html.erb
+++ b/app/views/donations/_donation_row.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= donation_row.source %></td>
-  <td><%= donation_row.dropoff_location.name %></td>
+  <td><%= donation_row.dropoff_location.name if donation_row.dropoff_location.present? %></td>
   <td><%= donation_row.storage_location.name %></td>
   <td><%= donation_row.total_items %></td>
   <td><%= donation_row.line_items.size %></td>

--- a/db/migrate/20170527183609_create_diaper_drive_participants.rb
+++ b/db/migrate/20170527183609_create_diaper_drive_participants.rb
@@ -1,0 +1,14 @@
+class CreateDiaperDriveParticipants < ActiveRecord::Migration[5.0]
+  def change
+    create_table :diaper_drive_participants do |t|
+      t.string :name
+      t.string :contact_name
+      t.string :email
+      t.string :phone
+      t.string :comment
+      t.integer :organization_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170527184803_add_diaper_drive_participant_id_to_donation.rb
+++ b/db/migrate/20170527184803_add_diaper_drive_participant_id_to_donation.rb
@@ -1,0 +1,5 @@
+class AddDiaperDriveParticipantIdToDonation < ActiveRecord::Migration[5.0]
+  def change
+    add_column :donations, :diaper_drive_participant_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170521132736) do
+ActiveRecord::Schema.define(version: 20170527184803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,6 +35,17 @@ ActiveRecord::Schema.define(version: 20170521132736) do
     t.index ["organization_id"], name: "index_barcode_items_on_organization_id", using: :btree
   end
 
+  create_table "diaper_drive_participants", force: :cascade do |t|
+    t.string   "name"
+    t.string   "contact_name"
+    t.string   "email"
+    t.string   "phone"
+    t.string   "comment"
+    t.integer  "organization_id"
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+  end
+
   create_table "distributions", force: :cascade do |t|
     t.text     "comment"
     t.datetime "created_at"
@@ -55,6 +66,7 @@ ActiveRecord::Schema.define(version: 20170521132736) do
     t.integer  "storage_location_id"
     t.text     "comment"
     t.integer  "organization_id"
+    t.integer  "diaper_drive_participant_id"
     t.index ["dropoff_location_id"], name: "index_donations_on_dropoff_location_id", using: :btree
     t.index ["organization_id"], name: "index_donations_on_organization_id", using: :btree
     t.index ["storage_location_id"], name: "index_donations_on_storage_location_id", using: :btree

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DonationsController, type: :controller do
         post :create, params: default_params.merge(
           donation: { storage_location_id: storage_location.id,
                       dropoff_location_id: dropoff_location.id,
-                      source: "foo",
+                      source: "Donation Pickup Location",
                       line_items: line_items } )
         d = Donation.last
         expect(response).to redirect_to(donations_path)
@@ -48,8 +48,8 @@ RSpec.describe DonationsController, type: :controller do
 
     describe "PUT#update" do
       it "redirects to #show" do
-        donation = create(:donation, source: "bar")
-        put :update, params: default_params.merge(id: donation.id, donation: { source: "foo" })
+        donation = create(:donation, source: "Purchased Supplies")
+        put :update, params: default_params.merge(id: donation.id, donation: { source: "Purchased Supplies" })
         expect(response).to redirect_to(donation_path(donation))
       end
     end

--- a/spec/factories/adjustments.rb
+++ b/spec/factories/adjustments.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: adjustments
+#
+#  id                  :integer          not null, primary key
+#  organization_id     :integer
+#  storage_location_id :integer
+#  comment             :text
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
 FactoryGirl.define do
   factory :adjustment do
     organization { Organization.try(:first) || create(:organization) }

--- a/spec/factories/diaper_drive_participants.rb
+++ b/spec/factories/diaper_drive_participants.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: diaper_drive_participants
+#
+#  id              :integer          not null, primary key
+#  name            :string
+#  contact_name    :string
+#  email           :string
+#  phone           :string
+#  comment         :string
+#  organization_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
+FactoryGirl.define do
+  factory :diaper_drive_participant do
+    organization { Organization.try(:first) || create(:organization) }
+    sequence(:name) { |n| "DD Participant ##{n}" }
+    contact_name "Don Draper"
+    sequence(:email) { |n| "don#{n}@scdp.com" }
+    phone "212-555-1111"
+    comment "A bit of a lush and philanderer."
+  end
+end

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -2,20 +2,22 @@
 #
 # Table name: donations
 #
-#  id                  :integer          not null, primary key
-#  source              :string
-#  dropoff_location_id :integer
-#  created_at          :datetime
-#  updated_at          :datetime
-#  storage_location_id :integer
-#  comment             :text
-#  organization_id     :integer
+#  id                          :integer          not null, primary key
+#  source                      :string
+#  dropoff_location_id         :integer
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  storage_location_id         :integer
+#  comment                     :text
+#  organization_id             :integer
+#  diaper_drive_participant_id :integer
 #
 
 FactoryGirl.define do
   factory :donation do
     dropoff_location
-    source { Donation::SOURCES.first }
+    diaper_drive_participant
+    source { "Misc. Donation" }
     comment "It's a fine day for diapers."
     storage_location
     organization { Organization.try(:first) || create(:organization) }

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -15,7 +15,7 @@
 FactoryGirl.define do
   factory :donation do
     dropoff_location
-    source "Donation"
+    source { Donation::SOURCES.first }
     comment "It's a fine day for diapers."
     storage_location
     organization { Organization.try(:first) || create(:organization) }

--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -2,12 +2,18 @@
 #
 # Table name: organizations
 #
-#  id         :integer          not null, primary key
-#  name       :string
-#  short_name :string
-#  address    :text
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :integer          not null, primary key
+#  name              :string
+#  short_name        :string
+#  address           :text
+#  email             :string
+#  url               :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  logo_file_name    :string
+#  logo_content_type :string
+#  logo_file_size    :integer
+#  logo_updated_at   :datetime
 #
 
 FactoryGirl.define do

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -30,17 +30,54 @@ RSpec.feature "Donations", type: :feature do
         visit @url_prefix + "/donations/new"
       end
 
-      scenario "User can fill out the form to create a new donation" do
-        select DropoffLocation.first.name, from: "donation_dropoff_location_id"
+      scenario "User can create a donation for a Diaper Drive source" do
+        select "Diaper Drive", from: "donation_source"
+        select DiaperDrive.first.name, from: "donation_diaper_drive"
         select StorageLocation.first.name, from: "donation_storage_location_id"
-        select Donation::SOURCES.first, from: "donation_source"
         select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
         fill_in "donation_line_items_attributes_0_quantity", with: "5"
-  
+
         expect {
           click_button "Create Donation"
         }.to change{Donation.count}.by(1)
       end
+
+      scenario "User can create a donation for a Donation Site source" do
+        select "Donation Pickup Location", from: "donation_source"
+        select DropoffLocation.first.name, from: "donation_dropoff_location_id"
+        select StorageLocation.first.name, from: "donation_storage_location_id"
+        select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
+        fill_in "donation_line_items_attributes_0_quantity", with: "5"
+
+        expect {
+          click_button "Create Donation"
+        }.to change{Donation.count}.by(1)
+      end
+
+      scenario "User can create a donation for Purchased Supplies" do
+        select "Purchased Supplies", from: "donation_source"
+        select StorageLocation.first.name, from: "donation_storage_location_id"
+        select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
+        fill_in "donation_line_items_attributes_0_quantity", with: "5"
+
+        expect {
+          click_button "Create Donation"
+        }.to change{Donation.count}.by(1)
+      end
+
+      scenario "User can create a donation with a Miscellaneous source" do
+        select "Misc. Donation", from: "donation_source"
+        select StorageLocation.first.name, from: "donation_storage_location_id"
+        select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
+        fill_in "donation_line_items_attributes_0_quantity", with: "5"
+
+        expect {
+          click_button "Create Donation"
+          save_and_open_page
+        }.to change{Donation.count}.by(1)
+
+      end
+
     end
 
     context "via barcode entry" do

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -32,8 +32,6 @@ RSpec.feature "Donations", type: :feature do
       end
 
       scenario "User can create a donation for a Diaper Drive source" do
-        #binding.pry
-
         select "Diaper Drive", from: "donation_source"
         select DiaperDriveParticipant.first.name, from: "donation_diaper_drive_participant_id"
         select StorageLocation.first.name, from: "donation_storage_location_id"
@@ -41,8 +39,8 @@ RSpec.feature "Donations", type: :feature do
         fill_in "donation_line_items_attributes_0_quantity", with: "5"
 
         expect {
+                  save_and_open_page
           click_button "Create Donation"
-          save_and_open_page
         }.to change{Donation.count}.by(1)
       end
 

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Donations", type: :feature do
+RSpec.feature "Donations", type: :feature, js: true do
   before :each do
     sign_in @user
     @url_prefix = "/#{@organization.short_name}"
@@ -33,32 +33,36 @@ RSpec.feature "Donations", type: :feature do
 
       scenario "User can create a donation for a Diaper Drive source" do
         select "Diaper Drive", from: "donation_source"
+        expect(page).to have_xpath("//select[@id='donation_diaper_drive_participant_id']")
+        expect(page).not_to have_xpath("//select[@id='donation_dropoff_location_id']")
         select DiaperDriveParticipant.first.name, from: "donation_diaper_drive_participant_id"
         select StorageLocation.first.name, from: "donation_storage_location_id"
         select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
         fill_in "donation_line_items_attributes_0_quantity", with: "5"
 
         expect {
-                  save_and_open_page
           click_button "Create Donation"
         }.to change{Donation.count}.by(1)
       end
 
       scenario "User can create a donation for a Donation Site source" do
         select "Donation Pickup Location", from: "donation_source"
+        expect(page).to have_xpath("//select[@id='donation_dropoff_location_id']")
+        expect(page).not_to have_xpath("//select[@id='donation_diaper_drive_participant_id']")
         select DropoffLocation.first.name, from: "donation_dropoff_location_id"
         select StorageLocation.first.name, from: "donation_storage_location_id"
         select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
         fill_in "donation_line_items_attributes_0_quantity", with: "5"
 
         expect {
-          save_and_open_page
           click_button "Create Donation"
         }.to change{Donation.count}.by(1)
       end
 
       scenario "User can create a donation for Purchased Supplies" do
         select "Purchased Supplies", from: "donation_source"
+        expect(page).not_to have_xpath("//select[@id='donation_dropoff_location_id']")
+        expect(page).not_to have_xpath("//select[@id='donation_diaper_drive_participant_id']")
         select StorageLocation.first.name, from: "donation_storage_location_id"
         select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
         fill_in "donation_line_items_attributes_0_quantity", with: "5"
@@ -70,6 +74,8 @@ RSpec.feature "Donations", type: :feature do
 
       scenario "User can create a donation with a Miscellaneous source" do
         select "Misc. Donation", from: "donation_source"
+        expect(page).not_to have_xpath("//select[@id='donation_dropoff_location_id']")
+        expect(page).not_to have_xpath("//select[@id='donation_diaper_drive_participant_id']")
         select StorageLocation.first.name, from: "donation_storage_location_id"
         select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
         fill_in "donation_line_items_attributes_0_quantity", with: "5"
@@ -77,7 +83,6 @@ RSpec.feature "Donations", type: :feature do
         expect {
           click_button "Create Donation"
         }.to change{Donation.count}.by(1)
-
       end
 
     end

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -85,6 +85,22 @@ RSpec.feature "Donations", type: :feature, js: true do
         }.to change{Donation.count}.by(1)
       end
 
+      # Since the form only shows/hides the irrelevant field, if the user already selected something it would still
+      # submit. The app should sanitize this so we aren't saving extraneous data
+      scenario "extraneous data is stripped if the user adds both dropoff_location and diaper_drive_participant" do
+        select "Donation Pickup Location", from: "donation_source"
+        select DropoffLocation.first.name, from: "donation_dropoff_location_id"
+        select "Diaper Drive", from: "donation_source"
+        select DiaperDriveParticipant.first.name, from: "donation_diaper_drive_participant_id"
+        select StorageLocation.first.name, from: "donation_storage_location_id"
+        select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
+        fill_in "donation_line_items_attributes_0_quantity", with: "5"
+        click_button "Create Donation"
+        donation = Donation.last
+        expect(donation.diaper_drive_participant_id).to be_present
+        expect(donation.dropoff_location_id).to be_nil
+      end
+
     end
 
     context "via barcode entry" do

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -73,7 +73,6 @@ RSpec.feature "Donations", type: :feature do
 
         expect {
           click_button "Create Donation"
-          save_and_open_page
         }.to change{Donation.count}.by(1)
 
       end

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -19,26 +19,30 @@ RSpec.feature "Donations", type: :feature do
 
   context "When creating a new donation" do
     before(:each) do
-      create(:item)
-      create(:dropoff_location)
-      create(:storage_location)
-      
+      create(:item, organization: @organization)
+      create(:storage_location, organization: @organization)
+      create(:dropoff_location, organization: @organization)
+      create(:diaper_drive_participant, organization: @organization)
+      @organization.reload
     end
 
     context "via manual entry" do
-      before do
+      before(:each) do
         visit @url_prefix + "/donations/new"
       end
 
       scenario "User can create a donation for a Diaper Drive source" do
+        #binding.pry
+
         select "Diaper Drive", from: "donation_source"
-        select DiaperDrive.first.name, from: "donation_diaper_drive"
+        select DiaperDriveParticipant.first.name, from: "donation_diaper_drive_participant_id"
         select StorageLocation.first.name, from: "donation_storage_location_id"
         select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
         fill_in "donation_line_items_attributes_0_quantity", with: "5"
 
         expect {
           click_button "Create Donation"
+          save_and_open_page
         }.to change{Donation.count}.by(1)
       end
 
@@ -50,6 +54,7 @@ RSpec.feature "Donations", type: :feature do
         fill_in "donation_line_items_attributes_0_quantity", with: "5"
 
         expect {
+          save_and_open_page
           click_button "Create Donation"
         }.to change{Donation.count}.by(1)
       end

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -1,3 +1,15 @@
+# == Schema Information
+#
+# Table name: adjustments
+#
+#  id                  :integer          not null, primary key
+#  organization_id     :integer
+#  storage_location_id :integer
+#  comment             :text
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+
 require 'rails_helper'
 
 RSpec.describe Adjustment, type: :model do

--- a/spec/models/diaper_drive_participant_spec.rb
+++ b/spec/models/diaper_drive_participant_spec.rb
@@ -1,0 +1,34 @@
+# == Schema Information
+#
+# Table name: diaper_drive_participants
+#
+#  id              :integer          not null, primary key
+#  name            :string
+#  contact_name    :string
+#  email           :string
+#  phone           :string
+#  comment         :string
+#  organization_id :integer
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#
+
+require 'rails_helper'
+
+RSpec.describe DiaperDriveParticipant, type: :model do
+  describe "Validations" do
+  	it "is invalid without a name" do
+      expect(build(:diaper_drive_participant, name: nil)).not_to be_valid
+  	end
+
+  	it "is invalid unless it has either a name or an email" do
+      expect(build(:diaper_drive_participant, phone: nil, email: nil)).not_to be_valid
+      expect(build(:diaper_drive_participant, phone: nil)).to be_valid
+      expect(build(:diaper_drive_participant, email: nil)).to be_valid
+  	end
+
+    it "is invalid without an organization" do
+      expect(build(:diaper_drive_participant, organization: nil)).not_to be_valid
+    end
+  end
+end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -2,14 +2,15 @@
 #
 # Table name: donations
 #
-#  id                  :integer          not null, primary key
-#  source              :string
-#  dropoff_location_id :integer
-#  created_at          :datetime
-#  updated_at          :datetime
-#  comment             :text
-#  organization_id     :integer
-#  storage_location_id :integer
+#  id                          :integer          not null, primary key
+#  source                      :string
+#  dropoff_location_id         :integer
+#  created_at                  :datetime
+#  updated_at                  :datetime
+#  storage_location_id         :integer
+#  comment                     :text
+#  organization_id             :integer
+#  diaper_drive_participant_id :integer
 #
 
 RSpec.describe Donation, type: :model do
@@ -20,6 +21,10 @@ RSpec.describe Donation, type: :model do
     it "requires a dropoff_location if the source is 'Donation Pickup Location'" do
       expect(build(:donation, source: "Donation Pickup Location", dropoff_location: nil)).not_to be_valid
       expect(build(:donation, source: "Purchased Supplies", dropoff_location: nil)).to be_valid
+    end
+    it "requires a diaper drive participant if the source is 'Diaper Drive'" do
+      expect(build(:donation, source: "Diaper Drive", diaper_drive_participant_id: nil)).not_to be_valid
+      expect(build(:donation, source: "Purchased Supplies", diaper_drive_participant_id: nil)).to be_valid
     end
     it "requires a source from the list of available sources" do
       expect(build(:donation, source: nil)).not_to be_valid

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -17,11 +17,13 @@ RSpec.describe Donation, type: :model do
     it "must belong to an organization" do
       expect(build(:donation, organization_id: nil)).not_to be_valid
     end
-    it "requires a dropoff_location" do
-      expect(build(:donation, dropoff_location: nil)).not_to be_valid
+    it "requires a dropoff_location if the source is 'Donation Pickup Location'" do
+      expect(build(:donation, source: "Donation Pickup Location", dropoff_location: nil)).not_to be_valid
+      expect(build(:donation, source: "Purchased Supplies", dropoff_location: nil)).to be_valid
     end
-    it "requires a source" do
+    it "requires a source from the list of available sources" do
       expect(build(:donation, source: nil)).not_to be_valid
+      expect(build(:donation, source: "Something new")).not_to be_valid
     end
     it "requires an inventory (storage location)" do
       expect(build(:donation, storage_location_id: nil)).not_to be_valid
@@ -40,7 +42,7 @@ RSpec.describe Donation, type: :model do
 
     describe "diaper_drive >" do
       it "returns all donations with the source `Diaper Drive`" do
-        create(:donation, source: "Somewhere else")
+        create(:donation, source: "Misc. Donation")
         create(:donation, source: "Diaper Drive")
         expect(Donation.diaper_drive.count).to eq(1)
       end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -2,14 +2,18 @@
 #
 # Table name: organizations
 #
-#  id         :integer          not null, primary key
-#  name       :string
-#  short_name :string
-#  address    :text
-#  email      :string
-#  url        :string
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
+#  id                :integer          not null, primary key
+#  name              :string
+#  short_name        :string
+#  address           :text
+#  email             :string
+#  url               :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  logo_file_name    :string
+#  logo_content_type :string
+#  logo_file_size    :integer
+#  logo_updated_at   :datetime
 #
 
 RSpec.describe Organization, type: :model do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 require 'capybara/rails'
+require 'capybara/poltergeist'
 require 'pry'
 
 # Add additional requires below this line. Rails is not loaded until this point!
@@ -29,6 +30,11 @@ Dir[Rails.root.join("spec/controllers/shared_examples/*.rb")].each {|f| require 
 # Checks for pending migration and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
+
+# Enable JS for Capybara tests
+Capybara.javascript_driver = :poltergeist
+# If an element is hidden, Capybara should ignore it
+Capybara.ignore_hidden_elements = true
 
 RSpec.configure do |config|
 

--- a/spec/support/poltergeist_hack.rb
+++ b/spec/support/poltergeist_hack.rb
@@ -1,0 +1,15 @@
+# Poltergeist runs with a different connection so we need to make our
+# normal records available to it.
+# From: https://github.com/railscasts/391-testing-javascript-with-phantomjs/blob/master/checkout-after/spec/support/share_db_connection.rb
+class ActiveRecord::Base
+  mattr_accessor :shared_connection
+  @@shared_connection = nil
+ 
+  def self.connection
+    @@shared_connection || retrieve_connection
+  end
+end
+ 
+# Forces all threads to share the same connection. This works on
+# Capybara because it starts the web server in a thread.
+ActiveRecord::Base.shared_connection = ActiveRecord::Base.connection


### PR DESCRIPTION
Fixes #56 
This feature has quite a bit of changes.

The main purpose of this feature is to add "Diaper Drive Participants" and make the "Source" more of a modal feature. This should make Donations be a bit more informative when they are completed. When a user creates a new donation, the "Source" type they pick -- depending on which source they pick, it will show/hide other drop-down lists as appropriate. Validations have been updated to require association IDs depending on source values. Test coverage for all of these features and model changes.

App changes that were indirectly impacted by this feature are:
 * Added Poltergeist gem
 * Added hack for Poltergeist to make it play nice with Devise
 * Donations now constrains associations to the current_organization (this is not directly related to this app, but was in the way so I added it)
 * Refactored the way the `features/donation_spec.rb` were organized (to fit with these specs)
 * re-ran `annotate`
 * re-ran `rake notes > TODO`

Future needs (will create issues)
 * CRUD for `DiaperDriveParticipant`
 * The "magic strings" for Donation::SOURCES needs a re-factor. It's getting a little ridiculous. This needs to be normalized or at least made indirect so that changing the text for that dropdown doesn't cause a bunch of crap to blow up.