### PR TITLE
Organization scope

### DIFF
--- a/app/controllers/diaper_drive_participants_controller.rb
+++ b/app/controllers/diaper_drive_participants_controller.rb
@@ -1,10 +1,10 @@
 class DiaperDriveParticipantsController < ApplicationController
   def index
-    @diaper_drive_participants = DiaperDriveParticipant.includes(:donations).all
+    @diaper_drive_participants = current_organization.diaper_drive_participants.includes(:donations).all
   end
 
   def create
-    @diaper_drive_participant = DiaperDriveParticipant.new(diaper_drive_participant_params.merge(organization: current_organization))
+    @diaper_drive_participant = current_organization.diaper_drive_participants.new(diaper_drive_participant_params.merge(organization: current_organization))
     if (@diaper_drive_participant.save)
       redirect_to @diaper_drive_participant, notice: "New diaper drive participant added!"
     else
@@ -15,19 +15,19 @@ class DiaperDriveParticipantsController < ApplicationController
   end
 
   def new
-    @diaper_drive_participant = DiaperDriveParticipant.new
+    @diaper_drive_participant = current_organization.diaper_drive_participants.new
   end
 
   def edit
-    @diaper_drive_participant = DiaperDriveParticipant.find(params[:id])
+    @diaper_drive_participant = current_organization.diaper_drive_participants.find(params[:id])
   end
 
   def show
-    @diaper_drive_participant = DiaperDriveParticipant.includes(:donations).find(params[:id])
+    @diaper_drive_participant = current_organization.diaper_drive_participants.includes(:donations).find(params[:id])
   end
 
   def update
-    @diaper_drive_participant = DiaperDriveParticipant.find(params[:id])
+    @diaper_drive_participant = current_organization.diaper_drive_participants.find(params[:id])
     @diaper_drive_participant.update_attributes(diaper_drive_participant_params)
     redirect_to @diaper_drive_participant, notice: "#{@diaper_drive_participant.name} updated!"
   end

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -68,8 +68,9 @@ class DonationsController < ApplicationController
   def edit
     @donation = Donation.find(params[:id])
     @donation.line_items.build
-    @storage_locations = StorageLocation.all
-    @dropoff_locations = DropoffLocation.all
+    @storage_locations = current_organization.storage_locations
+    @dropoff_locations = current_organization.dropoff_locations
+    @diaper_drive_participants = current_organization.diaper_drive_participants
   end
 
   def show
@@ -84,7 +85,7 @@ class DonationsController < ApplicationController
   end
 
   def destroy
-    @donation = current_organization.donations.find(params[:id])
+    @donation = current_organization.donations.includes(:line_items, storage_location: :inventory_items).find(params[:id])
     @donation.destroy
     redirect_to donations_path
   end
@@ -93,7 +94,7 @@ private
   def donation_params
     params = strip_unnecessary_params
     params = compact_line_items
-    params.require(:donation).permit(:source, :comment, :storage_location_id, :issued_at, :dropoff_location_id, :diaper_drive_participant_id, line_items_attributes: [:item_id, :quantity, :_destroy]).merge(organization: current_organization)
+    params.require(:donation).permit(:source, :comment, :storage_location_id, :issued_at, :dropoff_location_id, :diaper_drive_participant_id, line_items_attributes: [:id, :item_id, :quantity, :_destroy]).merge(organization: current_organization)
 
   end
 

--- a/app/controllers/dropoff_locations_controller.rb
+++ b/app/controllers/dropoff_locations_controller.rb
@@ -1,33 +1,33 @@
 class DropoffLocationsController < ApplicationController
   def index
-    @dropoff_locations = DropoffLocation.all
+    @dropoff_locations = current_organization.dropoff_locations.all
   end
 
   def create
-    @dropoff_location = DropoffLocation.create(dropoff_location_params)
+    @dropoff_location = current_organization.dropoff_locations.create(dropoff_location_params)
     redirect_to @dropoff_location, notice: "New dropoff location added!"
   end
 
   def new
