### PR TITLE
Csv Import

### DIFF
--- a/app/controllers/diaper_drive_participants_controller.rb
+++ b/app/controllers/diaper_drive_participants_controller.rb
@@ -32,6 +32,18 @@ class DiaperDriveParticipantsController < ApplicationController
     redirect_to @diaper_drive_participant, notice: "#{@diaper_drive_participant.name} updated!"
   end
 
+  def import_csv
+    if params[:file].nil?
+      redirect_back(fallback_location: diaper_drive_participants_path(organization_id: current_organization))
+      flash[:alert] = "No file was attached!"
+    else
+      filepath = params[:file].read
+      DiaperDriveParticipant.import_csv(filepath, current_organization.id)
+      flash[:notice] = "Diaper drive participants were imported successfully!"
+      redirect_back(fallback_location: diaper_drive_participants_path(organization_id: current_organization))
+    end
+  end
+
 private
   def diaper_drive_participant_params
     params.require(:diaper_drive_participant).permit(:name, :phone, :email)

--- a/app/controllers/dropoff_locations_controller.rb
+++ b/app/controllers/dropoff_locations_controller.rb
@@ -26,6 +26,18 @@ class DropoffLocationsController < ApplicationController
     redirect_to @dropoff_location, notice: "#{@dropoff_location.name} updated!"
   end
 
+  def import_csv
+    if params[:file].nil?
+      redirect_back(fallback_location: dropoff_locations_path(organization_id: current_organization))
+      flash[:alert] = "No file was attached!"
+    else
+      filepath = params[:file].read
+      DropoffLocation.import_csv(filepath, current_organization.id)
+      flash[:notice] = "Dropoff locations were imported successfully!"
+      redirect_back(fallback_location: dropoff_locations_path(organization_id: current_organization))
+    end
+  end
+
   def destroy
     current_organization.dropoff_locations.find(params[:id]).destroy
     redirect_to dropoff_locations_path

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -26,6 +26,18 @@ class PartnersController < ApplicationController
     redirect_to @partner, notice: "#{@partner.name} updated!"
   end
 
+  def import_csv
+    if params[:file].nil?
+      redirect_back(fallback_location: partners_path(organization_id: current_organization))
+      flash[:alert] = "No file was attached!"
+    else
+      filepath = params[:file].read
+      Partner.import_csv(filepath, current_organization.id)
+      flash[:notice] = "Partners were imported successfully!"
+      redirect_back(fallback_location: partners_path(organization_id: current_organization))
+    end
+  end
+
   def destroy
     current_organization.partners.find(params[:id]).destroy
     redirect_to partners_path

--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -21,6 +21,18 @@ class StorageLocationsController < ApplicationController
     @storage_location = current_organization.storage_locations.find(params[:id])
   end
 
+  def import_csv
+    if params[:file].nil?
+      redirect_back(fallback_location: admin_people_url)
+      flash[:alert] = "No file was attached!"
+    else
+      filepath = params[:file].read
+      StorageLocation.import_csv(filepath, current_organization.id)
+      flash[:notice] = "Storage locations were imported successfully!"
+      redirect_back(fallback_location: storage_locations_path(organization_id: current_organization))
+    end
+  end
+
   # TODO - the intake! method needs to be worked into this controller somehow.
   # TODO - the distribute! method needs to be worked into this controller somehow
   def update

--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -23,7 +23,7 @@ class StorageLocationsController < ApplicationController
 
   def import_csv
     if params[:file].nil?
-      redirect_back(fallback_location: admin_people_url)
+      redirect_back(fallback_location: storage_locations_path(organization_id: current_organization))
       flash[:alert] = "No file was attached!"
     else
       filepath = params[:file].read

--- a/app/models/diaper_drive_participant.rb
+++ b/app/models/diaper_drive_participant.rb
@@ -14,6 +14,8 @@
 #
 
 class DiaperDriveParticipant < ApplicationRecord
+  require 'csv'
+
   belongs_to :organization  # Automatically validates presence as of Rails 5
   has_many :donations, inverse_of: :diaper_drive_participant
 
@@ -25,4 +27,12 @@ class DiaperDriveParticipant < ApplicationRecord
   def volume
     donations.map { |d| d.line_items.total }.reduce(:+)
   end
