### PR TITLE
DiaperDriveParticipant CRUD (sans-D)

### DIFF
--- a/app/controllers/diaper_drive_participants_controller.rb
+++ b/app/controllers/diaper_drive_participants_controller.rb
@@ -1,0 +1,39 @@
+class DiaperDriveParticipantsController < ApplicationController
+  def index
+    @diaper_drive_participants = DiaperDriveParticipant.includes(:donations).all
+  end
+
+  def create
+    @diaper_drive_participant = DiaperDriveParticipant.new(diaper_drive_participant_params.merge(organization: current_organization))
+    if (@diaper_drive_participant.save)
+      redirect_to @diaper_drive_participant, notice: "New diaper drive participant added!"
+    else
+      flash[:notice] = "Something didn't work quite right -- try again?"
+      render action: :new
+    end
+    
+  end
+
+  def new
+    @diaper_drive_participant = DiaperDriveParticipant.new
+  end
+
+  def edit
+    @diaper_drive_participant = DiaperDriveParticipant.find(params[:id])
+  end
+
+  def show
+    @diaper_drive_participant = DiaperDriveParticipant.includes(:donations).find(params[:id])
+  end
+
+  def update
+    @diaper_drive_participant = DiaperDriveParticipant.find(params[:id])
+    @diaper_drive_participant.update_attributes(diaper_drive_participant_params)
+    redirect_to @diaper_drive_participant, notice: "#{@diaper_drive_participant.name} updated!"
+  end
+
+private
+  def diaper_drive_participant_params
+    params.require(:diaper_drive_participant).permit(:name, :phone, :email)
+  end
+end

--- a/app/models/diaper_drive_participant.rb
+++ b/app/models/diaper_drive_participant.rb
@@ -20,4 +20,9 @@ class DiaperDriveParticipant < ApplicationRecord
   validates :name, presence: true
   validates :phone, presence: { message: "Must provide a phone or an e-mail" }, if: Proc.new { |ddp| ddp.email.blank? }
   validates :email, presence: { message: "Must provide a phone or an e-mail" }, if: Proc.new { |ddp| ddp.phone.blank? }
+
+  # TODO - This should be set up with a callback to cache the total so we're not hitting the DB
+  def volume
+  	donations.map(&:total_items).reduce(:+)
+  end  
 end

--- a/app/models/diaper_drive_participant.rb
+++ b/app/models/diaper_drive_participant.rb
@@ -23,6 +23,6 @@ class DiaperDriveParticipant < ApplicationRecord
 
   # TODO - This should be set up with a callback to cache the total so we're not hitting the DB
   def volume
-  	donations.map(&:total_items).reduce(:+)
-  end  
+    donations.map(&:total_items).reduce(:+)
+  end
 end

--- a/app/views/diaper_drive_participants/_diaper_drive_participant_row.html.erb
+++ b/app/views/diaper_drive_participants/_diaper_drive_participant_row.html.erb
@@ -1,0 +1,9 @@
+<tr>
+  <td><%= diaper_drive_participant_row.name %></td>
+  <td><%= diaper_drive_participant_row.try(:phone) rescue "" %></td>
+  <td><%= diaper_drive_participant_row.try(:email) rescue "" %></td>
+  <td><%= diaper_drive_participant_row.volume %></td>
+  <td><%= link_to "View", diaper_drive_participant_row %> 
+      <%= link_to "Edit", edit_diaper_drive_participant_path(diaper_drive_participant_row) %>
+      </td>
+</tr>

--- a/app/views/diaper_drive_participants/_diaper_drive_participant_row.html.erb
+++ b/app/views/diaper_drive_participants/_diaper_drive_participant_row.html.erb
@@ -3,7 +3,8 @@
   <td><%= diaper_drive_participant_row.try(:phone) rescue "" %></td>
   <td><%= diaper_drive_participant_row.try(:email) rescue "" %></td>
   <td><%= diaper_drive_participant_row.volume %></td>
-  <td><%= link_to "View", diaper_drive_participant_row %> 
-      <%= link_to "Edit", edit_diaper_drive_participant_path(diaper_drive_participant_row) %>
-      </td>
+  <td>
+    <%= link_to "View", diaper_drive_participant_row %>
+    <%= link_to "Edit", edit_diaper_drive_participant_path(diaper_drive_participant_row) %>
+  </td>
 </tr>