-    @dropoff_location = DropoffLocation.new
+    @dropoff_location = current_organization.dropoff_locations.new
   end
 
   def edit
-    @dropoff_location = DropoffLocation.find(params[:id])
+    @dropoff_location = current_organization.dropoff_locations.find(params[:id])
   end
 
   def show
-    @dropoff_location = DropoffLocation.find(params[:id])
+    @dropoff_location = current_organization.dropoff_locations.find(params[:id])
   end
 
   def update
-    @dropoff_location = DropoffLocation.find(params[:id])
+    @dropoff_location = current_organization.dropoff_locations.find(params[:id])
     @dropoff_location.update_attributes(dropoff_location_params)
     redirect_to @dropoff_location, notice: "#{@dropoff_location.name} updated!"
   end
 
   def destroy
-    DropoffLocation.find(params[:id]).destroy
+    current_organization.dropoff_locations.find(params[:id]).destroy
     redirect_to dropoff_locations_path
   end
 

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -1,33 +1,33 @@
 class PartnersController < ApplicationController
   def index
-    @partners = Partner.all
+    @partners = current_organization.partners
   end
 
   def create
-    @partner = Partner.create(partner_params)
+    @partner = current_organization.partners.create(partner_params)
     redirect_to @partner, notice: "Partner added!"
   end
 
   def show
-    @partner = Partner.find(params[:id])
+    @partner = current_organization.partners.find(params[:id])
   end
 
   def new
-    @partner = Partner.new
+    @partner = current_organization.partners.new
   end
 
   def edit
-    @partner = Partner.find(params[:id])
+    @partner = current_organization.partners.find(params[:id])
   end
 
   def update
-    @partner = Partner.find(params[:id])
+    @partner = current_organization.partners.find(params[:id])
     @partner.update_attributes(partner_params)
     redirect_to @partner, notice: "#{@partner.name} updated!"
   end
 
   def destroy
-    Partner.find(params[:id]).destroy
+    current_organization.partners.find(params[:id]).destroy
     redirect_to partners_path
   end
 

--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -1,41 +1,41 @@
 class StorageLocationsController < ApplicationController
   def index
-    @items = StorageLocation.items_inventoried
-    @storage_locations = StorageLocation.includes(:inventory_items).filter(filter_params)
+    @items = current_organization.storage_locations.items_inventoried
+    @storage_locations = current_organization.storage_locations.includes(:inventory_items).filter(filter_params)
   end
 
   def create
-    @storage_location = StorageLocation.create(storage_location_params)
+    @storage_location = current_organization.storage_locations.create(storage_location_params)
     redirect_to @storage_location, notice: "New storage location added!"
   end
 
   def new
-    @storage_location = StorageLocation.new
+    @storage_location = current_organization.storage_locations.new
   end
 
   def edit
-    @storage_location = StorageLocation.find(params[:id])
+    @storage_location = current_organization.storage_locations.find(params[:id])
   end
 
   def show
-    @storage_location = StorageLocation.find(params[:id])
+    @storage_location = current_organization.storage_locations.find(params[:id])
   end
 
   # TODO - the intake! method needs to be worked into this controller somehow.
   # TODO - the distribute! method needs to be worked into this controller somehow
   def update
-    @storage_location = StorageLocation.find(params[:id])
+    @storage_location = current_organization.storage_locations.find(params[:id])
     @storage_location.update_attributes(storage_location_params)
     redirect_to @storage_location, notice: "#{@storage_location.name} updated!"
   end
 
   def destroy
-    StorageLocation.find(params[:id]).destroy
+    current_organization.storage_locations.find(params[:id]).destroy
     redirect_to storage_locations_path
   end
 
   def inventory
-    @storage_location = StorageLocation.includes(inventory_items: :item).find(params[:id])
+    @storage_location = current_organization.storage_locations.includes(inventory_items: :item).find(params[:id])
     respond_to :json
   end
 

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -67,6 +67,14 @@ class Donation < ApplicationRecord
     source == SOURCES[:dropoff]
   end
 
