### PR TITLE
Sources refactor

### DIFF
--- a/app/assets/javascripts/donations.coffee.erb
+++ b/app/assets/javascripts/donations.coffee.erb
@@ -6,9 +6,8 @@
 
 $(document).on 'turbolinks:load', () ->
   control_id = "#donation_source"
-  # TODO: This is tightly coupled to the Donation::SOURCES and that's not too shiny.
-  ddp_text = "Diaper Drive"
-  dpl_text = "Donation Pickup Location"
+  ddp_text = "<%= Donation::SOURCES[:diaper_drive] %>"
+  dpl_text = "<%= Donation::SOURCES[:dropoff] %>"
   ddp_container_id = "div.donation_diaper_drive_participant"
   dpl_container_id = "div.donation_dropoff_location"
   $(ddp_container_id).hide()

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -86,10 +86,9 @@ private
   end
 
   # Omits dropoff_location_id or diaper_drive_participant_id if those aren't selected as source
-  # FIXME "magic string" for source field should be DRYed out.
   def strip_unnecessary_params
-    params[:donation].delete(:dropoff_location_id) unless params[:donation][:source] == "Donation Pickup Location"
-    params[:donation].delete(:diaper_drive_participant_id) unless params[:donation][:source] == "Diaper Drive"
+    params[:donation].delete(:dropoff_location_id) unless params[:donation][:source] == Donation::SOURCES[:dropoff]
+    params[:donation].delete(:diaper_drive_participant_id) unless params[:donation][:source] == Donation::SOURCES[:diaper_drive]
     params
   end
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -26,8 +26,8 @@ class Donation < ApplicationRecord
   accepts_nested_attributes_for :line_items,
     allow_destroy: true
 
-  validates :dropoff_location, presence: { message: "must be specified since you chose 'Donation Pickup Location'" }, if: :from_dropoff_location?
-  validates :diaper_drive_participant, presence: { message: "must be specified since you chose 'Diaper Drive'" }, if: :from_diaper_drive?
+  validates :dropoff_location, presence: { message: "must be specified since you chose '#{SOURCES[:dropoff]}'" }, if: :from_dropoff_location?
+  validates :diaper_drive_participant, presence: { message: "must be specified since you chose '#{SOURCES[:diaper_drive]}'" }, if: :from_diaper_drive?
   validates :source, presence: true, inclusion: { in: SOURCES.values, message: "Must be a valid source." }
   # FIXME - This validation can be removed because it's implicit in belongs_to as of Rails 5
   validates :storage_location, :organization, presence: true
@@ -35,15 +35,15 @@ class Donation < ApplicationRecord
   scope :between, ->(start, stop) { where(donations: { created_at: start..stop }) }
   scope :during, ->(range) { where(donations: { created_at: range }) }
   # TODO - change this to "by_source()" with an argument that accepts a source name
-  scope :diaper_drive, -> { where(source: "Diaper Drive") }
+  scope :diaper_drive, -> { where(source: SOURCES[:diaper_drive] ) }
   scope :recent, ->(count=3) { order(:created_at).limit(count) }
 
   def from_diaper_drive?
-    source == "Diaper Drive"
+    source == SOURCES[:diaper_drive]
   end
 
   def from_dropoff_location?
-    source == "Donation Pickup Location"
+    source == SOURCES[:dropoff]
   end
 
   def self.daily_quantities_by_source(start, stop)

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -14,7 +14,7 @@
 #
 
 class Donation < ApplicationRecord
-  SOURCES = ["Diaper Drive", "Purchased Supplies", "Donation Pickup Location", "Misc. Donation"].freeze
+  SOURCES = { diaper_drive: "Diaper Drive", purchased: "Purchased Supplies", dropoff: "Donation Pickup Location", misc: "Misc. Donation" }.freeze
 
   belongs_to :organization
 
@@ -28,7 +28,7 @@ class Donation < ApplicationRecord
 
   validates :dropoff_location, presence: { message: "must be specified since you chose 'Donation Pickup Location'" }, if: :from_dropoff_location?
   validates :diaper_drive_participant, presence: { message: "must be specified since you chose 'Diaper Drive'" }, if: :from_diaper_drive?
-  validates :source, presence: true, inclusion: { in: SOURCES, message: "Must be a valid source." }
+  validates :source, presence: true, inclusion: { in: SOURCES.values, message: "Must be a valid source." }
   # FIXME - This validation can be removed because it's implicit in belongs_to as of Rails 5
   validates :storage_location, :organization, presence: true
 

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for @donation do |f| %>
 