--- a/app/views/diaper_drive_participants/_form.html.erb
+++ b/app/views/diaper_drive_participants/_form.html.erb
@@ -1,0 +1,9 @@
+<%= simple_form_for form do |f| %>
+
+<%= f.input :name, label: "Name", error: "A name is required" %>
+<%= f.input :phone, label: "Phone", error: "Either a phone or an e-mail is required" %>
+<%= f.input :email, label: "Email", error: "Either a phone or an e-mail is required" %>
+
+<%= f.button :submit %>
+
+<% end %>

--- a/app/views/diaper_drive_participants/edit.html.erb
+++ b/app/views/diaper_drive_participants/edit.html.erb
@@ -1,0 +1,5 @@
+<% content_for :title, "#{current_organization.name} - Diaper Drive Participants - Edit" %>
+
+<h1>Diaper Drive: <%= @diaper_drive_participant.name %></h1>
+
+<%= render partial: "form", object: @diaper_drive_participant %>

--- a/app/views/diaper_drive_participants/index.html.erb
+++ b/app/views/diaper_drive_participants/index.html.erb
@@ -1,0 +1,23 @@
+<% content_for :title, "#{current_organization.name} - Agencies - Diaper Drive Participants" %>
+
+<div class="header-action">
+  <%= link_to "New Diaper Drive Participant", new_diaper_drive_participant_path(organization_id: current_organization), class: "button float-right" %>
+</div>
+
+
+<h1>Diaper Drive Participants</h1>
+
+<table id="diaper_drive_participants">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Phone</th>
+      <th>Email</th>
+      <th>Volume</th>
+      <th>&nbsp;</th>
+  </thead>
+
+  <tbody>
+    <%= render partial: "diaper_drive_participant_row", collection: @diaper_drive_participants %>
+  </tbody>
+</table>

--- a/app/views/diaper_drive_participants/index.html.erb
+++ b/app/views/diaper_drive_participants/index.html.erb
@@ -15,6 +15,7 @@
       <th>Email</th>
       <th>Volume</th>
       <th>&nbsp;</th>
+    </tr>
   </thead>
 
   <tbody>

--- a/app/views/diaper_drive_participants/new.html.erb
+++ b/app/views/diaper_drive_participants/new.html.erb
@@ -1,0 +1,5 @@
+<% content_for :title, "#{current_organization.name} - Agencies - Diaper Drive Participants - New" %>
+
+<h1>Create a new Diaper Drive Participant</h1>
+
+<%= render partial: "form", object: @diaper_drive_participant %>

--- a/app/views/diaper_drive_participants/show.html.erb
+++ b/app/views/diaper_drive_participants/show.html.erb
@@ -1,0 +1,30 @@
+<% content_for :title, "#{current_organization.name} - Agencies - Diaper Drive Participants - #{@diaper_drive_participant.name}" %>
+
+<h1><%= @diaper_drive_participant.name %></h1>
+
+<ul>
+<% if @diaper_drive_participant.phone.present? %>
+  <li><%= @diaper_drive_participant.phone %></li>
+<% end %>
+<% if @diaper_drive_participant.email.present? %>
+  <li><%= link_to @diaper_drive_participant.email, "mailto:#{@diaper_drive_participant.email}" %></li>
+<% end %>
+</ul>
+
+<table id="diaper_drive_participants">
+  <thead>
+    <tr>
+      <th>Date</th>
+      <th>Volume</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @diaper_drive_participant.donations.each do |donation| %>
+      <tr>
+        <td><%= donation.created_at %></td>
+        <td><%= donation.total_items %></td>
+      </tr>
+    <% end %>
+  </tbody>  
+</table>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -1,12 +1,12 @@
 <div class="top-bar" id="main-menu">
   <div class="top-bar-title">
-    
+
     <% if current_organization && current_organization.logo.present? %>
       <%= image_tag current_organization.logo.url, alt: current_organization.name, id: "logo" %>
     <% else %>
       <%= image_tag "DiaperBase-Logo.png", alt: "DiaperBase Logo", id: "logo" %>
     <% end %>