+  def source_view
+    from_diaper_drive? ? format_drive_name : source
+  end
+
+  def format_drive_name
+    diaper_drive_participant.name.present? ? "#{diaper_drive_participant.name} (diaper drive)" : source
+  end
+
   def self.daily_quantities_by_source(start, stop)
     joins(:line_items).includes(:line_items).between(start, stop).group(:source).group_by_day("donations.created_at").sum("line_items.quantity")
   end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -49,6 +49,8 @@ class Donation < ApplicationRecord
     :reject_if => proc { |li| li[:item_id].blank? || li[:quantity].blank? }
 
   before_create :combine_duplicates
+  before_destroy :remove_inventory
+
   validates :dropoff_location, presence: { message: "must be specified since you chose '#{SOURCES[:dropoff]}'" }, if: :from_dropoff_location?
   validates :diaper_drive_participant, presence: { message: "must be specified since you chose '#{SOURCES[:diaper_drive]}'" }, if: :from_diaper_drive?
   validates :source, presence: true, inclusion: { in: SOURCES.values, message: "Must be a valid source." }
@@ -100,6 +102,14 @@ class Donation < ApplicationRecord
     end
   end
 
+  def dropoff_view
+    dropoff_location.nil? ? "N/A" : dropoff_location.name 
+  end
+
+  def storage_view
+    storage_location.nil? ? "N/A" : storage_location.name
+  end
+
   def total_quantity
     self.line_items.sum(:quantity)
   end
@@ -123,6 +133,10 @@ class Donation < ApplicationRecord
     line_item = self.line_items.find_by(item_id: i.id)
     line_item.quantity += q
     line_item.save
+  end
+
+  def remove_inventory
+    storage_location.remove!(self)
   end
 
 private

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,7 +13,8 @@
 
 class Item < ApplicationRecord
   belongs_to :organization # If these are universal this isn't necessary
-  validates :name, presence: true, uniqueness: true
+  validates_uniqueness_of :name, :scope => :organization
+  validates_presence_of :name
   validates :organization, presence: true
 
   has_many :line_items

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -38,6 +38,10 @@ class Organization < ApplicationRecord
   has_attached_file :logo, styles: { medium: "763x188>" }, default_url: "/DiaperBase-Logo.png"
   validates_attachment_content_type :logo, content_type: /\Aimage\/.*\z/
 
+  after_create { |org| seed_it!(org) }
+
+  include Seedable
+
   # NOTE: when finding Organizations, use Organization.find_by(short_name: params[:organization_id])
   def to_param
     short_name

