### PR TITLE
Notify diaper partner app about new partners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,16 @@ RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main" 
 RUN apt-get update
 RUN apt-get install -y postgresql-client-9.5
 
+# Install phantomjs for rspec
+ARG PHANTOM_VERSION=2.1.1
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get install -y curl fontconfig cmake \
+    && cd /tmp \
+    && curl -L -O https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOM_VERSION}-linux-x86_64.tar.bz2 \
+    && tar xvjf phantomjs-${PHANTOM_VERSION}-linux-x86_64.tar.bz2 \
+    && cp /tmp/phantomjs-*/bin/phantomjs /usr/local/bin/phantomjs
+
 RUN mkdir /app
 WORKDIR /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+gem 'api-auth', '~> 1.5'
 gem 'bootstrap-sass'
 gem "bugsnag"
 gem 'chartkick', '~> 2.2'

--- a/Gemfile
+++ b/Gemfile
@@ -68,6 +68,7 @@ group :test do
   gem 'phantomjs', '~> 2.1', require: "phantomjs/poltergeist"
   gem 'poltergeist', '~> 1.15'
   gem 'rails-controller-testing', '~> 1.0'
+  gem 'webmock', '~> 2.1'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,7 @@ GEM
     annotate (2.7.2)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
+    api-auth (1.5.0)
     arel (8.0.0)
     autoprefixer-rails (7.1.6)
       execjs
@@ -361,6 +362,7 @@ PLATFORMS
 
 DEPENDENCIES
   annotate (~> 2.6)
+  api-auth (~> 1.5)
   awesome_print (~> 1.7)
   better_errors (~> 2.1)
   binding_of_caller (~> 0.7)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,8 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.2)
     database_cleaner (1.6.1)
     debug_inspector (0.0.3)
@@ -161,6 +163,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    hashdiff (0.3.7)
     i18n (0.9.3)
       concurrent-ruby (~> 1.0)
     jbuilder (2.7.0)
@@ -297,6 +300,7 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
+    safe_yaml (1.0.4)
     sass (3.4.25)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -350,6 +354,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (2.3.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -416,6 +424,7 @@ DEPENDENCIES
   tzinfo-data (~> 1.2)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
+  webmock (~> 2.1)
   yajl-ruby
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Try to keep your PRs limited to one particular issue and don't make changes that
 
 ### Testing
 
-This app uses RSpec, Capybara, Poltergeist, and FactoryBot for testing. Make sure `bundle exec rake spec` runs clean & green before submitting a Pull Request. If you are inexperienced in writing tests or get stuck on one, please reach out so one of us can help you. :) 
+If you are using Docker you may run the tests with `docker-compose run test`, otherwise run `bundle exec rake spec`.
+
+This app uses RSpec, Capybara, Poltergeist, and FactoryBot for testing. Make sure the tests run clean & green before submitting a Pull Request. If you are inexperienced in writing tests or get stuck on one, please reach out so one of us can help you. :) 
 
 The one situation where you probably don't need to write new tests is when simple re-stylings are done (ie. the page may look slightly different but the Test suite is unaffected by those changes). 
 

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -20,11 +20,28 @@ class Partner < ApplicationRecord
   validates :name, :email, presence: true, uniqueness: true
   validates_format_of :email, :with => /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, :on => :create
 
+  after_create :notify_diaper_partner
+
   def self.import_csv(filename,organization)
     CSV.parse(filename, :headers => true) do |row|
       loc = Partner.new(row.to_hash)
       loc.organization_id = organization
       loc.save!
+    end
+  end
+
+  private
+
+  def notify_diaper_partner
+    diaper_partner_url = ENV['DIAPER_PARTNER_URL']
+    return unless diaper_partner_url.present?
+
+    uri = URI(diaper_partner_url + '/partners')
+    request = Net::HTTP::Post.new uri
+    request.set_form_data attributes
+
+    Net::HTTP.start(uri.hostname, uri.port) do |http|
+      http.request ApiAuth.sign!(request, 'diaperbase', ENV['DIAPER_PARTNER_SECRET_KEY'])
     end
   end
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -33,15 +33,15 @@ class Partner < ApplicationRecord
   private
 
   def notify_diaper_partner
