### PR TITLE
Fix ruby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 This project is taking what we built for the [Portland Diaper Bank in 2016](https://github.com/rubyforgood/pdx_diaper) and turning it into a multitenant application, something that all diaper banks can use. We will be re-using models, code and other documentation where applicable as well as implementing new features and functionality requested by the stakeholder. We're super excited to have Rachel Alston, the director of the Portland Diaper Bank, attending our event in 2017 to provide guidance and give us the best chance of success!
 
 ## Ruby Version
-This app uses Ruby version 2.4.1, indicated in `/.ruby-version`, which will be auto-selected if you use a Ruby versioning manager like `rvm` or `rbenv`.
+This app uses Ruby version 2.4.2, indicated in `/.ruby-version`, which will be auto-selected if you use a Ruby versioning manager like `rvm` or `rbenv`.
 
 ## Database Configuration
 This app uses PostgreSQL for all environments. You'll also need to create the `dev` and `test` databases, the app is expecting them to be named `diaper_development` and `diaper_test`, respectively. This should all be handled with `rails db:setup`.


### PR DESCRIPTION
***Why is this change necessary?***
The README file says that this app uses Ruby version 2.4.1 but the `/.ruby-version` file indicates 2.4.2

***How does this accomplish the change?***
Updated the README.md file