--- a/app/models/seedable.rb
+++ b/app/models/seedable.rb
@@ -1,0 +1,64 @@
+module Seedable
+  ITEMS_BY_CATEGORY = {
+    "Diapers - Adult Briefs" => [
+      { name: "Adult Briefs (Large/X-Large)" },
+      { name: "Adult Briefs (Medium/Large)" },
+      { name: "Adult Briefs (Small/Medium)" },
+      { name: "Adult Briefs (XXL)" }
+    ],
+    "Diapers - Childrens" => [
+      { name: "Cloth Diapers (Plastic Cover Pants)" },
+      { name: "Disposable Inserts" },
+      { name: "Kids (Newborn)" },
+      { name: "Kids (Preemie)" },
+      { name: "Kids (Size 1)" },
+      { name: "Kids (Size 2)" },
+      { name: "Kids (Size 3)" },
+      { name: "Kids (Size 4)" },
+      { name: "Kids (Size 5)" },
+      { name: "Kids (Size 6)" },
+      { name: "Kids L/XL (60-125 lbs)" },
+      { name: "Kids Pull-Ups (2T-3T)" },
+      { name: "Kids Pull-Ups (3T-4T)" },
+      { name: "Kids Pull-Ups (4T-5T)" },
+      { name: "Kids S/M (38-65 lbs)" },
+      { name: "Swimmers" }
+    ],
+    "Diapers - Cloth (Adult)" => [
+      { name: "Adult Cloth Diapers (Large/XL/XXL)" },
+      { name: "Adult Cloth Diapers (Small/Medium)" }
+    ],
+    "Diapers - Cloth (Kids)" => [
+      { name: "Cloth Diapers (AIO's/Pocket)" },
+      { name: "Cloth Diapers (Covers)" },
+      { name: "Cloth Diapers (Prefolds & Fitted)" },
+      { name: "Cloth Inserts (For Cloth Diapers)" },
+      { name: "Cloth Swimmers (Kids)" }
+    ],
+    "Incontinence Pads - Adult" => [
+      { name: "Adult Incontinence Pads" },
+      { name: "Underpads (Pack)" }
+    ],
+    "Misc Supplies" => [
+      { name: "Bed Pads (Cloth)" },
+      { name: "Bed Pads (Disposable)" },
+      { name: "Bibs (Adult & Child)" },
+      { name: "Diaper Rash Cream/Powder" },
+    ],
+    "Training Pants" => [
+      { name: "Cloth Potty Training Pants/Underwear" },
+    ],
+    "Wipes - Childrens" => [
+      { name: "Wipes (Baby)" },
+    ]
+  }
+
+  def seed_it!(org)
+    ITEMS_BY_CATEGORY.each do |category, entries|
+      entries.each do |entry|
+        item = org.items.find_or_create_by!(name: entry[:name], organization: self)
+        item.update_attributes(entry.except(:name).merge(category: category))
+      end
+    end
+  end
+end

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -52,6 +52,21 @@ class StorageLocation < ApplicationRecord
     log
   end
 
+  def remove!(donation)
+    log = {}
+    donation.line_items.each do |line_item|
+      inventory_item = InventoryItem.find_by(storage_location: id, item_id: line_item.item_id )
+      if inventory_item.quantity - line_item.quantity <= 0
+        inventory_item.destroy
+      else
+        inventory_item.quantity -= line_item.quantity
+        inventory_item.save
+      end
+      log[line_item.item_id] = "-#{line_item.quantity}"
+    end
+    log
+  end
+
   def distribute!(distribution)
     updated_quantities = {}
     insufficient_items = []

--- a/app/views/barcode_items/_barcode_item_row.html.erb
+++ b/app/views/barcode_items/_barcode_item_row.html.erb
@@ -2,7 +2,7 @@
   <td><%= barcode_item_row.item.name %></td>
   <td><%= barcode_item_row.quantity %></td>
   <td><%= barcode_item_row.value %></td>
-  <td><%= link_to "View", barcode_item_path(barcode_item_row) %>
-      <%= link_to "Edit", edit_barcode_item_path(barcode_item_row) %>
-      <%= link_to "Delete", barcode_item_path(barcode_item_row), method: :delete, confirm: "Are you sure?" %>
+  <td><%= link_to "View", barcode_item_path(barcode_item_row), class: "button" %>
+      <%= link_to "Edit", edit_barcode_item_path(barcode_item_row), class: "button" %>
+      <%= link_to "Delete", barcode_item_path(barcode_item_row), method: :delete, class: "button alert", data: { confirm: "Are you sure?" } %>
 </tr>

--- a/app/views/donations/_donation_row.html.erb
+++ b/app/views/donations/_donation_row.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= donation_row.source %></td>
+  <td><%= donation_row.source_view %></td>
   <td><%= donation_row.dropoff_location.name if donation_row.dropoff_location.present? %></td>
   <td><%= donation_row.storage_location.name %></td>
   <td><%= donation_row.total_items %></td>

--- a/app/views/donations/_donation_row.html.erb
+++ b/app/views/donations/_donation_row.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= donation_row.source_view %></td>
+  <td><%= link_to donation_row.source_view, donation_row %></td>
   <td><%= donation_row.dropoff_location.name if donation_row.dropoff_location.present? %></td>
   <td><%= donation_row.storage_location.name %></td>
   <td><%= donation_row.total_items %></td>