-    
+
     <span class="menu-hamburger" data-responsive-toggle="responsive-menu" data-hide-for="medium">
       <span class="menu-text" data-toggle>Menu</span>
       <span class="menu-icon" data-toggle></span>
@@ -38,8 +38,10 @@
           <ul class="submenu menu vertical" data-submenu>
             <li><%= navigation_link_to('Donation Sites', dropoff_locations_path) %></li>
             <li><%= navigation_link_to('Partner Agencies', partners_path) %></li>
-            <li><%= navigation_link_to('
-            Diaper Drive Participants', diaper_drive_participants_path) %></li>
+            <li>
+              <%= navigation_link_to('Diaper Drive Participants',
+                                     diaper_drive_participants_path) %>
+            </li>
           </ul>
         </li>
       <% ############# END SIGNED IN ############### %>
@@ -58,7 +60,7 @@
           </ul>
         </li>
         <li class="hide-for-medium"><%= link_to('Log out', destroy_user_session_path(organization_id: nil), method: 'delete') %></li>
-      <% ############### NOT SIGNED IN ########### %>        
+      <% ############### NOT SIGNED IN ########### %>
       <% else %>
         <li class="hide-for-medium"><%= link_to 'Sign In', new_user_session_path(organization_id: nil) %></li>
       <% end %>
@@ -82,7 +84,7 @@
             </ul>
           </li>
           <li><%= link_to('Log out', destroy_user_session_path(organization_id: nil), method: 'delete') %></li>
-        <% ############### NOT SIGNED IN ########### %>        
+        <% ############### NOT SIGNED IN ########### %>
         <% else %>
           <li><%= link_to 'Sign In', new_user_session_path(organization_id: nil) %></li>
         <% end %>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -38,6 +38,8 @@
           <ul class="submenu menu vertical" data-submenu>
             <li><%= navigation_link_to('Donation Sites', dropoff_locations_path) %></li>
             <li><%= navigation_link_to('Partner Agencies', partners_path) %></li>
+            <li><%= navigation_link_to('
+            Diaper Drive Participants', diaper_drive_participants_path) %></li>
           </ul>
         </li>
       <% ############# END SIGNED IN ############### %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,7 @@ Rails.application.routes.draw do
 
     resources :barcode_items
     resources :dropoff_locations
+    resources :diaper_drive_participants, except: [:destroy]
     resources :items
     resources :partners
 

--- a/spec/controllers/diaper_drive_participants_controller_spec.rb
+++ b/spec/controllers/diaper_drive_participants_controller_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe DiaperDriveParticipantsController, type: :controller do
+  let(:default_params) {
+    { organization_id: @organization.to_param }
+  }
+
+  context "While signed in" do
+    before do
+      sign_in(@user)
+    end
+  
+    describe "GET #index" do
+      subject { get :index, params: default_params }
+      it "returns http success" do
+        expect(subject).to be_successful
+      end
+    end
+  
+    describe "GET #new" do
+      subject { get :new, params: default_params }
+      it "returns http success" do
+        expect(subject).to be_successful
+      end
+    end
+  
+    describe "GET #edit" do
+      subject { get :edit, params: default_params.merge({ id: create(:diaper_drive_participant) }) }
+      it "returns http success" do
+        expect(subject).to be_successful
+      end
+    end
+  
+    describe "GET #show" do
+      subject { get :show, params: default_params.merge({ id: create(:diaper_drive_participant) }) }
+      it "returns http success" do
+        expect(subject).to be_successful
+      end
+    end
+  
+    describe "DELETE #destroy" do
+      subject { delete :destroy, params: default_params.merge({ id: create(:diaper_drive_participant) }) }
+      it "does not have a route for this" do
+        expect{subject}.to raise_error(ActionController::UrlGenerationError)
+      end
+    end
+
+    context "Looking at a different organization" do
+        let(:object) { create(:diaper_drive_participant, organization: create(:organization) ) }
+        include_examples "requiring authorization"
+    end
+  end
+  
+  context "While not signed in" do
+    let(:object) { create(:diaper_drive_participant) }
+  
+    include_examples "requiring authentication"
+  end
+
+end

--- a/spec/features/diaper_drive_participant_spec.rb
+++ b/spec/features/diaper_drive_participant_spec.rb
@@ -1,0 +1,51 @@
+RSpec.feature "Diaper Drive Participant", type: :feature do
+  before do
+    sign_in(@user)
+  end
+  let(:url_prefix) { "/#{@organization.to_param}" }
+
+  scenario "User can create a new diaper drive instance" do
+    visit url_prefix + '/diaper_drive_participants/new'
+    diaper_drive_participant_traits = attributes_for(:diaper_drive_participant)
+    fill_in "Name", with: diaper_drive_participant_traits[:name]
+    fill_in "Phone", with: diaper_drive_participant_traits[:phone]
+    
+    expect {
+      click_button "Create Diaper drive participant"
+    }.to change{DiaperDriveParticipant.count}.by(1)
+
+    expect(page.find('.flash.success')).to have_content "added"
+  end
+
+  scenario "User can update the contact info for a diaper drive participant" do
+    diaper_drive_participant = create(:diaper_drive_participant)
+    new_email = 'foo@bar.com'
+    visit url_prefix + "/diaper_drive_participants/#{diaper_drive_participant.id}/edit"
+    fill_in "Phone", with: ''
+    fill_in "Email", with: new_email
+    click_button "Update Diaper drive participant"
+
+    expect(page.find('.flash.success')).to have_content "updated"
+    expect(page).to have_content(diaper_drive_participant.name)
+    expect(page).to have_content(new_email)
+  end
+
+  context "When the Diaper Drives have donations associated with them already" do
+    before(:each) do
+      @ddp = create(:diaper_drive_participant)
+      create(:donation, :with_item, created_at: 1.day.ago, item_quantity: 10, source: Donation::SOURCES[:diaper_drive], diaper_drive_participant: @ddp)
+      create(:donation, :with_item, created_at: 1.week.ago, item_quantity: 15, source: Donation::SOURCES[:diaper_drive], diaper_drive_participant: @ddp)
+    end
+
+    scenario "Existing Diaper Drive Participants show in the #index with some summary stats" do
+      visit url_prefix + "/diaper_drive_participants"
+      expect(page).to have_xpath("//table[@id='diaper_drive_participants']/tbody/tr/td", text: @ddp.name)
+      expect(page).to have_xpath("//table[@id='diaper_drive_participants']/tbody/tr/td", text: "25")
+    end
+  
+    scenario "Single Diaper Drive Participants show semi-detailed stats about donations from that diaper drive" do
+      visit url_prefix + "/diaper_drive_participants/#{@ddp.to_param}"
+      expect(page).to have_xpath("//table[@id='diaper_drive_participants']/tbody/tr", count: 2)
+    end
+  end
+end

--- a/spec/models/diaper_drive_participant_spec.rb
+++ b/spec/models/diaper_drive_participant_spec.rb
@@ -16,7 +16,7 @@
 require 'rails_helper'
 
 RSpec.describe DiaperDriveParticipant, type: :model do
-  describe "Validations" do
+  context "Validations" do
   	it "is invalid without a name" do
       expect(build(:diaper_drive_participant, name: nil)).not_to be_valid
   	end
@@ -29,6 +29,16 @@ RSpec.describe DiaperDriveParticipant, type: :model do
 
     it "is invalid without an organization" do
       expect(build(:diaper_drive_participant, organization: nil)).not_to be_valid
+    end
+  end
+
+  context "Methods" do
+    describe "volume" do
+      it "retrieves the amount of product that has been donated through this diaper drive" do
+        ddp = create(:diaper_drive_participant)
+        create(:donation, :with_item, item_quantity: 10, source: Donation::SOURCES[:diaper_drive], diaper_drive_participant: ddp)
+        expect(ddp.volume).to eq(10)
+      end
     end
   end
 end


### PR DESCRIPTION
Adds basic DiaperDriveParticipant CRU actions, with basic validation. 
Feature specs to cover. Adds new method to DDP model to gather total volume for that DD. Some DB optimization is still necessary and this is another good candidate for pre-caching those totals with a callback.

Tested with both spec coverage and manual testing in `rails s`. Needs a touch of optimization to reduce DB queries.