### PR TITLE
Responsive navigation works now and looks totally awesome

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -26,10 +26,6 @@
   margin-top: 16px;
 }
 
-a.active[disabled] {
-  color: #777;
-}
-
-.top-bar .logo img {
-  height: 40px;
+img#logo {
+  max-height: 40px;
 }

--- a/app/assets/stylesheets/foundation_and_overrides.scss
+++ b/app/assets/stylesheets/foundation_and_overrides.scss
@@ -16,10 +16,10 @@
 @include foundation-forms;
 @include foundation-visibility-classes;
 @include foundation-float-classes;
-@include foundation-accordion;
-@include foundation-accordion-menu;
+// @include foundation-accordion;
+// @include foundation-accordion-menu;
 @include foundation-badge;
-@include foundation-breadcrumbs;
+// @include foundation-breadcrumbs;
 @include foundation-button-group;
 @include foundation-callout;
 @include foundation-card;
@@ -35,7 +35,7 @@
 @include foundation-off-canvas;
 @include foundation-orbit;
 @include foundation-pagination;
-@include foundation-progress-bar;
+// @include foundation-progress-bar;
 @include foundation-slider;
 @include foundation-sticky;
 @include foundation-reveal;
@@ -62,7 +62,7 @@ $blue: #0BA6CC;
 $light-blue: #CEE8F1;
 $lighter-blue: #EDFAFF;
 $error: #DE5347;