+  
+  def self.import_csv(filename,organization)
+    CSV.parse(filename, :headers => true) do |row|
+      loc = DiaperDriveParticipant.new(row.to_hash)
+      loc.organization_id = organization
+      loc.save!
+    end
+  end  
 end

--- a/app/models/dropoff_location.rb
+++ b/app/models/dropoff_location.rb
@@ -11,10 +11,19 @@
 #
 
 class DropoffLocation < ApplicationRecord
+  require 'csv'
+
 	belongs_to :organization
 	
 	validates :name, :address, :organization, presence: true
    
 	has_many :donations
-
+	
+  def self.import_csv(filename,organization)
+    CSV.parse(filename, :headers => true) do |row|
+      loc = DropoffLocation.new(row.to_hash)
+      loc.organization_id = organization
+      loc.save!
+    end
+  end
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -11,10 +11,20 @@
 #
 
 class Partner < ApplicationRecord
+  require 'csv'
+
   belongs_to :organization
   has_many :distributions
 
   validates :organization, presence: true
   validates :name, :email, presence: true, uniqueness: true
   validates_format_of :email, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, :on => :create
+
+  def self.import_csv(filename,organization)
+    CSV.parse(filename, :headers => true) do |row|
+      loc = Partner.new(row.to_hash)
+      loc.organization_id = organization
+      loc.save!
+    end
+  end
 end

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -11,6 +11,8 @@
 #
 
 class StorageLocation < ApplicationRecord
+  require 'csv'
+
   belongs_to :organization
   has_many :inventory_items, -> { includes(:item).order("items.name") }
   has_many :donations
@@ -18,8 +20,6 @@ class StorageLocation < ApplicationRecord
   has_many :items, through: :inventory_items
 
   validates :name, :address, :organization, presence: true
-
-  require 'csv'    
 
   include Filterable
   scope :containing, ->(item_id) { joins(:inventory_items).where('inventory_items.item_id = ?', item_id) }
@@ -103,7 +103,6 @@ class StorageLocation < ApplicationRecord
       loc.save!
     end
   end
-
 
   # TODO - this action is happening in the Transfer model/controller - does this method belong here?
   def move_inventory!(transfer)

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -19,6 +19,8 @@ class StorageLocation < ApplicationRecord
 
   validates :name, :address, :organization, presence: true
 
+  require 'csv'    
+
   include Filterable
   scope :containing, ->(item_id) { joins(:inventory_items).where('inventory_items.item_id = ?', item_id) }
   scope :alphabetized, -> { order(:name) }
@@ -93,6 +95,15 @@ class StorageLocation < ApplicationRecord
 
     update_inventory_inventory_items(updated_quantities)
   end
+
+  def self.import_csv(filename,organization)
+    CSV.parse(filename, :headers => true) do |row|
+      loc = StorageLocation.new(row.to_hash)
+      loc.organization_id = organization
+      loc.save!
+    end
+  end
+
 
   # TODO - this action is happening in the Transfer model/controller - does this method belong here?
   def move_inventory!(transfer)

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= simple_form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.error_notification %>
+  <%= f.full_error :confirmation_token %>
+
+  <div class="form-inputs">
+    <%= f.input :email, required: true, autofocus: true %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -2,6 +2,16 @@
 
 <p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
 
+The first things you'll want to do after you sign in and set a password are:
+
+1) Import the storage locations for your diaper bank. (inventory->storage locations)
+2) Import the partners agencies of your diaper bank. (community->partner agencies)
+3) Import the dropoff locations of your diaper bank. (community->donation dropoff locations)
+4) Import the diaper drive participants of your diaper bank. (community->diaper drive participants)
+
+On each of the pages there will be a button that will give insructions on how to do this.
+
+
 <p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, :invitation_token => @token) %></p>
 
 <% if @resource.invitation_due_at %>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= simple_form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= f.error_notification %>
+  <%= f.full_error :unlock_token %>
+
+  <div class="form-inputs">
+    <%= f.input :email, required: true, autofocus: true %>
+  </div>
+
+  <div class="form-actions">
+    <%= f.button :submit, "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "devise/shared/links" %>

--- a/app/views/diaper_drive_participants/index.html.erb
+++ b/app/views/diaper_drive_participants/index.html.erb
@@ -5,6 +5,31 @@
 </div>
 
 