-    diaper_partner_url = ENV['DIAPER_PARTNER_URL']
+    diaper_partner_url = ENV["DIAPER_PARTNER_URL"]
     return unless diaper_partner_url.present?
 
-    uri = URI(diaper_partner_url + '/partners')
+    uri = URI(diaper_partner_url + "/partners")
     request = Net::HTTP::Post.new uri
     request.set_form_data attributes
 
     Net::HTTP.start(uri.hostname, uri.port) do |http|
-      http.request ApiAuth.sign!(request, 'diaperbase', ENV['DIAPER_PARTNER_SECRET_KEY'])
+      http.request ApiAuth.sign!(request, "diaperbase", ENV["DIAPER_PARTNER_SECRET_KEY"])
     end
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
     environment:
       - PG_USERNAME=postgres
       - PG_HOST=postgres
+      - DIAPER_PARTNER_URL=http://diaperpartner:3000
+      - DIAPER_PARTNER_SECRET_KEY=secretkey123
 
   postgres:
     image: postgres:9.5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,20 @@ services:
       - DIAPER_PARTNER_URL=http://diaperpartner:3000
       - DIAPER_PARTNER_SECRET_KEY=secretkey123
 
+  test:
+    build:
+      context: .
+    volumes:
+      - .:/usr/src/app
+    working_dir: '/usr/src/app'
+    command: [rake, spec]
+    links:
+      - postgres
+    environment:
+      - PG_USERNAME=postgres
+      - PG_HOST=postgres
+      - RAILS_ENV=test
+
   postgres:
     image: postgres:9.5
     ports:

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -29,21 +29,24 @@ RSpec.describe Partner, type: :model do
   end
   context "Callbacks >" do
     describe "when DIAPER_PARTNER_URL is present" do
-      let(:diaper_partner_url) { 'http://diaper.partner.io' }
+      let(:diaper_partner_url) { "http://diaper.partner.io" }
       let(:callback_url) { "#{diaper_partner_url}/partners" }
 
       before do
-        allow(ENV).to receive(:[]).with('DIAPER_PARTNER_URL') { diaper_partner_url }
-        allow(ENV).to receive(:[]).with('DIAPER_PARTNER_SECRET_KEY') { 'secretkey123' }
-
+        stub_env "DIAPER_PARTNER_URL", diaper_partner_url
+        stub_env "DIAPER_PARTNER_SECRET_KEY", "secretkey123"
         stub_request :post, callback_url
       end
 
       it "notifies the Diaper Partner app" do
         partner = create :partner
-        headers = { 'Authorization'=>/APIAuth diaperbase:.*/, 'Content-Type'=>'application/x-www-form-urlencoded' }
+        headers = {
+          "Authorization" => /APIAuth diaperbase:.*/,
+          "Content-Type" => "application/x-www-form-urlencoded"
+        }
         body = URI.encode_www_form partner.attributes
-        expect(WebMock).to have_requested(:post, callback_url).with(headers: headers, body: body).once
+        expect(WebMock).to have_requested(:post, callback_url).
+          with(headers: headers, body: body).once
       end
     end
   end

--- a/spec/support/env_helper.rb
+++ b/spec/support/env_helper.rb
@@ -1,0 +1,3 @@
+def stub_env(key, value)
+  allow(ENV).to receive(:[]).with(key) { value }
+end

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,0 +1,2 @@
+require 'webmock/rspec'
+WebMock.disable_net_connect! allow_localhost: true

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,2 +1,2 @@
-require 'webmock/rspec'
+require "webmock/rspec"
 WebMock.disable_net_connect! allow_localhost: true


### PR DESCRIPTION
Initial implementation for #224 

### Description

This is a first draft implementation for #224.
It is a no-op unless the `DIAPER_PARTNER_URL` env var is set, but I needed to get something in to test https://github.com/rubyforgood/diaperpartner/issues/1 against.

### Type of change

New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Just locally, using the Docker compose set up.