### PR TITLE
162 universal barcodes

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -24,7 +24,7 @@ class Organization < ApplicationRecord
   validates :email, format: /[^@]+@[^@]+/, allow_blank: true
 
   has_many :adjustments
-  has_many :barcode_items
+  has_many :barcode_items, ->(organization) { unscope(where: :organization_id).where(organization_id: [nil,organization.id]) }
   has_many :distributions
   has_many :donations
   has_many :dropoff_locations
@@ -71,7 +71,7 @@ class Organization < ApplicationRecord
         pu_3t_4t:   items.find_by(name: "Kids Pull-Ups (3T-4T)").id,
         pu_4t_5t:   items.find_by(name: "Kids Pull-Ups (4T-5T)").id,
         k_preemie:  items.find_by(name: "Kids (Preemie)").id,
-        k_newborm:  items.find_by(name: "Kids (Newborn)").id,        
+        k_newborm:  items.find_by(name: "Kids (Newborn)").id,
         k_size1:    items.find_by(name: "Kids (Size 1)").id,
         k_size2:    items.find_by(name: "Kids (Size 2)").id,
         k_size3:    items.find_by(name: "Kids (Size 3)").id,

--- a/spec/controllers/barcode_items_controller_spec.rb
+++ b/spec/controllers/barcode_items_controller_spec.rb
@@ -37,15 +37,23 @@ RSpec.describe BarcodeItemsController, type: :controller do
     end
 
     describe "GET #find" do
+      let!(:global_barcode) { create(:barcode_item) }
+      let!(:organization_barcode) { create(:barcode_item, :for_organization, organization: @organization) }
+      let!(:other_barcode) { create(:barcode_item, :for_organization, organization: create(:organization)) }
       context "via ajax" do
-        subject { get :find, params: default_params.merge({ barcode_item: { value: create(:barcode_item).value }, format: :json}) }
-        it "returns http success" do
+        subject { get :find, params: default_params.merge({ barcode_item: { value: organization_barcode.value }, format: :json}) }
+        it "can find a barcode that is scoped to just this organization" do
           expect(subject).to be_successful
+        end
+
+        it "can find a barcode that's universally available" do
+          get :find, params: default_params.merge({ barcode_item: { value: global_barcode.value }, format: :json})
+          expect(response).to be_successful
         end
 
         context "when it's missing" do
           it "returns a 404" do
-            get :find, params: default_params.merge({ barcode_item: { value: 9999999 }, format: :json })
+            get :find, params: default_params.merge({ barcode_item: { value: other_barcode.value }, format: :json })
             expect(response.status).to eq(404)
           end
         end

--- a/spec/controllers/barcode_items_controller_spec.rb
+++ b/spec/controllers/barcode_items_controller_spec.rb
@@ -66,10 +66,11 @@ RSpec.describe BarcodeItemsController, type: :controller do
     end
   end
 
-  context "While not signed in" do
-    let(:object) { create(:barcode_item) }
-
-    include_examples "requiring authentication"
-  end
+  # For the time being, users cannot access these routes, but this may change in
+  # the near future.
+  #context "While not signed in" do
+  #  let(:object) { create(:barcode_item) }
+  #  include_examples "requiring authentication"
+  #end
 
 end

--- a/spec/factories/barcode_items.rb
+++ b/spec/factories/barcode_items.rb
@@ -14,9 +14,13 @@
 FactoryGirl.define do
 
   factory :barcode_item do
-    organization { Organization.try(:first) || create(:organization) }
+    organization nil
     sequence(:value) { |n| "#{n}" * 12 } # 037000863427
     item
     quantity 50
+
+    trait :for_organization do
+      organization { Organization.try(:first) || create(:organization) }
+    end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -18,6 +18,18 @@
 #
 
 RSpec.describe Organization, type: :model do
+  let(:organization) { create(:organization) }
+  context "Associations >" do
+    describe "barcode_items" do
+      it "returns both this organizations barcodes as well as global ones" do
+        create(:barcode_item, :for_organization, organization: organization)
+        expect(organization.barcode_items.count).to eq(1)
+        create(:barcode_item, organization_id: nil) # global
+        expect(organization.barcode_items.count).to eq(2)
+      end
+    end
+  end
+
   describe "#short_name" do
     it "can only contain valid characters" do
       expect(build(:organization, short_name: 'asdf')).to be_valid


### PR DESCRIPTION
This is item 2 in the #162 -- it adjusts the association for `Organization` so that the `barcode_items` available so that it transparently sees both global and org-scoped barcode items.

I even wrote a post about the process!

http://amhill.net/2017/10/26/modifying-a-has_many-association-to-include-nils/