+<% if @diaper_drive_participants.empty? %>
+
+<div class="reveal" id="addStorageLocationModal" data-reveal>
+  <h2 id="modalTitle">Import Diaper Drive Participants</h2>
+  <p class="lead">Instructions:</p>
+    <ol>
+      <li><%= link_to "Download example csv", "/diaper_drive_participants.csv", :format => :csv, :class => "btn btn-info" %>.</li>
+      <li>Open the csv file with excel or your favourite spreadsheet program.</li>
+      <li>Delete the sample data and enter your storage location names and addresses in the appropriate columns.</li>
+      <li>Save the file as a csv file.</li>
+      <li>Click the choose file button and navigate to the saved file and select it.</li>
+      <li>Then click the Import CSV button to import your storage locations.</li>
+    </ol>
+    <p class="help-text">Note: You're only able to run the import one time to prevent accidental imports or writing over existing locations!</p>
+
+    <%= form_tag import_csv_diaper_drive_participants_path, multipart: true do %>
+        <%= file_field_tag :file, :accept => 'text/csv' %>
+        <%= submit_tag "Import CSV", :class => "btn btn-white" %>
+    <% end %>
+</div>
+<br/>
+<p><a class="button success" data-open="addStorageLocationModal">Import Diaper Drive Participants</a></p>
+<% end %>
+
+
 <h1>Diaper Drive Participants</h1>
 
 <table id="diaper_drive_participants">

--- a/app/views/dropoff_locations/index.html.erb
+++ b/app/views/dropoff_locations/index.html.erb
@@ -5,6 +5,29 @@
   <%= link_to "New Donation Dropoff Location", new_dropoff_location_path(organization_id: current_organization), class: "button float-right" %>
 </div>
 
+<% if @dropoff_locations.empty? %>
+
+<div class="reveal" id="addStorageLocationModal" data-reveal>
+  <h2 id="modalTitle">Import Dropoff Locations</h2>
+  <p class="lead">Instructions:</p>
+    <ol>
+      <li><%= link_to "Download example csv", "/dropoff_locations.csv", :format => :csv, :class => "btn btn-info" %>.</li>
+      <li>Open the csv file with excel or your favourite spreadsheet program.</li>
+      <li>Delete the sample data and enter your storage location names and addresses in the appropriate columns.</li>
+      <li>Save the file as a csv file.</li>
+      <li>Click the choose file button and navigate to the saved file and select it.</li>
+      <li>Then click the Import CSV button to import your storage locations.</li>
+    </ol>
+    <p class="help-text">Note: You're only able to run the import one time to prevent accidental imports or writing over existing locations!</p>
+
+    <%= form_tag import_csv_dropoff_locations_path, multipart: true do %>
+        <%= file_field_tag :file, :accept => 'text/csv' %>
+        <%= submit_tag "Import CSV", :class => "btn btn-white" %>
+    <% end %>
+</div>
+<br/>
+<p><a class="button success" data-open="addStorageLocationModal">Import Dropoff Locations</a></p>
+<% end %>
 
 
 <h1>Donation Dropoff Locations</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,8 +20,8 @@
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
     <meta name="theme-color" content="#ffffff">
-    <title><%= content_for?(:title) ? yield(:title) : default_title_content %></title>
 
+    <title><%= content_for?(:title) ? yield(:title) : default_title_content %></title>
     <%= stylesheet_link_tag    "application" %>
     <%= javascript_include_tag "application", 'data-turbolinks-track' => true %>
 
@@ -47,3 +47,4 @@
 
   </body>
 </html>
+

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -6,6 +6,30 @@
 </div>
 
 
+<% if @partners.empty? %>
+
+<div class="reveal" id="addStorageLocationModal" data-reveal>
+  <h2 id="modalTitle">Import Partners</h2>
+  <p class="lead">Instructions:</p>
+    <ol>
+      <li><%= link_to "Download example csv", "/partners.csv", :format => :csv, :class => "btn btn-info" %>.</li>
+      <li>Open the csv file with excel or your favourite spreadsheet program.</li>
+      <li>Delete the sample data and enter your storage location names and addresses in the appropriate columns.</li>
+      <li>Save the file as a csv file.</li>
+      <li>Click the choose file button and navigate to the saved file and select it.</li>
+      <li>Then click the Import CSV button to import your storage locations.</li>
+    </ol>
+    <p class="help-text">Note: You're only able to run the import one time to prevent accidental imports or writing over existing locations!</p>
+
+    <%= form_tag import_csv_partners_path, multipart: true do %>
+        <%= file_field_tag :file, :accept => 'text/csv' %>
+        <%= submit_tag "Import CSV", :class => "btn btn-white" %>
+    <% end %>
+</div>
+<br/>
+<p><a class="button success" data-open="addStorageLocationModal">Import Partners</a></p>
+<% end %>
+
 <h1>Partner Agencies</h1>
 
 <table id="partners">