--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -6,8 +6,8 @@
 <p>This donation was started on <%= @donation.created_at.strftime("%B %-d %Y") %>:</p>
 <ul>
   <li>It was collected through: <%= @donation.source %></li>
-  <li>It was dropped off at: <%= @donation.dropoff_location.name %></li>
-  <li>It will be stored at: <%= @donation.storage_location.name %></li>
+  <li>It was dropped off at: <%= @donation.dropoff_view %></li>
+  <li>It will be stored at: <%= @donation.storage_view %></li>
 </ul>
 <%= link_to "Make a correction >", edit_donation_path(@donation) %>
 </fieldset>

--- a/app/views/dropoff_locations/_dropoff_location_row.html.erb
+++ b/app/views/dropoff_locations/_dropoff_location_row.html.erb
@@ -1,8 +1,8 @@
 <tr>
   <td><%= dropoff_location_row.name %></td>
   <td><%= dropoff_location_row.address %></td>
-  <td><%= link_to "View", dropoff_location_row %> 
-      <%= link_to "Edit", edit_dropoff_location_path(dropoff_location_row) %>
-      <%= link_to "Delete", dropoff_location_row, method: :delete, confirm: "Are you sure?" %>
+  <td><%= link_to "View", dropoff_location_row, class: "button" %> 
+      <%= link_to "Edit", edit_dropoff_location_path(dropoff_location_row), class: "button" %>
+      <%= link_to "Delete", dropoff_location_row, method: :delete, class: "button alert", data: { confirm: "Are you sure?" } %>
       </td>
 </tr>

--- a/app/views/dropoff_locations/index.html.erb
+++ b/app/views/dropoff_locations/index.html.erb
@@ -1,5 +1,12 @@
 <% content_for :title, "#{current_organization.name} - Agencies - Dropoff Locations" %>
 
+
+<div class="header-action">
+  <%= link_to "New Dropoff Location", new_dropoff_location_path(organization_id: current_organization), class: "button float-right" %>
+</div>
+
+
+
 <h1>Donation Sites</h1>
 
 <table id="dropoff_locations">

--- a/app/views/partners/_partner_row.html.erb
+++ b/app/views/partners/_partner_row.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td><%= partner_row.name %></td>
   <td><%= link_to partner_row.email, "mailto:#{partner_row.email}" %></td>
-  <td><%= link_to "View", partner_path(partner_row) %>    
-      <%= link_to "Edit", edit_partner_path(partner_row) %> 
-      <%= link_to "Delete", partner_path(partner_row), method: :delete %></td>
+  <td><%= link_to "View", partner_path(partner_row), class: "button" %>    
+      <%= link_to "Edit", edit_partner_path(partner_row), class: "button" %> 
+      <%= link_to "Delete", partner_path(partner_row), method: :delete, class: "button alert", data: { confirm: "Are you sure?" } %></td>
 </tr>

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -1,5 +1,11 @@
 <% content_for :title, "#{current_organization.name} - Agencies - Partners" %>
 
+
+<div class="header-action">
+  <%= link_to "New Partner Agency", new_partner_path(organization_id: current_organization), class: "button float-right" %>
+</div>
+
+
 <h1>Partner Agencies</h1>
 
 <table id="partners">

--- a/app/views/storage_locations/_storage_location_row.html.erb
+++ b/app/views/storage_locations/_storage_location_row.html.erb
@@ -2,8 +2,8 @@
   <td><%= storage_location.name %></td>
   <td><%= storage_location.address %></td>
   <td><%= storage_location.size %></td>
-  <td><%= link_to "View", storage_location %>
-  <%= link_to "Edit", edit_storage_location_path(storage_location) %>
-  <%= link_to "Delete", storage_location, method: :delete, confirm: "Are you sure?" %>
+  <td><%= link_to "View", storage_location, class: "button" %>
+  <%= link_to "Edit", edit_storage_location_path(storage_location), class: "button" %>
+  <%= link_to "Delete", storage_location, method: :delete, class: "button alert", data: { confirm: "Are you sure?" } %>
   </td>
 </tr>