-$sucess: #6EB85B;
+$success: #6EB85B;
 
 h1, h2, h3, h4, p, th {
   color:$dark-grey;
@@ -113,71 +113,91 @@ hr {
   width: 100%;
 }
 
-// nav background color
-.top-bar, .top-bar li, .top-bar ul.menu  {
-  // background: $light-blue;
-  // background: $white;
-  background: $blue;
-}
-
-
-// nav links
-.top-bar, .top-bar li, .top-bar ul.menu, .top-bar a {
-  // color: $grey;
-  color: $white;
-  font-weight: bold;
-}
-
-// .top-bar li:hover, .top-bar ul.menu:hover,
-.top-bar a:hover {
-  color: $light-grey;
-}
-
 .top-bar {
-  a.active[disabled] {
-    color: $dark-grey;
-    cursor: default;
-  }
-}
-
-// dropdown menu arrow color
-.dropdown.menu li.is-dropdown-submenu-parent a::after  {
-  // border-color: $grey transparent transparent;
-  border-color: $white transparent transparent;
-}
-
-// nav dropdown menu
-.top-bar ul.menu {
-  border :none;
-}
-
-// add bottom border to dropdown menu items
-.top-bar li.is-submenu-item {
-  border-bottom: solid;
-  border-bottom-width: 1px;
-  border-color: $light-grey;
-}
-
-// remove border from last item in dropdown menu
-.top-bar li.is-submenu-item:last-child{
-    border-bottom: none;
-}
-
-// top-bar button style
-ul.menu .button {
-  background-color: $blue;
+  background: $blue;
   color: $white;
-  font-weight: 400;
-  border: solid;
-  border-width: 1px;
-  border-color: $white;
-  margin-top: 3px;
-}
 
-// top-bar button hover
-ul.menu .button:hover, ul.menu .button:focus {
-  color: $blue;
-  background-color: $white;
+  .top-bar-title {
+    padding: 0;
+
+    @media only screen and (max-width: #{map-get($breakpoints,medium)}) {
+      width: 100%;
+    }
+    img {
+      display: inline-block;
+    }
+  }
+
+  .menu-hamburger {
+    @media only screen and (max-width: #{map-get($breakpoints,medium)}) {
+      padding: .4rem;
+    }
+    float: right;
+    .menu-text {
+      color: $off-white;
+    }
+  }
+
+  ul.menu {
+    background: $blue;
+    border: none;
+
+    li {
+      a {
+        color: $off-white;
+        font-weight: bold;
+  
+        &.active[disabled] {
+          color: lighten($blue, 18%);
+          cursor: default;
+        }
+  
+        &:hover {
+          color: darken($off-white, 18%);
+        }
+      }
+    }
+
+    .button {
+      background-color: $blue;
+      color: $white;
+      font-weight: 400;
+      border: solid;
+      border-width: 1px;
+      border-color: $white;
+      margin-top: 3px;
+
+      &:hover, &:focus {
+        color: $blue;
+        background-color: $white;
+      }
+    }
+  }
+
+  .dropdown.menu .submenu {
+    border: none;
+  }
+
+  .dropdown.menu > li.is-dropdown-submenu-parent > a:after {
+    border-color: $white transparent transparent;
+  }
+  
+  /* No idea why -- but .menu > li is getting set to display as a table-cell
+     so we have to put this override in here so that it displays correctly
+     in responsive mode */
+  .is-drilldown li {
+    display: block;
+  }
+
+  .is-drilldown-submenu-parent > a::after,
+  .is-dropdown-submenu .is-dropdown-submenu-parent.opens-right > a:after {
+    border-color: transparent transparent transparent $white;
+  }
+
+  .js-drilldown-back > a:before, 
+  .is-dropdown-submenu .is-dropdown-submenu-parent.opens-left > a:after {
+    border-color: transparent $white transparent transparent;
+  }
 }
 
 // table header font
@@ -216,18 +236,17 @@ fieldset{
 
 // alert callout style sucess
 .callout.success {
-  background-color: $sucess;
+  background-color: $success;
   color: $white;
 }
 
 // X closeout for alert box
 button span {
 color: $white;
-}
-
-// X closeout for alert box hover
-button span:hover {
-color: $light-grey;
+  // X closeout for alert box hover
+  &:hover {
+    color: $light-grey;  
+  }
 }
 
 // style error alert text
@@ -248,7 +267,7 @@ small.error{
   margin-bottom: 16px;
 }
 
-// add radious and padding to buttons
+// add radius and padding to buttons
 div.button, .button, .button:hover, .button:focus, ul.menu .button, ul.menu .button:hover, ul.menu .button:focus, .input-group:last-child .button{
   border-radius: 4px;
   padding-top: 8px;
@@ -263,10 +282,10 @@ div.button, .button {
   border: solid;
   border-width: 1px;
   border-color: $blue;
-}
 
-// button hover style
-.button:hover, .button:focus {
-  color: white;
-  background-color: $blue;
+  // button hover style
+  &:hover, &:focus {
+    color: white;
+    background-color: $blue;
+  }
 }

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,12 +1,12 @@
 <div class="top-bar" id="main-menu">
   <div class="top-bar-title">
-    <% if user_signed_in? %>
-      <% if current_organization && current_organization.logo.present? %>
-        <%= image_tag current_organization.logo.url, alt: current_organization.name, id: "logo" %>
-      <% else %>
-        <%= image_tag "DiaperBase-Logo.png", alt: "DiaperBase Logo", id: "logo" %>
-      <% end %>
+    
+    <% if current_organization && current_organization.logo.present? %>
+      <%= image_tag current_organization.logo.url, alt: current_organization.name, id: "logo" %>
+    <% else %>
+      <%= image_tag "DiaperBase-Logo.png", alt: "DiaperBase Logo", id: "logo" %>
     <% end %>
+    
     <span class="menu-hamburger" data-responsive-toggle="responsive-menu" data-hide-for="medium">
       <span class="menu-text" data-toggle>Menu</span>
       <span class="menu-icon" data-toggle></span>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,95 +1,91 @@
-<% if user_signed_in? %>
-  <div class="top-bar-container" data-sticky-container>
-    <div class="sticky" data-sticky data-options="anchor: page; marginTop: 0; stickyOn: small;">
-      <div class="title-bar" data-responsive-toggle="example-menu" data-hide-for="medium">
-        <button class="menu-icon" type="button" data-toggle="example-menu"></button>
-        <div class="title-bar-title">
-          <% if current_organization.present?  %>
-            <%= current_organization.name %>
-          <% elsif current_user.organization.present?  %>
-            <%= current_user.organization.name %>
-          <% else %>
-            <span>DiaperBase</span>
-          <% end %>
-        </div>
-      </div>
-      <div class="top-bar" id="example-menu">
-        <div class="top-bar-left">
-          <ul class="dropdown menu" data-dropdown-menu>
-            <li class="menu-text organization-name">
-              <% if current_organization.present?  %>
-                <%= current_organization.name %>
-              <% elsif current_user.organization.present?  %>
-                <%= current_user.organization.name %>
-              <% else %>
-                <span>DiaperBase</span>
-              <% end %>
-            </li>
-            <li><%= navigation_link_to('Dashboard', dashboard_path) %></li>
-            <li><%= navigation_link_to('Donations', donations_path) %></li>
-            <li><%= navigation_link_to('Distributions', distributions_path) %></li>
-            <li><%= navigation_link_to('Transfers', transfers_path) %></li>
-            <li class="has-submenu">
-              <a href="javascript:void(0)">Inventory</a>
-              <ul class="submenu menu vertical" data-submenu>
-                <li><%= navigation_link_to('Barcode Items', barcode_items_path) %></li>
-              </ul>
-            </li>
-            <li class="has-submenu">
-              <a href="javascript:void(0)">Address List</a>
-              <ul class="submenu menu vertical" data-submenu>
-                <li><%= navigation_link_to('Dropoff Locations', dropoff_locations_path) %></li>
-                <li><%= navigation_link_to('Partners', partners_path) %></li>
-                <li><%= navigation_link_to('Storage Locations', storage_locations_path) %></li>
-              </ul>
-            </li>
-          </ul>
-        </div>
-        <div class="top-bar-right">
-          <ul class="menu dropdown" data-dropdown-menu>
-            <li><%= current_user.email %></li>
-            <li class='has-submenu'>
-              <a href='javascript:void(0)'>Settings</a>
-              <ul class="submenu vertical menu">
-                <li><%= navigation_link_to "Account Settings", edit_user_registration_path(organization_id: nil) %></li>
-                <% with_options organization_id: current_user.organization.to_param do |with_org| %>
-                  <li><%= navigation_link_to "Manage users", with_org.users_path %></li>
-                  <li><%= navigation_link_to "Modify organization", with_org.edit_organization_path %></li>
-                <% end %>
-              </ul>
-            </li>
-            <li><%= link_to('Log out', destroy_user_session_path(organization_id: nil), method: 'delete') %></li>
-          </ul>
-        </div>
-          <ul class="menu">
-            <li><button type="button" class="button">Login</button></li>
-          </ul>
-        </div>
-      </div>
-    </div>
-  </div>
-<% else %>
-<div class="top-bar-container" data-sticky-container>
-  <div class="sticky" data-sticky data-options="anchor: page; marginTop: 0; stickyOn: small;">
-    <div class="title-bar" data-responsive-toggle="example-menu" data-hide-for="medium">
-      <button class="menu-icon" type="button" data-toggle="example-menu"></button>
-      <div class="title-bar-title">
-        <span>DiaperBase</span>
-      </div>
-    </div>
-    <div class="top-bar" id="example-menu">
-        <div class="top-bar-left">
-          <ul class='menu'>
-            <li class="menu-text organization-name"><span>Diaper Base</span></li>
-          </ul>
-        </div>
+<div class="top-bar" id="main-menu">
+  <div class="top-bar-title">
+    <% if user_signed_in? %>
+      <% if current_organization && current_organization.logo.present? %>
+        <%= image_tag current_organization.logo.url, alt: current_organization.name, id: "logo" %>
+      <% else %>
+        <%= image_tag "DiaperBase-Logo.png", alt: "DiaperBase Logo", id: "logo" %>
+      <% end %>
+    <% end %>
+    <span class="menu-hamburger" data-responsive-toggle="responsive-menu" data-hide-for="medium">
+      <span class="menu-text" data-toggle>Menu</span>
+      <span class="menu-icon" data-toggle></span>
+    </span>
 
-        <div class="top-bar-right">
-          <ul class="menu dropdown" data-dropdown-menu>
-            <li><%= link_to 'Sign In', new_user_session_path(organization_id: nil) %></li>
-          </ul>
-        </div>
-      </div>
   </div>
-</div>
-<% end %>
+
+  <div id="responsive-menu">
+    <div class="top-bar-left">
+
+      <ul class="menu" data-responsive-menu="drilldown medium-dropdown" data-parent-link="true" data-back-button="<li class='js-drilldown-back'><a tabindex='0'>Back</a></li>">
+      <% ############# SIGNED IN ############### %>
+      <% if user_signed_in? %>
+        <li><%= navigation_link_to('Dashboard', dashboard_path) %></li>
+        <li><%= navigation_link_to('Donations', donations_path) %></li>
+        <li><%= navigation_link_to('Distributions', distributions_path)   %></li>
+        <li class="has-submenu">
+          <a href="javascript:void(0)">Inventory</a>
+          <ul class="submenu menu vertical" data-submenu>
+            <li><%= navigation_link_to('Items', items_path) %></li>
+            <li><%= navigation_link_to('Barcode Items', barcode_items_path) %></li>
+            <li><%= navigation_link_to('Storage Locations', storage_locations_path) %></li>
+            <li><%= navigation_link_to('Adjustments', adjustments_path) %></li>
+            <li><%= navigation_link_to('Transfers', transfers_path) %></li>
+          </ul>
+        </li>
+        <li>
+          <a href="javascript:void(0)">Community</a>
+          <ul class="submenu menu vertical" data-submenu>
+            <li><%= navigation_link_to('Donation Sites', dropoff_locations_path) %></li>
+            <li><%= navigation_link_to('Partner Agencies', partners_path) %></li>
+          </ul>
+        </li>
+      <% ############# END SIGNED IN ############### %>
+      <% end %>
+      <% ############# SIGNED IN ############### %>
+      <% # This should really be DRYed out %>
+      <% if user_signed_in? %>
+        <li class="has-submenu hide-for-medium">
+          <a href='javascript:void(0)'>Settings</a>
+          <ul class="submenu menu vertical" data-submenu>
+            <li><%= navigation_link_to "Account Settings", edit_user_registration_path(organization_id: nil) %>      </li>
+            <% with_options organization_id: current_user.organization.to_param do |with_org| %>
+            <li><%= navigation_link_to "Manage users", with_org.users_path %></li>
+            <li><%= navigation_link_to "Modify organization", with_org.edit_organization_path %></li>
+            <% end %>
+          </ul>
+        </li>
+        <li class="hide-for-medium"><%= link_to('Log out', destroy_user_session_path(organization_id: nil), method: 'delete') %></li>
+      <% ############### NOT SIGNED IN ########### %>        
+      <% else %>
+        <li class="hide-for-medium"><%= link_to 'Sign In', new_user_session_path(organization_id: nil) %></li>
+      <% end %>
+      <% ############### END #################### %>
+      </ul>
+    </div><!-- top-bar-left -->
+
+    <div class="top-bar-right">
+      <ul class="menu show-for-medium" data-responsive-menu="drilldown medium-dropdown" data-parent-link="true" data-back-button="<li class='js-drilldown-back'><a tabindex='0'>Back</a></li>">
+        <% ############# SIGNED IN ############### %>
+        <% if user_signed_in? %>
+          <li><%= current_user.email %></li>
+          <li class="has-submenu">
+            <a href='javascript:void(0)'>Settings</a>
+            <ul class="submenu menu vertical" data-submenu>
+              <li><%= navigation_link_to "Account Settings", edit_user_registration_path(organization_id: nil) %>        </li>
+              <% with_options organization_id: current_user.organization.to_param do |with_org| %>
+              <li><%= navigation_link_to "Manage users", with_org.users_path %></li>
+              <li><%= navigation_link_to "Modify organization", with_org.edit_organization_path %></li>
+              <% end %>
+            </ul>
+          </li>
+          <li><%= link_to('Log out', destroy_user_session_path(organization_id: nil), method: 'delete') %></li>
+        <% ############### NOT SIGNED IN ########### %>        
+        <% else %>
+          <li><%= link_to 'Sign In', new_user_session_path(organization_id: nil) %></li>
+        <% end %>
+        <% ############### END #################### %>
+      </ul>
+    </div><!-- top-bar-right -->
+  </div><!-- responsive-menu -->
+</div><!-- main-menu -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,72 +13,7 @@
   </head>
 
   <body>
-    <div class="top-bar">
-      <div class="top-bar-left">
-        <% if user_signed_in? %>
-          <ul class="dropdown menu" data-dropdown-menu>
-            <li class="logo">
-              <% if current_organization && current_organization.logo.present? %>
-                <%= image_tag current_organization.logo.url, alt: current_organization.name %>
-              <% else %>
-                <%= image_tag "DiaperBase-Logo.png", alt: "DiaperBase Logo" %>
-              <% end %>
-            </li>
-            <li><%= navigation_link_to('Dashboard', dashboard_path) %></li>
-            <li><%= navigation_link_to('Donations', donations_path) %></li>
-            <li><%= navigation_link_to('Distributions', distributions_path) %></li>
-            <li class="has-submenu">
-              <a href="javascript:void(0)">Inventory</a>
-              <ul class="submenu menu vertical" data-submenu>
-                <li><%= navigation_link_to('Items', items_path) %></li>
-                <li><%= navigation_link_to('Barcode Items', barcode_items_path) %></li>
-                <li><%= navigation_link_to('Storage Locations', storage_locations_path) %></li>
-                <li><%= navigation_link_to('Adjustments', adjustments_path) %></li>
-                <li><%= navigation_link_to('Transfers', transfers_path) %></li>
-              </ul>
-            </li>
-            <li class="has-submenu">
-              <a href="javascript:void(0)">Community</a>
-              <ul class="submenu menu vertical" data-submenu>
-                <li><%= navigation_link_to('Donation Sites', dropoff_locations_path) %></li>
-                <li><%= navigation_link_to('Partner Agencies', partners_path) %></li>
-              </ul>
-            </li>
-          </ul>
-        <% else %>
-          <ul class='menu'>
-            <li class="logo">
-              <% if current_organization && current_organization.logo.present? %>
-                <%= image_tag current_organization.logo.url, alt: current_organization.name %>
-              <% else %>
-                <%= image_tag "DiaperBase-Logo.png", alt: "DiaperBase Logo" %>
-              <% end %>
-            </li>
-          </ul>
-        <% end %>
-      </div>
-      <div class="top-bar-right">
-        <ul class="menu dropdown" data-dropdown-menu>
-          <% if user_signed_in? %>
-            <li><%= current_user.email %></li>
-            <li class='has-submenu'>
-              <a href='javascript:void(0)'>Settings</a>
-              <ul class="submenu vertical menu">
-                <li><%= navigation_link_to "Account Settings", edit_user_registration_path(organization_id: nil) %></li>
-                <% with_options organization_id: current_user.organization.to_param do |with_org| %>
-                  <li><%= navigation_link_to "Manage users", with_org.users_path %></li>
-                  <li><%= navigation_link_to "Modify organization", with_org.edit_organization_path %></li>
-                <% end %>
-              </ul>
-            </li>
-            <li><%= link_to('Log out', destroy_user_session_path(organization_id: nil), method: 'delete') %></li>
-          <% else %>
-            <li><%= link_to 'Sign In', new_user_session_path(organization_id: nil) %></li>
-          <% end %>
-        </ul>
-      </div>
-    </div>
-
+    <%= render partial: "layouts/navbar" %>
     <%= display_flash_messages %>
 
     <div class="row">


### PR DESCRIPTION
Makes navbar responsive using F6 drilldown menus. Correcks a speling eror in overrides.scss. Cleans up some of the SCSS in overrides. Refactors nav to separate file.

This was a major PITA, but it appears to be super awesome now.

It uses the F6 responsive menu drilldown feature which mimics iOS interface (sliding left/right). I had to replicate the user-account nav items a little so that the menu didn't behave weirdly  when in responsive mode. If that can be DRYed out somehow, that might be best.

Tables display funky still. I think there's an F6 responsive tables mixin or something that we might be able to use. On mobile widths they force the width to be wider than it wants to be and htat makes the interface look dumb.