--- a/app/views/storage_locations/index.html.erb
+++ b/app/views/storage_locations/index.html.erb
@@ -4,6 +4,30 @@
   <%= link_to "New Storage Location", new_storage_location_path, class: "button float-right" %>
 </div>
 
+<% if @storage_locations.empty? %>
+
+<div class="reveal" id="addStorageLocationModal" data-reveal>
+  <h2 id="modalTitle">Import Storage Locations</h2>
+  <p class="lead">Instructions:</p>
+    <ol>
+      <li><%= link_to "Download example csv", "/storage_locations.csv", :format => :csv, :class => "btn btn-info" %>.</li>
+      <li>Open the csv file with excel or your favourite spreadsheet program.</li>
+      <li>Delete the sample data and enter your storage location names and addresses in the appropriate columns.</li>
+      <li>Save the file as a csv file.</li>
+      <li>Click the choose file button and navigate to the saved file and select it.</li>
+      <li>Then click the Import CSV button to import your storage locations.</li>
+    </ol>
+    <p class="help-text">Note: You're only able to run the import one time to prevent accidental imports or writing over existing locations!</p>
+
+    <%= form_tag import_csv_storage_locations_path, multipart: true do %>
+        <%= file_field_tag :file, :accept => 'text/csv' %>
+        <%= submit_tag "Import CSV", :class => "btn btn-white" %>
+    <% end %>
+</div>
+<br/>
+<p><a class="button success" data-open="addStorageLocationModal">Import Storage Locations</a></p>
+<% end %>
+
 <h1>Storage Locations</h1>
 
 <table id="storage_locations">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,10 +35,23 @@ Rails.application.routes.draw do
     resources :barcode_items do
       get :find, on: :collection
     end
-    resources :dropoff_locations
-    resources :diaper_drive_participants, except: [:destroy]
+    resources :dropoff_locations do
+      collection do
+        post :import_csv
+      end
+    end
+    resources :diaper_drive_participants, except: [:destroy] do
+      collection do
+        post :import_csv
+      end
+    end
     resources :items
-    resources :partners
+    resources :partners do
+      collection do
+        post :import_csv
+      end
+    end
+
 
     resources :donations do
       collection do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,9 @@ Rails.application.routes.draw do
     resources :adjustments
     resources :transfers, only: [:index, :create, :new, :show]
     resources :storage_locations do
+      collection do
+        post :import_csv
+      end
       member do
         get :inventory
       end

--- a/public/diaper_drive_participants.csv
+++ b/public/diaper_drive_participants.csv
@@ -1,0 +1,4 @@
+name,phone,email
+Diaper Drive Participant 1,123-456-7890,email1@example.com
+Diaper Drive Participant 2,231-456-7890,email2@example.com
+Diaper Drive Participant 3,321-456-7890,email3@example.com

--- a/public/dropoff_locations.csv
+++ b/public/dropoff_locations.csv
@@ -1,0 +1,4 @@
+name,address
+Dropoff Location 1,123 Dropoff Location Way
+Dropoff Location 2,456 Dropoff Location Way
+Dropoff Location 3,789 Dropoff Location Way

--- a/public/partners.csv
+++ b/public/partners.csv
@@ -1,0 +1,4 @@
+name,email
+Partner 1,partner1@example.com
+Partner 2,partner2@example.com
+Partner 3,partner3@example.com

--- a/public/storage_locations.csv
+++ b/public/storage_locations.csv
@@ -1,0 +1,4 @@
+name,address
+Example Location 1,123 Example Address Street
+Example Location 2,456 Example Road
+Example Location 3,789 Example Way

--- a/spec/fixtures/diaper_drive_participants.csv
+++ b/spec/fixtures/diaper_drive_participants.csv
@@ -1,0 +1,4 @@
+name,phone,email
+Diaper Drive Participant 1,123-456-7890,email1@example.com
+Diaper Drive Participant 2,231-456-7890,email2@example.com
+Diaper Drive Participant 3,321-456-7890,email3@example.com