-  <%= f.input :source, collection: Donation::SOURCES, label: "Source", error: "What effort or initiative did this donation come from?" %>
+  <%= f.input :source, collection: Donation::SOURCES.values, label: "Source", error: "What effort or initiative did this donation come from?" %>
   <%= f.association :dropoff_location, collection: @dropoff_locations, label: "Dropoff Location", error: "Where was this donation dropped off?" %>
   <%= f.association :diaper_drive_participant, collection: @diaper_drive_participants, label_method: :name, label: "Diaper Drive Participant", error: "Which diaper drive was this from?" %>
   <%= f.association :storage_location, collection: @storage_locations, label: "Storage Location", error: "Where is it being stored?" %>

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -17,7 +17,7 @@ FactoryGirl.define do
   factory :donation do
     dropoff_location
     diaper_drive_participant
-    source { "Misc. Donation" }
+    source { Donation::SOURCES[:misc] }
     comment "It's a fine day for diapers."
     storage_location
     organization { Organization.try(:first) || create(:organization) }

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature "Donations", type: :feature, js: true do
       end
 
       scenario "User can create a donation with a Miscellaneous source" do
-        select "Misc. Donation", from: "donation_source"
+        select Donation::SOURCES[:misc], from: "donation_source"
         expect(page).not_to have_xpath("//select[@id='donation_dropoff_location_id']")
         expect(page).not_to have_xpath("//select[@id='donation_diaper_drive_participant_id']")
         select StorageLocation.first.name, from: "donation_storage_location_id"

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -32,7 +32,7 @@ RSpec.feature "Donations", type: :feature, js: true do
       end
 
       scenario "User can create a donation for a Diaper Drive source" do
-        select "Diaper Drive", from: "donation_source"
+        select Donation::SOURCES[:diaper_drive], from: "donation_source"
         expect(page).to have_xpath("//select[@id='donation_diaper_drive_participant_id']")
         expect(page).not_to have_xpath("//select[@id='donation_dropoff_location_id']")
         select DiaperDriveParticipant.first.name, from: "donation_diaper_drive_participant_id"
@@ -46,7 +46,7 @@ RSpec.feature "Donations", type: :feature, js: true do
       end
 
       scenario "User can create a donation for a Donation Site source" do
-        select "Donation Pickup Location", from: "donation_source"
+        select Donation::SOURCES[:dropoff], from: "donation_source"
         expect(page).to have_xpath("//select[@id='donation_dropoff_location_id']")
         expect(page).not_to have_xpath("//select[@id='donation_diaper_drive_participant_id']")
         select DropoffLocation.first.name, from: "donation_dropoff_location_id"
@@ -60,7 +60,7 @@ RSpec.feature "Donations", type: :feature, js: true do
       end
 
       scenario "User can create a donation for Purchased Supplies" do
-        select "Purchased Supplies", from: "donation_source"
+        select Donation::SOURCES[:purchased], from: "donation_source"
         expect(page).not_to have_xpath("//select[@id='donation_dropoff_location_id']")
         expect(page).not_to have_xpath("//select[@id='donation_diaper_drive_participant_id']")
         select StorageLocation.first.name, from: "donation_storage_location_id"
@@ -88,9 +88,9 @@ RSpec.feature "Donations", type: :feature, js: true do
       # Since the form only shows/hides the irrelevant field, if the user already selected something it would still
       # submit. The app should sanitize this so we aren't saving extraneous data
       scenario "extraneous data is stripped if the user adds both dropoff_location and diaper_drive_participant" do
-        select "Donation Pickup Location", from: "donation_source"
+        select Donation::SOURCES[:dropoff], from: "donation_source"
         select DropoffLocation.first.name, from: "donation_dropoff_location_id"
-        select "Diaper Drive", from: "donation_source"
+        select Donation::SOURCES[:diaper_drive], from: "donation_source"
         select DiaperDriveParticipant.first.name, from: "donation_diaper_drive_participant_id"
         select StorageLocation.first.name, from: "donation_storage_location_id"
         select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -129,4 +129,13 @@ RSpec.describe Donation, type: :model do
       end
     end
   end
+
+  describe "SOURCES" do
+    it "is a hash that is referenceable by key to avoid 'magic strings'" do
+      expect(Donation::SOURCES).to have_key(:diaper_drive)
+      expect(Donation::SOURCES).to have_key(:purchased)
+      expect(Donation::SOURCES).to have_key(:dropoff)
+      expect(Donation::SOURCES).to have_key(:misc)
+    end
+  end
 end


### PR DESCRIPTION
Fixes #90

Changes the `Donation::SOURCES` from an array of strings to a hash of strings, and then changes all previous instances of those strings to instead reference this hash via the hashkey.

My thinking here is that the spelling or wording of those things may possibly vary in the future, but the fact that they're sources will probably not (ie. "Donation PIckup Location" could change back to "Dropoff Location", but it's the same thing with a different name)