### PR TITLE
Added all the needed files to create an intake location.

### DIFF
--- a/app/assets/javascripts/components/scale.jsx
+++ b/app/assets/javascripts/components/scale.jsx
@@ -103,7 +103,6 @@ class Scale extends React.Component {
   getDiaper(event) {
     const count =  Math.trunc(this.state.weight / event.target.value)
     const kind = event.target.attributes.getNamedItem('label').value
-    console.log(kind)
     this.setState({diaperCount: count})
     this.setState({diaperKind: kind})
   }
@@ -122,7 +121,11 @@ class Scale extends React.Component {
         number_of_diapers: diaperCount,
         diaper_type: diaperKind,
       })
-    })
+    }).then(response => {
+      if (response.status == 200) {
+        alert("Diapers Added to Inventory!");
+      }
+    });
   }
 
   bindDevice(device) {

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -45,12 +45,14 @@ class DonationsController < ApplicationController
   def scale_intake
     @donation = Donation.create( organization: current_organization,
                                  source: "Misc. Donation",
-                                 storage_location_id: 1,
+                                 storage_location_id: current_organization.intake_location,
                                  issued_at: Date.today,
                                  line_items_attributes:{"0"=>{"item_id"=>params["diaper_type"], 
                                                               "quantity"=>params["number_of_diapers"], 
                                                               "_destroy"=>"false"}}
       )
+    binding.pry
+    render status: 200, json: @donation.to_json
   end
 
   def create

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -25,6 +25,6 @@ class OrganizationsController < ApplicationController
   private
 
   def organization_params
-    params.require(:organization).permit(:name, :short_name, :address, :email, :url, :logo)
+    params.require(:organization).permit(:name, :short_name, :address, :email, :url, :logo, :intake_location)
   end
 end

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -1,6 +1,6 @@
 <% content_for :title, "#{current_organization.name} - Edit" %>
 
-<h1>Edit <%= current_organization.name %></h1>
+<h1 class="medium-offset-3 medium-6"">Edit <%= current_organization.name %></h1>
 
 <%= simple_form_for current_organization, url: organization_path do |f| %>
   <%= f.error_notification %>
@@ -11,8 +11,10 @@
     <%= f.input :url, as: :url, placeholder: "http://www.example.com" %>
     <%= f.input :email %>
     <%= f.input :address %>
+    <%= f.input :intake_location, :collection => StorageLocation.all, :label_method => :name,:value_method => :id,:label => "Intake Location" ,:include_blank => true %>
     <%= f.input :logo %>
-    <p class="help-text">Logo should be a 4:1 ratio of width / height (default image is 763 x 188 pixels)
+
+    <p class="help-text medium-offset-3 medium-6">Logo should be a 4:1 ratio of width / height (default image is 763 x 188 pixels)</p>
     <% if current_organization.logo.present? %>
       <div class="reveal" id="exampleModal1" data-reveal>
         <%= image_tag current_organization.logo.url %>
@@ -20,11 +22,11 @@
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
-      <p><a data-open="exampleModal1">Preview current logo</a></p>
+      <p><a data-open="exampleModal1" class="medium-offset-3 medium-6">Preview current logo</a></p>
     <% end %>
   </div>
 
-  <div class="form-actions">
+  <div class="form-actions medium-offset-3 medium-6"">
     <%= f.button :submit, "Update" %>
   </div>
 <% end %>

--- a/db/migrate/20170830203628_add_intake_location_to_organizations.rb
+++ b/db/migrate/20170830203628_add_intake_location_to_organizations.rb
@@ -1,0 +1,5 @@
+class AddIntakeLocationToOrganizations < ActiveRecord::Migration[5.1]
+  def change
+    add_column :organizations, :intake_location, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170622195729) do
+ActiveRecord::Schema.define(version: 20170830203628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -123,6 +123,7 @@ ActiveRecord::Schema.define(version: 20170622195729) do
     t.string "logo_content_type"
     t.integer "logo_file_size"
     t.datetime "logo_updated_at"
+    t.integer "intake_location"
     t.index ["short_name"], name: "index_organizations_on_short_name"
   end
 
@@ -181,7 +182,6 @@ ActiveRecord::Schema.define(version: 20170622195729) do
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
-    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 


### PR DESCRIPTION
This closes #139 

This PR contains a migration to add `intake_location` to the organization model.
It cleans up the edit page for organizations and adds in a `collection_select` to allow the user to select their default intake organization.
Updates the scale actions to use the default organization.