### PR TITLE
Fixes #71

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -39,6 +39,7 @@ class DonationsController < ApplicationController
       @storage_locations = current_organization.storage_locations
       @dropoff_locations = current_organization.dropoff_locations
       @diaper_drive_participants = current_organization.diaper_drive_participants
+      @items = current_organization.items.alphabetized
       flash[:notice] = "There was an error starting this donation, try again?"
       render action: :new
     end

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -100,6 +100,18 @@ RSpec.feature "Donations", type: :feature, js: true do
         expect(donation.diaper_drive_participant_id).to be_present
         expect(donation.dropoff_location_id).to be_nil
       end
+
+      # Bug fix -- Issue #71
+      # When a user creates a donation without it passing validation, the items
+      # dropdown is not populated on the return trip.
+      scenario "items dropdown is still repopulated even if initial submission doesn't validate" do
+        item_count = @organization.items.count + 1  # Adds 1 for the "choose an item" option
+        expect(page).to have_xpath("//select[@id='donation_line_items_attributes_0_item_id']/option", count: item_count)
+        click_button "Create Donation"
+
+        expect(page).to have_content("error")
+        expect(page).to have_xpath("//select[@id='donation_line_items_attributes_0_item_id']/option", count: item_count)
+      end
     end
 
 


### PR DESCRIPTION
Adds missing @items initialization in donations#create fail-block. Adds test coverage for this bug.

bug was simple, in the end -- just missing `@items = current_organization.items.alphabetized` like in the normal `Donations#new` action. :+1: 