### PR TITLE
238 makes adjustments bidirectional

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,8 +26,10 @@
 
 
 window.setTimeout(function() {
-    $(".alert").fadeTo(1000, 0).slideUp(1000, function(){
-        $(this).remove(); 
+    // When the user is given an error message, we should not auto-hide it so that
+    // they can fully read it and potentially copy/paste it into an issue.
+    $(".alert").not(".alert-danger").fadeTo(1000, 0).slideUp(1000, function(){
+        $(this).remove();
     });
 }, 2500);
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -46,3 +46,10 @@ img#logo {
 .nav li.active {
   background-color: #ecf0f5;
 }
+
+tr.negative {
+  background-color: #FDD;
+}
+tr.positive {
+  background-color: #DFD;
+}

--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -33,7 +33,7 @@ class AdjustmentsController < ApplicationController
       @adjustment.storage_location.adjust!(@adjustment)
 
       if @adjustment.save
-        redirect_to adjustments_path, notice: 'Adjustment was successfully created.'
+        redirect_to adjustment_path(@adjustment), notice: 'Adjustment was successfully created.'
       else
         flash[:error] = @adjustment.errors.collect { |model,message| "#{model}: " + message }.join("<br />".html_safe)
         render :new

--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -26,6 +26,8 @@ class AdjustmentsController < ApplicationController
   # POST /adjustments
   def create
     @adjustment = current_organization.adjustments.new(adjustment_params)
+    @storage_locations = current_organization.storage_locations
+    @items = current_organization.items.alphabetized
 
     if @adjustment.valid?
       @adjustment.storage_location.adjust!(@adjustment)
@@ -33,13 +35,15 @@ class AdjustmentsController < ApplicationController
       if @adjustment.save
         redirect_to adjustments_path, notice: 'Adjustment was successfully created.'
       else
+        flash[:error] = @adjustment.errors.collect { |model,message| "#{model}: " + message }.join("<br />".html_safe)
         render :new
       end
     else
+      flash[:error] = @adjustment.errors.collect { |model,message| "#{model}: " + message }.join("<br />".html_safe)
       render :new
     end
   rescue Errors::InsufficientAllotment => ex
-    flash[:alert] = ex.message
+    flash[:error] = ex.message
     render :new
   end
 

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -11,7 +11,7 @@ class AdminsController < ApplicationController
     if @organization.update_attributes(organization_params)
       redirect_to admins_path, notice: 'Updated organization!'
     else
-      flash[:alert] = 'Failed to update this organization.'
+      flash[:error] = 'Failed to update this organization.'
       render :edit
     end
   end
@@ -37,7 +37,7 @@ class AdminsController < ApplicationController
     if @organization.save
       redirect_to admins_path, notice: "Organization added!"
     else
-      flash[:alert] = "Failed to create Organization."
+      flash[:error] = "Failed to create Organization."
       render :new
     end
   end
@@ -51,7 +51,7 @@ class AdminsController < ApplicationController
     if @organization.destroy
       redirect_to admins_path, notice: "Organization deleted!"
     else
-      redirect_to admins_path, alert: "Failed to delete Organization."  
+      redirect_to admins_path, alert: "Failed to delete Organization."
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
 
   def verboten!
     respond_to do |format|
-      format.html { redirect_to dashboard_path, alert: "Access Denied." }
+      format.html { redirect_to dashboard_path, flash: { error: "Access Denied." } }
       format.json { render body: nil, status: 403 }
     end
   end

--- a/app/controllers/barcode_items_controller.rb
+++ b/app/controllers/barcode_items_controller.rb
@@ -19,7 +19,7 @@ class BarcodeItemsController < ApplicationController
         format.html { redirect_to barcode_items_path, notice: msg }
       end
     else
-      flash[:alert] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again?"
       render action: :new
     end
   end
@@ -50,7 +50,7 @@ class BarcodeItemsController < ApplicationController
     if @barcode_item.update_attributes(barcode_item_params)
     redirect_to barcode_items_path, notice: "Barcode updated!"
     else
-      flash[:alert] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end

--- a/app/controllers/diaper_drive_participants_controller.rb
+++ b/app/controllers/diaper_drive_participants_controller.rb
@@ -8,7 +8,7 @@ class DiaperDriveParticipantsController < ApplicationController
     if (@diaper_drive_participant.save)
       redirect_to diaper_drive_participants_path, notice: "New diaper drive participant added!"
     else
-      flash[:alert] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again?"
       render action: :new
     end
 
@@ -31,7 +31,7 @@ class DiaperDriveParticipantsController < ApplicationController
     if @diaper_drive_participant.update_attributes(diaper_drive_participant_params)
     redirect_to diaper_drive_participants_path, notice: "#{@diaper_drive_participant.name} updated!"
     else
-      flash[:alert] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end
@@ -39,7 +39,7 @@ class DiaperDriveParticipantsController < ApplicationController
   def import_csv
     if params[:file].nil?
       redirect_back(fallback_location: diaper_drive_participants_path(organization_id: current_organization))
-      flash[:alert] = "No file was attached!"
+      flash[:error] = "No file was attached!"
     else
       filepath = params[:file].read
       DiaperDriveParticipant.import_csv(filepath, current_organization.id)

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -33,19 +33,19 @@ class DistributionsController < ApplicationController
         flash[:notice] = "Distribution created!"
         redirect_to distributions_path
       else
-        flash[:alert] = "There was an error, try again?"
+        flash[:error] = "There was an error, try again?"
         render :new
       end
     else
       @storage_locations = current_organization.storage_locations
-      flash[:alert] = "An error occurred, try again?"
+      flash[:error] = "An error occurred, try again?"
       logger.error "failed to save distribution: #{ @distribution.errors.full_messages }"
       render :new
     end
   rescue Errors::InsufficientAllotment => ex
     @storage_locations = current_organization.storage_locations
     @items = current_organization.items.alphabetized
-    flash[:alert] = ex.message
+    flash[:error] = ex.message
     render :new
   end
 

--- a/app/controllers/donation_sites_controller.rb
+++ b/app/controllers/donation_sites_controller.rb
@@ -8,7 +8,7 @@ class DonationSitesController < ApplicationController
     if @donation_site.save
     redirect_to donation_sites_path, notice: "New donation site added!"
     else
-    flash[:alert] = "Something didn't work quite right -- try again?"
+    flash[:error] = "Something didn't work quite right -- try again?"
     render action: :new
     end
   end
@@ -30,7 +30,7 @@ class DonationSitesController < ApplicationController
     if @donation_site.update_attributes(donation_site_params)
     redirect_to donation_sites_path, notice: "#{@donation_site.name} updated!"
     else
-      flash[:alert] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end
@@ -38,7 +38,7 @@ class DonationSitesController < ApplicationController
   def import_csv
     if params[:file].nil?
       redirect_back(fallback_location: donation_sites_path(organization_id: current_organization))
-      flash[:alert] = "No file was attached!"
+      flash[:error] = "No file was attached!"
     else
       filepath = params[:file].read
       DonationSite.import_csv(filepath, current_organization.id)

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -70,8 +70,8 @@ class DonationsController < ApplicationController
     else
       load_form_collections
       @donation.line_items.build if @donation.line_items.count == 0
-      flash[:alert] = "There was an error starting this donation, try again?"
-      Rails.logger.info "ERROR: #{@donation.errors}"
+      flash[:error] = "There was an error starting this donation, try again?"
+      Rails.logger.error "ERROR: #{@donation.errors}"
       render action: :new
     end
   end
@@ -106,7 +106,7 @@ class DonationsController < ApplicationController
   end
 
 private
-  
+
   def load_form_collections
     @storage_locations = current_organization.storage_locations
     @donation_sites = current_organization.donation_sites

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -28,7 +28,7 @@ class ItemsController < ApplicationController
     if @item.save
     redirect_to items_path, notice: "#{@item.name} added!"
       else
-      flash[:alert] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again?"
       render action: :new
     end
   end
@@ -53,7 +53,7 @@ class ItemsController < ApplicationController
     if @item.update_attributes(item_params)
     redirect_to items_path, notice: "#{@item.name} updated!"
     else
-      flash[:alert] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -9,7 +9,7 @@ class OrganizationsController < ApplicationController
     if @organization.update_attributes(organization_params)
       redirect_to edit_organization_path(organization_id: current_organization.to_param), notice: 'Updated organization!'
     else
-      flash[:alert] = 'Failed to update organization'
+      flash[:error] = 'Failed to update organization'
       render :edit
     end
   end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -8,7 +8,7 @@ class PartnersController < ApplicationController
     if @partner.save
     redirect_to partners_path, notice: "Partner added!"
     else
-      flash[:alert] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again?"
       render action: :new
     end
   end
@@ -30,7 +30,7 @@ class PartnersController < ApplicationController
     if @partner.update_attributes(partner_params)
     redirect_to partners_path, notice: "#{@partner.name} updated!"
     else
-      flash[:alert] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end
@@ -38,7 +38,7 @@ class PartnersController < ApplicationController
   def import_csv
     if params[:file].nil?
       redirect_back(fallback_location: partners_path(organization_id: current_organization))
-      flash[:alert] = "No file was attached!"
+      flash[:error] = "No file was attached!"
     else
       filepath = params[:file].read
       Partner.import_csv(filepath, current_organization.id)

--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -9,7 +9,7 @@ class StorageLocationsController < ApplicationController
     if @storage_location.save
     redirect_to storage_locations_path, notice: "New storage location added!"
     else
-      flash[:alert] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again?"
       render action: :new
     end
   end
@@ -27,26 +27,26 @@ class StorageLocationsController < ApplicationController
     respond_to do |format|
       format.html
       format.csv { send_data @storage_location.to_csv }
-      format.xls 
+      format.xls
     end
   end
 
   def import_inventory
     if params[:file].nil?
       redirect_back(fallback_location: storage_locations_path(organization_id: current_organization))
-      flash[:alert] = "No file was attached!"
+      flash[:error] = "No file was attached!"
     else
       filepath = params[:file].read
       StorageLocation.import_inventory(filepath, current_organization.id, params[:storage_location])
       flash[:notice] = "Inventory imported successfully!"
       redirect_back(fallback_location: storage_locations_path(organization_id: current_organization))
     end
-  end    
+  end
 
   def import_csv
     if params[:file].nil?
       redirect_back(fallback_location: storage_locations_path(organization_id: current_organization))
-      flash[:alert] = "No file was attached!"
+      flash[:error] = "No file was attached!"
     else
       filepath = params[:file].read
       StorageLocation.import_csv(filepath, current_organization.id)
@@ -62,7 +62,7 @@ class StorageLocationsController < ApplicationController
     if @storage_location.update_attributes(storage_location_params)
     redirect_to storage_locations_path, notice: "#{@storage_location.name} updated!"
     else
-      flash[:alert] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
     end
   end

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -16,18 +16,18 @@ class TransfersController < ApplicationController
       if @transfer.save
         redirect_to transfers_path, notice: 'Transfer was successfully created.'
       else
-        flash[:alert] = "There was an error, try again?"
+        flash[:error] = "There was an error, try again?"
         render :new
       end
     else
-      flash[:alert] = "There was an error creating the transfer"
+      flash[:error] = "There was an error creating the transfer"
       @storage_locations = current_organization.storage_locations.alphabetized
       @items = current_organization.items.alphabetized
       @transfer.line_items.build unless @transfer.line_items.size > 0
       render :new
     end
   rescue Errors::InsufficientAllotment => ex
-    flash[:alert] = ex.message
+    flash[:error] = ex.message
     render :new
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
       @user.invite!(@user)
       redirect_to users_path, notice: 'Created a new user!'
     else
-      flash[:alert] = 'Failed to create user'
+      flash[:error] = 'Failed to create user'
       render :new
     end
   end
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
       @user.destroy
       redirect_to users_path, notice: "Deleted that user"
     else
-      redirect_to users_path, notice: "Couldn't find that user, sorry"
+      redirect_to users_path, flash: { error: "Couldn't find that user, sorry" }
     end
 
   end

--- a/app/models/errors.rb
+++ b/app/models/errors.rb
@@ -1,5 +1,6 @@
 module Errors
   class InsufficientAllotment < StandardError
+    # TODO: This should be removed once other models no longer depend on it; it should be encapsulated and accessed through an interface
     attr_accessor :insufficient_items
 
     def initialize(message, insufficient_items=[])
@@ -7,13 +8,34 @@ module Errors
       @insufficient_items = insufficient_items
     end
 
+    ###
+    # add_insufficiency
+    #   Adds a note of insufficiency, to keep the list encapsulated
+    ###
     def add_insufficiency(item, quantity_on_hand, quantity_requested)
       insufficient_items << {
-        item: item.to_s,
+        item_id: item.id,
+        item: item.name,
         quantity_on_hand: quantity_on_hand.to_i,
         quantity_requested: quantity_requested.to_i
       }
     end
+
+    ###
+    # satisfied?
+    #   Informs the model that we're OK here, so that we don't have to expose the field
+    ###
+    def satisfied?
+      insufficient_items.empty?
+    end
+
+    ###
+    # message
+    #   overrides the default behavior by showing the message and then the items
+    #   that are insufficient.
+    ###
+    def message
+      super.to_s + ("<ul><li>" + insufficient_items.map { |i| "#{i[:quantity_requested]} #{i[:item]} requested, only #{i[:quantity_on_hand]} available. (Reduce by #{i[:quantity_requested].to_i - i[:quantity_on_hand].to_i})" }.join("</li><li>") + "</li></ul>")
+    end
   end
 end
-

--- a/app/models/errors.rb
+++ b/app/models/errors.rb
@@ -35,7 +35,10 @@ module Errors
     #   that are insufficient.
     ###
     def message
-      super.to_s + ("<ul><li>" + insufficient_items.map { |i| "#{i[:quantity_requested]} #{i[:item]} requested, only #{i[:quantity_on_hand]} available. (Reduce by #{i[:quantity_requested].to_i - i[:quantity_on_hand].to_i})" }.join("</li><li>") + "</li></ul>")
+      super.to_s + ("<ul><li>" + insufficient_items.map { |i|
+        "#{i[:quantity_requested]} #{i[:item]} requested, only #{i[:quantity_on_hand]} available." +
+        "(Reduce by #{i[:quantity_requested].to_i - i[:quantity_on_hand].to_i})"
+      }.join("</li><li>") + "</li></ul>")
     end
   end
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -16,5 +16,5 @@ class LineItem < ApplicationRecord
   belongs_to :item
 
   validates :item_id, presence: true
-  validates :quantity, numericality: { greater_than: 0 }
+  validates :quantity, numericality: { other_than: 0 }
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -16,5 +16,5 @@ class LineItem < ApplicationRecord
   belongs_to :item
 
   validates :item_id, presence: true
-  validates :quantity, numericality: { other_than: 0 }
+  validates :quantity, numericality: { other_than: 0, only_integer: true }
 end

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -167,8 +167,8 @@ class StorageLocation < ApplicationRecord
       inventory_item = self.inventory_items.find_by(item: line_item.item)
       next if inventory_item.nil? || inventory_item.quantity == 0
 
-      if inventory_item.quantity >= line_item.quantity
-        updated_quantities[inventory_item.id] = (updated_quantities[inventory_item.id] || inventory_item.quantity) - line_item.quantity
+      if ((inventory_item.quantity + line_item.quantity) >= 0)
+        updated_quantities[inventory_item.id] = (updated_quantities[inventory_item.id] || inventory_item.quantity) + line_item.quantity
       else
         item_validator.add_insufficiency(line_item.item, inventory_item.quantity, line_item.quantity)
       end

--- a/app/views/adjustments/edit.html.erb
+++ b/app/views/adjustments/edit.html.erb
@@ -1,7 +1,7 @@
 <section class="content-header">
 	<% content_for :title, "#{current_organization.name} - Inventory - Adjustments - Edit" %>
 	<h1>
-	  Editing Adjustment
+	  Editing Inventory Adjustment
 	  <small>for <%= current_organization.name %></small>
 	</h1>
 	<ol class="breadcrumb">
@@ -9,7 +9,7 @@
 	    <i class="fa fa-dashboard"></i> Home
 	  <% end %>
 	  </li>
-	  <li><%= link_to "All Adjustment", (adjustments_path) %></li>  
+	  <li><%= link_to "All Adjustment", (adjustments_path) %></li>
 	  <li class="active">Adjustment (<%= @adjustment.created_at.strftime("%m/%d/%Y") %>)</li>
 	</ol>
 </section>

--- a/app/views/adjustments/new.html.erb
+++ b/app/views/adjustments/new.html.erb
@@ -1,7 +1,7 @@
 <section class="content-header">
 <% content_for :title, "#{current_organization.name} - Inventory - Adjustments - New" %>
   <h1>
-    New Adjustment
+    New Inventory Adjustment
     <small>for <%= current_organization.name %></small>
   </h1>
   <ol class="breadcrumb">
@@ -9,7 +9,7 @@
       <i class="fa fa-dashboard"></i> Home
     <% end %>
     </li>
-    <li><%= link_to "Distributions", (adjustments_path) %></li>  
+    <li><%= link_to "Distributions", (adjustments_path) %></li>
     <li class="active"> New Adjustment</li>
   </ol>
 </section>

--- a/app/views/adjustments/new.html.erb
+++ b/app/views/adjustments/new.html.erb
@@ -24,7 +24,7 @@
   </div>
 
   <div class="box-body">
-
+<p class="help">Enter a negative amount for <code>quantity</code> if you want to subtract that kind of item.</p>
 <%= simple_form_for @adjustment do |f| %>
 
   <%= f.association :storage_location,

--- a/app/views/adjustments/new.html.erb
+++ b/app/views/adjustments/new.html.erb
@@ -48,14 +48,14 @@
     <fieldset style="margin-bottom: 2rem;">
       <legend>Items in this donation</legend>
       <%= f.simple_fields_for :line_items do |item| %>
-        <div id="donation_line_items" data-capture-barcode="true">
+        <div id="adjustment_line_items" data-capture-barcode="true">
           <%= render 'line_item_fields', f: item %>
         </div>
         <div class="row links">
           <div class="col-xs-12">
             <%= link_to_add_association f, :line_items,
             data: {
-              association_insertion_node: "#donation_line_items",
+              association_insertion_node: "#adjustment_line_items",
               association_insertion_method: "append"
             }, id: "__add_line_item", class: "btn btn-md btn-success", style: "margin-top: 1rem;" do
             %>

--- a/app/views/adjustments/new.html.erb
+++ b/app/views/adjustments/new.html.erb
@@ -9,7 +9,7 @@
       <i class="fa fa-dashboard"></i> Home
     <% end %>
     </li>
-    <li><%= link_to "Distributions", (adjustments_path) %></li>
+    <li><%= link_to "Adjustments", (adjustments_path) %></li>
     <li class="active"> New Adjustment</li>
   </ol>
 </section>

--- a/app/views/adjustments/show.html.erb
+++ b/app/views/adjustments/show.html.erb
@@ -38,13 +38,15 @@
   <div class="box-body table-responsive no-padding">
     <table class="table table-hover">
     <tr>
+      <th>&nbsp;</th>
       <th>Item</th>
       <th>Quantity</th>
     </tr>
-  <% @adjustment.line_items.each do |line_item| %>
-    <tr>
+  <% @adjustment.line_items.each do |line_item|  %>
+    <tr class="<%= line_item.quantity > 0 ? "positive" : "negative" %>">
+      <td><%= (line_item.quantity > 0) ? "Added " : "Removed " %></td>
+      <td><%= line_item.quantity.abs %></td>
       <td><%= line_item.item.name %></td>
-      <td><%= line_item.quantity %></td>
     </tr>
   <% end %>
     </table>

--- a/app/views/adjustments/show.html.erb
+++ b/app/views/adjustments/show.html.erb
@@ -2,7 +2,7 @@
 <section class="content-header">
   <% content_for :title, "#{current_organization.name} - Inventory - Adjustments" %>
   <h1>
-    Adjustment
+    Inventory Adjustment
     <small>for <%= current_organization.name %></small>
   </h1>
   <ol class="breadcrumb">
@@ -10,7 +10,7 @@
       <i class="fa fa-dashboard"></i> Home
     <% end %>
     </li>
-    <li><%= link_to "All Adjustments", (adjustments_path) %></li>  
+    <li><%= link_to "All Adjustments", (adjustments_path) %></li>
     <li class="active">Adjustment (<%= @adjustment.created_at.strftime("%m/%d/%Y") %>)</li>
   </ol>
 </section>
@@ -55,11 +55,6 @@
       <!-- /.box -->
   <strong>Comments:</strong>
   <%= @adjustment.comment %>
-</p>    
+</p>
   </div>
 </div>
-
-
-
-
-

--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -11,11 +11,6 @@
           <%= link_to(dashboard_path) do %>
             <i class="fa fa-dashboard"></i> <span>Dashboard</span>
           <% end %>
-
-<!--           <ul class="treeview-menu">
-            <li><a href="/index.html"><i class="fa fa-circle-o"></i> Dashboard v1</a></li>
-            <li><a href="/index2.html"><i class="fa fa-circle-o"></i> Dashboard v2</a></li>
-          </ul> -->
         </li>
         <li class="<%= active_class(['donations']) %> treeview">
           <a href="#">
@@ -26,17 +21,17 @@
             </span>
           </a>
           <ul class="treeview-menu">
-            <li class="<%= 'active' if current_page?(donations_path) %>">          
+            <li class="<%= 'active' if current_page?(donations_path) %>">
               <%= link_to(donations_path) do %>
                 <i class="fa fa-circle-o"></i> All Donations
               <% end %>
             </li>
-            <li class="<%= 'active' if current_page?(new_donation_path) %>">          
+            <li class="<%= 'active' if current_page?(new_donation_path) %>">
               <%= link_to(new_donation_path) do %>
                 <i class="fa fa-circle-o"></i> New Donation
               <% end %>
             </li>
-            <li class="<%= 'active' if current_page?(scale_donations_path) %>">          
+            <li class="<%= 'active' if current_page?(scale_donations_path) %>">
               <%= link_to(scale_donations_path) do %>
                 <i class="fa fa-circle-o"></i> Repackaged Donation
               <% end %>
@@ -44,11 +39,11 @@
           </ul>
         </li>
         <li>
-        <li class="<%= active_class(['distributions']) %>">          
+        <li class="<%= active_class(['distributions']) %>">
           <%= link_to(distributions_path) do %>
             <i class="fa fa-circle-o"></i> <span>Distributions</span>
           <% end %>
-        </li>          
+        </li>
         </li>
         <li class="<%= active_class(['items','barcode_items','storage_locations','adjustments','transfers']) %> treeview">
           <a href="#">
@@ -59,27 +54,27 @@
             </span>
           </a>
           <ul class="treeview-menu">
-            <li class="<%= active_class(['items']) %>">          
+            <li class="<%= active_class(['items']) %>">
               <%= link_to(items_path) do %>
-                <i class="fa fa-circle-o"></i> Items & Inventory
+                <i class="fa fa-circle-o"></i> Items &amp; Inventory
               <% end %>
             </li>
-            <li class="<%= active_class(['barcode_items']) %>">          
+            <li class="<%= active_class(['barcode_items']) %>">
               <%= link_to(barcode_items_path) do %>
                 <i class="fa fa-circle-o"></i> Barcode Items
               <% end %>
             </li>
-            <li class="<%= active_class(['storage_locations']) %>">          
+            <li class="<%= active_class(['storage_locations']) %>">
               <%= link_to(storage_locations_path) do %>
                 <i class="fa fa-circle-o"></i> Storage Locations
               <% end %>
             </li>
-            <li class="<%= active_class(['adjustments']) %>">          
+            <li class="<%= active_class(['adjustments']) %>">
               <%= link_to(adjustments_path) do %>
-                <i class="fa fa-circle-o"></i> Adjustments
+                <i class="fa fa-circle-o"></i> Inventory Adjustments
               <% end %>
             </li>
-            <li class="<%= active_class(['transfers']) %>">          
+            <li class="<%= active_class(['transfers']) %>">
               <%= link_to(transfers_path) do %>
                 <i class="fa fa-circle-o"></i> Transfers
               <% end %>
@@ -97,17 +92,17 @@
             </span>
           </a>
           <ul class="treeview-menu">
-            <li class="<%= active_class(['donation_sites']) %>">          
+            <li class="<%= active_class(['donation_sites']) %>">
               <%= link_to(donation_sites_path) do %>
                 <i class="fa fa-circle-o"></i> Donation Sites
               <% end %>
             </li>
-            <li class="<%= active_class(['partners']) %>">          
+            <li class="<%= active_class(['partners']) %>">
               <%= link_to(partners_path) do %>
                 <i class="fa fa-circle-o"></i> Partner Agencies
               <% end %>
             </li>
-            <li class="<%= active_class(['diaper_drive_participants']) %>">          
+            <li class="<%= active_class(['diaper_drive_participants']) %>">
               <%= link_to(diaper_drive_participants_path) do %>
                 <i class="fa fa-circle-o"></i> Diaper Drive Participants
               <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,9 @@
     <!-- Content Header (Page header) -->
     <% flash.each do |key, value| %>
       <div class="<%= flash_class(key) %> alert-dismissible">
-            <%= value %>
+            <a href="#" class="close" data-dismiss="alert" aria-label="close" style="text-decoration: none;"><%= fa_icon('times') %></a>
+            <% # TODO: is using .html_safe ok here? Are there potential security considerations? %>
+            <%= value.html_safe %>
       </div>
     <% end %>
     <%= yield %>

--- a/spec/controllers/adjustments_controller_spec.rb
+++ b/spec/controllers/adjustments_controller_spec.rb
@@ -67,9 +67,9 @@ RSpec.describe AdjustmentsController, type: :controller do
           expect(assigns(:adjustment)).to be_persisted
         end
 
-        it "redirects to the index after created adjustment" do
+        it "redirects to the #show after created adjustment" do
           post :create, params: default_params.merge(adjustment: valid_attributes), session: valid_session
-          expect(response).to redirect_to(adjustments_path)
+          expect(response).to redirect_to(adjustment_path(Adjustment.last))
         end
       end
 

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe DistributionsController, type: :controller do
       it "renders #new again on failure, with notice" do
         post :create, params:default_params.merge(distribution: { comment: nil, partner_id: nil, storage_location_id: nil })
         expect(response).to be_successful
-        expect(flash[:alert]).to match(/error/i)
+        expect(flash[:error]).to match(/error/i)
       end
     end
 

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -39,10 +39,10 @@ RSpec.describe DonationsController, type: :controller do
         expect(response).to redirect_to(donations_path)
       end
 
-      it "renders GET#new with notice on failure" do
+      it "renders GET#new with error on failure" do
         post :create, params: default_params.merge(donation: { storage_location_id: nil, donation_site_id: nil, source: nil } )
         expect(response).to be_successful # Will render :new
-        expect(flash[:alert]).to match(/error/i)
+        expect(flash[:error]).to match(/error/i)
       end
     end
 

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe TransfersController, type: :controller do
         post :create, params: { organization_id: @organization.short_name, transfer: { from_id: nil, to_id: nil } }
         expect(response).to be_successful # Will render :new
         expect(response).to render_template("new")
-        expect(flash[:alert]).to match(/error/i)
+        expect(flash[:error]).to match(/error/i)
       end
     end
 

--- a/spec/factories/adjustments.rb
+++ b/spec/factories/adjustments.rb
@@ -15,5 +15,23 @@ FactoryBot.define do
     organization { Organization.try(:first) || create(:organization) }
     storage_location
     comment "A comment"
+
+    trait :with_items do
+      storage_location { create :storage_location, :with_items }
+
+      transient do
+        item_quantity 100
+        item nil
+      end
+
+      after(:build) do |adjustment, evaluator|
+        item = if evaluator.item.nil?
+                 adjustment.storage_location.inventory_items.first.item
+               else
+                 evaluator.item
+               end
+        adjustment.line_items << build(:line_item, quantity: evaluator.item_quantity, item: item)
+      end
+    end
   end
 end

--- a/spec/features/adjustment_spec.rb
+++ b/spec/features/adjustment_spec.rb
@@ -4,16 +4,35 @@ before do
 end
 let!(:url_prefix) { "/#{@organization.to_param}" }
 
-scenario "User can adjust an inventory at a storage location" do
+scenario "User can add an inventory adjustment at a storage location" do
+  add_quantity = 10
   storage_location = create(:storage_location, :with_items, organization: @organization)
   visit url_prefix + "/adjustments"
   click_link "New Adjustment"
   select storage_location.name, from: "From storage location"
   fill_in "Comment", with: "something"
   select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
-  fill_in "adjustment_line_items_attributes_0_quantity", with: "10"
-  click_button "Create Adjustment"
+  fill_in "adjustment_line_items_attributes_0_quantity", with: "#{add_quantity}"
 
+  expect {
+    click_button "Create Adjustment"
+  }.to change{storage_location.size}.by(add_quantity)
+  expect(page).to have_content("Adjustment was successfully created")
+end
+
+scenario "User can subtract an inventory adjustment at a storage location" do
+  sub_quantity = -10
+  storage_location = create(:storage_location, :with_items, organization: @organization)
+  visit url_prefix + "/adjustments"
+  click_link "New Adjustment"
+  select storage_location.name, from: "From storage location"
+  fill_in "Comment", with: "something"
+  select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
+  fill_in "adjustment_line_items_attributes_0_quantity", with: "#{sub_quantity}"
+
+  expect {
+    click_button "Create Adjustment"
+  }.to change{storage_location.size}.by(sub_quantity)
   expect(page).to have_content("Adjustment was successfully created")
 end
 

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -22,5 +22,13 @@ RSpec.describe LineItem, type: :model do
 		it "requires a quantity" do
 			expect(build(:line_item, quantity: nil)).not_to be_valid
 		end
+
+		it "the quantity must be an integer and cannot be 0" do
+			expect(build(:line_item, quantity: 'a')).not_to be_valid
+			expect(build(:line_item, quantity: '1.0')).not_to be_valid
+			expect(build(:line_item, quantity: 0)).not_to be_valid
+			expect(build(:line_item, quantity: -1)).to be_valid
+			expect(build(:line_item, quantity: 1)).to be_valid
+		end
 	end
 end


### PR DESCRIPTION
Fixes #238 

I did a few things here -- some weren't COMPLETELY in scope, but they're related enough that I fixed them for this issue.

### Changes labelling in menu and headers to read 'Inventory Adjustment' instad of just 'Adjustment'

Trivial change.

### Cleans up the error UI for adjustments somewhat. Makes InsufficientItems error more encapsulated.

So this did a couple things. I changed the JS so that it doesn't auto-hide when the box is classed with `alert-danger` -- this is so that when something has an error, the user has adequate time to read and process it (and copy/paste it into a Github issue, if needed). 2.5s was an inadequate time for me to read some of the errors when they had multiple lines :) 

It also changes the `InsufficientItems` error to be more encapsulated -- the Error currently has an attribute exposed and I don't think it makes sense to do so -- we should be respecting the encapsulation of the object and only accessing that data (which, TBH, requires marshalling on both directions) through interfaces. I put the parts in for that to happen, but other models are still doing it the old way and will need to be updated.

### Changes GT0 requirement for LineItems quantity to NE0 so that Adjustments can provide negative values.

Previously we had a `numericality` constraint that enforced greater-than zero values for line-items -- I understand why that was in place and I think merely making this "not equal to zero" **creates a small amount of technical debt** -- technically a user could add a negative number for a Donation, for example -- and that's unexpected. We may need to either include a proc in the `numericality` validator, or do a conditional validation or something similar. Only `Adjustment` needs this treatment; every other model can be GT0 only.

HOWEVER, this was the most direct method to make this feature work as expected. I also added some helper text to the top of the `Adjustments#new` page that indicates how to subtract quantities.

### Users can now add or delete items in an adjustment (...)
```Creating an adjustment now redirects to the `#show` for that adjustment (for review), and the rows are colored to reflect whether it was add or deleted, with words that indicate adding / removing. Also adds test coverage for all features.```

This actually completes the feature and includes tests to back it up. I improved the #show action display slightly (doing green/red coloring as a UI assistant -- but there is explicit text for users that might be R/G color blind)