### PR TITLE
This makes the multiple scanning more usable until we get past the it…

### DIFF
--- a/app/assets/javascripts/barcode_items.js.erb
+++ b/app/assets/javascripts/barcode_items.js.erb
@@ -50,15 +50,17 @@ $(document).ready(function() {
           if (data['src'] != this && data['value'] == this.value) {
               line_item = this.closest('.nested-fields');
               if ($(line_item).attr('scanned_more_than_two_times') != undefined) {
-                  prompt_value = prompt('Enter quantity of additional items', line_item_quantity);
+                  prompt_value = prompt('Enter total quantity of items', line_item_quantity);
                   if (prompt_value != null) {
                       line_item_quantity = parseInt(prompt_value);
                   } else {
                       line_item_quantity = 0;
                   }
               }
+              if ($(line_item).attr('scanned_more_than_two_times') != "true") {
+                line_item_quantity = Number(line_item_quantity) + Number($(line_item).find('input[type=number]').val());
+              }
               $(line_item).attr('scanned_more_than_two_times', true);
-              line_item_quantity = Number(line_item_quantity) + Number($(line_item).find('input[type=number]').val());
           }
       })
       $(line_item).find('input[type=number]').val(line_item_quantity);


### PR DESCRIPTION
…em blocker.

<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #286  <!--fill issue number-->

### Description
This is a temp fix to improve the barcode scanning workflow. Our users found it unintuitive when they had to add an additional amount when there are multiple scans. This changes it and prompts the users to `Enter the total amount of items` so they don't have to do any math.
   
List any dependencies that are required for this change. (gems, js libraries, etc.)