--- a/spec/features/item_spec.rb
+++ b/spec/features/item_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Item management", type: :feature do
+  RSpec.feature "Item management", type: :feature do
   before do
     sign_in(@user)
   end
@@ -23,6 +23,7 @@ RSpec.feature "Item management", type: :feature do
   end
 
   scenario "User can filter the #index by category type" do
+    Item.delete_all
     item = create(:item, category: "same")
     item2 = create(:item, category: "different")
     visit url_prefix + "/items"
@@ -33,6 +34,7 @@ RSpec.feature "Item management", type: :feature do
   end
 
   scenario "Filters presented to user are alphabetized by category" do
+    Item.delete_all
     item = create(:item, category: "same")
     item2 = create(:item, category: "different")
     expected_order = [item2.category, item.category]

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -184,6 +184,14 @@ RSpec.describe Donation, type: :model do
         }.to change{donation.line_items.first.quantity}.by(1)
       end
     end
+
+    describe "remove_inventory" do
+      it "removes inventory from the right storage location when donation deleted" do
+        donation = create(:donation, :with_item)
+        expect(donation.storage_location).to receive(:remove!)
+        donation.remove_inventory
+      end
+    end
   end
 
   describe "SOURCES" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -50,10 +50,11 @@ RSpec.describe Item, type: :model do
         item = create(:item, category: "same")
         create(:item, category: "different")
         result = Item.categories
-        expect(result.length).to eq(2)
+        expect(result.length).to eq(10)
       end
 
       it "returns the list of categories alphabetized" do
+        Item.delete_all
         item1 = create(:item, category: "one")
         item2 = create(:item, category: "two")
         item3 = create(:item, category: "three")
@@ -92,6 +93,7 @@ RSpec.describe Item, type: :model do
 
   context "Alphabetized Scope >" do
     it "retrieves items in alphabetical order" do
+      Item.delete_all
       item_c = create(:item, name: "C")
       item_b = create(:item, name: "B")
       item_a = create(:item, name: "A")

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -96,6 +96,37 @@ RSpec.describe StorageLocation, type: :model do
       end
     end
 
+    describe "remove!" do
+      let(:storage_location) { create(:storage_location) }
+      let(:donation)         { create(:donation, :with_item, item_quantity: 10) }
+
+      before(:each) do
+        storage_location.intake!(donation)
+        storage_location.items.reload
+
+        expect(storage_location.size).to eq(10)
+        expect(storage_location.items.count).to eq(1)
+      end
+
+      it "removes items from a storage location" do
+        storage_location.remove!(donation)
+        storage_location.items.reload
+
+        expect(storage_location.size).to eq(0)
+        expect(storage_location.items.count).to eq(0)
+      end
+
+      it "removes the inventory item from the DB if the item's removal results in a 0 count" do
+        expect(InventoryItem.count).to eq(1)
+
+        storage_location.remove!(donation)
+        storage_location.items.reload
+
+        expect(InventoryItem.count).to eq(0)
+      end
+    end
+
+
     describe "distribute!" do
       it "distrbutes items from storage location" do
         storage_location = create :storage_location, :with_items, item_quantity: 300


### PR DESCRIPTION
This PR does the following:
* Adds in scoping for diaper drives, dropoff locations, storage locations, and partners.
* Changes all the actions on index (show, edit, delete) from hyperlinks to buttons. Also added confirmation messages on destroy actions.
* Added buttons on dropoff locations and partners to be able to create.
* Added crud functionality to donations. Also added a few view fixes.
* Updated the item model to scope the uniqueness of the item name to the organization. This will allow multiple organizations to generate their own items in case they use different names for them.
* Updated the organization with an after_create action that pulls in a seed_it! method from a new seedable module(we can change this) that seeds the newly created organization with items.

Closes #122 
Closes #134 
Closes #128 
Closes #136 
