### PR TITLE
Updating the capistrano deploy file.

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -23,7 +23,9 @@ require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano/puma'
 # require 'capistrano/passenger'
+require "capistrano/scm/git"
 
+install_plugin Capistrano::SCM::Git
 install_plugin Capistrano::Puma  # Default puma tasks
 install_plugin Capistrano::Puma::Workers  # if you want to control the workers (in cluster mode)
 install_plugin Capistrano::Puma::Nginx  # if you want to upload a nginx site template

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -67,17 +67,9 @@ namespace :deploy do
     end
   end
 
-  desc 'Restart application'
-  task :restart do
-    on roles(:app), in: :sequence, wait: 5 do
-      invoke 'puma:restart'
-    end
-  end
-
   before :starting,     :check_revision
   after  :finishing,    :compile_assets
   after  :finishing,    :cleanup
-  after  :finishing,    :restart
 end
 
 # ps aux | grep puma    # Get puma pid


### PR DESCRIPTION
This is the fix for the double puma restart happening with capistrano.

It turns out that this is because of the defined restart task we have conflicting with the one built into the capistration3-puma gem. More information can be found in [this stackoverflow answer](https://stackoverflow.com/a/39812330/752979).



