### PR TITLE
Changes bar code item "global" checkbox to radio buttons

### DIFF
--- a/app/controllers/barcode_items_controller.rb
+++ b/app/controllers/barcode_items_controller.rb
@@ -13,7 +13,7 @@ class BarcodeItemsController < ApplicationController
     @barcode_item = current_organization.barcode_items.new(barcode_item_params)
     if @barcode_item.save
       msg = "New barcode added"
-      msg += barcode_item_params[:global] == "1" ? " globally!" : " to your private set!"
+      msg += barcode_item_params[:global] == "true" ? " globally!" : " to your private set!"
       respond_to do |format|
         format.json { render json: @barcode_item.to_json }
         format.html { redirect_to barcode_items_path, notice: msg }

--- a/app/views/barcode_items/_form.html.erb
+++ b/app/views/barcode_items/_form.html.erb
@@ -27,11 +27,9 @@
 
     <div class="row">
       <div class="col-xs-8 col-md-6 col-lg-3">
-        <div class="checkbox form-group-check">
           <%= f.input :global,
-                label: "Make this barcode available to everyone?",
-                class: "form-control" %>
-        </div>
+                as: :radio_buttons,
+                label: "Make this barcode available to everyone?" %>
       </div><!-- ./col-xs-8 -->
     </div><!-- /.row -->
 

--- a/app/views/barcode_items/_form.html.erb
+++ b/app/views/barcode_items/_form.html.erb
@@ -27,9 +27,9 @@
 
     <div class="row">
       <div class="col-xs-8 col-md-6 col-lg-3">
-          <%= f.input :global,
-                as: :radio_buttons,
-                label: "Make this barcode available to everyone?" %>
+        <%= f.input :global,
+              as: :radio_buttons,
+              label: "Make this barcode available to everyone?" %>
       </div><!-- ./col-xs-8 -->
     </div><!-- /.row -->
 

--- a/app/views/donations/_barcode_modal.html.erb
+++ b/app/views/donations/_barcode_modal.html.erb
@@ -26,8 +26,7 @@
         <div class="row">
           <%= f.input :global,
                 as: :radio_buttons,
-                label: "Make this barcode available to everyone?",
-                class: "form-control" %>
+                label: "Make this barcode available to everyone?" %>
         </div><!-- /.row -->
         <%= f.button :submit, id: "awesomebutton", class:"btn btn-primary btn-lg"%>
       </div><!-- /.box-body -->

--- a/app/views/donations/_barcode_modal.html.erb
+++ b/app/views/donations/_barcode_modal.html.erb
@@ -24,12 +24,10 @@
           <% end %>
         </div><!-- /.row -->
         <div class="row">
-          <div class="checkbox form-group-check" checked>
-            <%= f.input :global,
-                  label: "Make this barcode available to everyone?",
-                  class: "form-control",
-                  :input_html => { :checked => true } %>
-          </div>
+          <%= f.input :global,
+                as: :radio_buttons,
+                label: "Make this barcode available to everyone?",
+                class: "form-control" %>
         </div><!-- /.row -->
         <%= f.button :submit, id: "awesomebutton", class:"btn btn-primary btn-lg"%>
       </div><!-- /.box-body -->

--- a/app/views/purchases/_barcode_modal.html.erb
+++ b/app/views/purchases/_barcode_modal.html.erb
@@ -24,11 +24,10 @@
           <% end %>
         </div><!-- /.row -->
         <div class="row">
-          <div class="checkbox form-group-check" checked>
-            <%= f.input :global,
-                  label: "Make this barcode available to everyone?",
-                  class: "form-control",
-                  :input_html => { :checked => true } %>
+          <%= f.input :global,
+                as: :radio_buttons,
+                label: "Make this barcode available to everyone?",
+                class: "form-control" %>
           </div>
         </div><!-- /.row -->
         <%= f.button :submit, id: "awesomebutton", class:"btn btn-primary btn-lg"%>

--- a/app/views/purchases/_barcode_modal.html.erb
+++ b/app/views/purchases/_barcode_modal.html.erb
@@ -26,8 +26,7 @@
         <div class="row">
           <%= f.input :global,
                 as: :radio_buttons,
-                label: "Make this barcode available to everyone?",
-                class: "form-control" %>
+                label: "Make this barcode available to everyone?" %>
           </div>
         </div><!-- /.row -->
         <%= f.button :submit, id: "awesomebutton", class:"btn btn-primary btn-lg"%>

--- a/spec/features/barcode_item_spec.rb
+++ b/spec/features/barcode_item_spec.rb
@@ -23,7 +23,6 @@ RSpec.feature "Barcode management", type: :feature do
       select item.name, from: "Item"
       fill_in "Quantity", id: "barcode_item_quantity", with: barcode_traits[:quantity]
       fill_in "Barcode", id: "barcode_item_value", with: barcode_traits[:value]
-      uncheck 'barcode_item_global'
       click_button "Create Barcode item"
 
       expect(page.find('.alert')).to have_content "added to your"
@@ -67,8 +66,8 @@ RSpec.feature "Barcode management", type: :feature do
       select item.name, from: "Item"
       fill_in "Quantity", id: "barcode_item_quantity", with: barcode_traits[:quantity]
       fill_in "Barcode", id: "barcode_item_value", with: barcode_traits[:value]
-      expect(page).to have_xpath("//input[@id='barcode_item_global']")
-      check "barcode_item_global"
+      expect(page).to have_xpath("//input[@id='barcode_item_global_true']")
+      choose "barcode_item_global_true"
       click_button "Create Barcode item"
 
       expect(page.find('.alert')).to have_content "added globally"


### PR DESCRIPTION
Resolves #285 

### Description

We are switching from a checkbox to radio buttons to make the choice more explicit when choosing whether or not a bar code item should be available globally.  The default is "No", since I thought that was what the default was for the checkbox.  I can update it if that's not correct.
   
### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Updated the specs to reflect radio buttons instead of a checkbox, and manually tested locally for both adding a new bar code item, as well as editing an existing one.

### Screenshots

<img width="652" alt="screen shot 2018-03-16 at 2 43 59 pm" src="https://user-images.githubusercontent.com/4250366/37539094-20b0ef58-2929-11e8-8cbe-15338f10c9d2.png">