--- a/spec/fixtures/dropoff_locations.csv
+++ b/spec/fixtures/dropoff_locations.csv
@@ -1,0 +1,4 @@
+name,address
+Dropoff Location 1,123 Dropoff Location Way
+Dropoff Location 2,456 Dropoff Location Way
+Dropoff Location 3,789 Dropoff Location Way

--- a/spec/fixtures/partners.csv
+++ b/spec/fixtures/partners.csv
@@ -1,0 +1,4 @@
+name,email
+Partner 1,partner1@example.com
+Partner 2,partner2@example.com
+Partner 3,partner3@example.com

--- a/spec/fixtures/storage_locations.csv
+++ b/spec/fixtures/storage_locations.csv
@@ -1,0 +1,4 @@
+name,address
+Storage Location 1,123 Location Way
+Storage Location 2,456 Location Way
+Storage Location 3,789 Location Way

--- a/spec/models/diaper_drive_participant_spec.rb
+++ b/spec/models/diaper_drive_participant_spec.rb
@@ -41,4 +41,12 @@ RSpec.describe DiaperDriveParticipant, type: :model do
       end
     end
   end
+  describe "import_csv" do
+    it "imports storage locations from a csv file" do
+      organization = create(:organization)
+      import_file_path = Rails.root.join("spec", "fixtures", "diaper_drive_participants.csv").read
+      DiaperDriveParticipant.import_csv(import_file_path, organization.id)
+      expect(DiaperDriveParticipant.count).to eq 3
+    end
+  end     
 end

--- a/spec/models/dropoff_location_spec.rb
+++ b/spec/models/dropoff_location_spec.rb
@@ -24,5 +24,13 @@ RSpec.describe DropoffLocation, type: :model do
 		  expect(build(:dropoff_location, address: nil)).not_to be_valid
 		end
 	end
+  describe "import_csv" do
+    it "imports storage locations from a csv file" do
+      organization = create(:organization)
+      import_file_path = Rails.root.join("spec", "fixtures", "dropoff_locations.csv").read
+      DropoffLocation.import_csv(import_file_path, organization.id)
+      expect(DropoffLocation.count).to eq 3
+    end
+  end 	
 end
 

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -27,4 +27,12 @@ RSpec.describe Partner, type: :model do
       expect(build(:partner, email: "boooooooooo")).not_to be_valid
     end
   end
+  describe "import_csv" do
+    it "imports storage locations from a csv file" do
+      organization = create(:organization)
+      import_file_path = Rails.root.join("spec", "fixtures", "partners.csv").read
+      Partner.import_csv(import_file_path, organization.id)
+      expect(Partner.count).to eq 3
+    end
+  end  
 end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe StorageLocation, type: :model do
     describe "import_csv" do
       it "imports storage locations from a csv file" do
         organization = create(:organization)
-        import_file_path = Rails.root.join("spec", "fixtures", "storage_locations.csv")
+        import_file_path = Rails.root.join("spec", "fixtures", "storage_locations.csv").read
         StorageLocation.import_csv(import_file_path, organization.id)
         expect(StorageLocation.count).to eq 3
       end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -153,6 +153,15 @@ RSpec.describe StorageLocation, type: :model do
       end
     end
 
+    describe "import_csv" do
+      it "imports storage locations from a csv file" do
+        organization = create(:organization)
+        import_file_path = Rails.root.join("spec", "fixtures", "storage_locations.csv")
+        StorageLocation.import_csv(import_file_path, organization.id)
+        expect(StorageLocation.count).to eq 3
+      end
+    end
+
     describe "move_inventory!" do
       pending "removes inventory from a storage location and adds them to another storage location"
 


### PR DESCRIPTION
This closes #143 closes #146 and closes #155 

This PR adds in the ability to import in Storage Locations, Partner Agencies, Dropoff Locations, and Diaper Drive Participants through the uploading of spreadsheets. It only allows the uploading if there are none present.

With a partner agency present import button doesn't show up:
![](https://i.imgur.com/Y9388iz.png)

With no partner agencies the import button is visible:
![](https://i.imgur.com/CdTfXJA.png)

Clicking that button opens a modal with import instructions:
![](https://i.imgur.com/fnyA6U7.png)

Results using dummy data:
![](https://i.imgur.com/FuzXESQ.png)

Storage locations, Dropoffs, and Diaper Drives work in an identical way.