### PR TITLE
Fix link/image to master TravisCI status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # README
 
-[![Build Status](https://travis-ci.org/rubyforgood/pdx_diaper.svg?branch=master)](https://travis-ci.org/rubyforgood/pdx_diaper) [![View performance data on Skylight](https://badges.skylight.io/status/LrXHcxDK7Be9.svg)](https://oss.skylight.io/app/applications/LrXHcxDK7Be9)
+[![Build Status](https://travis-ci.org/rubyforgood/diaper.svg?branch=master)](https://travis-ci.org/rubyforgood/diaper) [![View performance data on Skylight](https://badges.skylight.io/status/LrXHcxDK7Be9.svg)](https://oss.skylight.io/app/applications/LrXHcxDK7Be9)
 
 ## About
 


### PR DESCRIPTION
### Description

I noticed that the TravisCI badge pointed at the old repo -- this fixes it to point at the correct build status.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Viewed resulting README.md to verify better rendering and link.
