### PR TITLE
Remove turbolinks from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'sass-rails', '~> 5.0'
 gem 'simple_form', '~> 3.4'
 gem 'uglifier', '>= 1.3.0'
 gem 'therubyracer', '~> 0.12',  platforms: :ruby
-gem 'turbolinks', '~> 5'
 gem 'yajl-ruby'
 gem 'toastr-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,9 +335,6 @@ GEM
     toastr-rails (1.0.3)
       railties (>= 3.1.0)
     ttfunk (1.5.1)
-    turbolinks (5.0.1)
-      turbolinks-source (~> 5)
-    turbolinks-source (5.0.3)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
@@ -410,7 +407,6 @@ DEPENDENCIES
   terminal-notifier-guard
   therubyracer (~> 0.12)
   toastr-rails
-  turbolinks (~> 5)
   tzinfo-data (~> 1.2)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)


### PR DESCRIPTION
It looks like this hasnt been included in the bundle since 0acabd3