### PR TITLE
Adds logo bottom center of distribution report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ after_success:
 - "eval `ssh-agent -s`"
 - "ssh-add config/deploy_id_rsa"
 - "[[ $TRAVIS_BRANCH = 'master' ]] && bundle exec cap production deploy"
+- ssh-agent -k
 env:
   global:
   - secure: x16+B4ioERzzKu2jYeRXwWDl2wys7ssNegalS3MJvIiit9WZvMAyBbIY2O0vSr4Ik86X7PQLAokTNFN4oOM3puZcs9Ix5lf2liQeN27dCDBi53tAbOF0rvfKB8A4nAv1Unrf/sw/AzW46c88u0/sKTqu+HWoyjfEUX79GJf7BB9F1/7z+RK06XhuPPjSRxgzZFniUfvoum/4wHvQt8zUusDDba8B3lIwPyDGL4euMJaNB56SHsszCmO4mu7+TExiM+oWbnyi+wFnqp0oBa6hyxwNIwAAeznig/Dshq2uPCuMXLaexAwVzaKhKlsPDsVw+xH0DUQ8/8RXzvIaJuhovQX72Jnj+/WrA9dLLBbm53JGUrD8BVjII5mZmzUshxWCpw/3XMocaDVwj8VMeAMcZpGdolXvC5nh3H/ABti0BibP3hDSXU5gNuxiS+HJsIC9jkwq7TGs8wxA8X4SULy1oM7v5qKT1z5dG7y9TwTiAJ1x0KHLdRgzXcm9iHqSwnNgfZ59pW/fvnhUMqo4E1wplTo5Oysr7qjw63LsklA8aKixDgWShHp0CsO3v2ragyZvyrL+sSast++c6+iQHVnp6Bt4IZs8zcLmEeWGGzWe5RZwdg0o9Wp+Ul2uIsPhSGzIVK5ahnjPqdHYLIDOL4A8emgFXAtNxZhaB8tIKTGHguo=

--- a/app/helpers/distributions_helper.rb
+++ b/app/helpers/distributions_helper.rb
@@ -1,7 +1,7 @@
 module DistributionsHelper
 
-  def logo_file_path(organization)
-    if organization.logo.present?
+  def logo_file_path(organization=nil)
+    if organization && organization.logo.present?
       organization.logo.path
     else
       Rails.root.join('app', 'assets', 'images', 'DiaperBase-Logo.png')

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -53,7 +53,7 @@ class Organization < ApplicationRecord
   end
 
   def address_inline
-    address.split("\n").join(",")
+    address.split("\n").map(&:strip).join(", ")
   end
 
   def total_inventory

--- a/app/views/distributions/print.pdf.prawn
+++ b/app/views/distributions/print.pdf.prawn
@@ -93,17 +93,19 @@ prawn_document do |pdf|
 
   pdf.number_pages "Page <page> of <total>", {
     start_count_at: 1,
-    at: [pdf.bounds.right - 130, 37],
+    at: [pdf.bounds.right - 130, 73],
     align: :right
   }
 
   pdf.repeat :all do
     # Page footer
-    pdf.bounding_box [pdf.bounds.left, pdf.bounds.bottom + 50], width: pdf.bounds.width do
+    pdf.bounding_box [pdf.bounds.left, pdf.bounds.bottom + 85], width: pdf.bounds.width do
       pdf.font "Helvetica"
       pdf.stroke_horizontal_rule
       pdf.move_down(5)
-      pdf.table([[current_organization.name, current_organization.address_inline, ""]]) do
+      pdf.table([
+        [current_organization.name, current_organization.address_inline, ""],
+      ]) do
         self.width = pdf.bounds.width
         cells.borders = []
         column(0).width = 125
@@ -111,7 +113,15 @@ prawn_document do |pdf|
         column(1).style align: :center
         column(2).style align: :right
       end
+      pdf.move_down(10)
+      pdf.span(200, position: :center) do
+        pdf.text "Lovingly created with", align: :center
+      end
+      pdf.image logo_file_path,
+                width: 125,
+                position: (pdf.bounds.width - 125) / 2
     end
+
   end
 end
 

--- a/app/views/distributions/print.pdf.prawn
+++ b/app/views/distributions/print.pdf.prawn
@@ -93,13 +93,14 @@ prawn_document do |pdf|
 
   pdf.number_pages "Page <page> of <total>", {
     start_count_at: 1,
-    at: [pdf.bounds.right - 130, 73],
+    at: [pdf.bounds.right - 130, 22],
     align: :right
   }
 
   pdf.repeat :all do
     # Page footer
-    pdf.bounding_box [pdf.bounds.left, pdf.bounds.bottom + 85], width: pdf.bounds.width do
+    pdf.bounding_box [pdf.bounds.left, pdf.bounds.bottom + 35], width: pdf.bounds.width do
+      pdf.stroke_bounds
       pdf.font "Helvetica"
       pdf.stroke_horizontal_rule
       pdf.move_down(5)
@@ -113,13 +114,11 @@ prawn_document do |pdf|
         column(1).style align: :center
         column(2).style align: :right
       end
-      pdf.move_down(10)
-      pdf.span(200, position: :center) do
-        pdf.text "Lovingly created with", align: :center
+      logo_offset = (pdf.bounds.width - 190) / 2
+      pdf.bounding_box([logo_offset, 0], width: 190, height: 33) do
+        pdf.text "Lovingly created with", valign: :center
+        pdf.image logo_file_path, width: 75, vposition: :center, position: :right
       end
-      pdf.image logo_file_path,
-                width: 125,
-                position: (pdf.bounds.width - 125) / 2
     end
 
   end


### PR DESCRIPTION
WIP!!! Do not merge yet. Looking for comments

This adds the diaperbase logo to the bottom of the report. But I had trouble making it fit. I bumped the footer bounding box up from 50 to 85 units offset from the bottom of the page, which is very high. After the logo was added, making this value any smaller causes an error that says we are running outside of the graphic stack. 

I need to play with this more to figure out how to make things fit better without having such a huge footer. Also need to be careful not to put things too close to the bottom of the page that it might sit outside of some printer's printable margins. 

<img width="976" alt="screen shot 2017-06-17 at 11 40 51 am" src="https://user-images.githubusercontent.com/1625840/27254216-2401c0ae-5352-11e7-9252-6b2de1e6835d.png">


#novacodeandcoffee