### PR TITLE
Changed shipped to distributed on dashboard

### DIFF
--- a/app/views/dashboard/_distribution.html.erb
+++ b/app/views/dashboard/_distribution.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="pull-left">
     <%= link_to distribution do %>
-      <%= distribution.line_items.total %> items shipped to
+      <%= distribution.line_items.total %> items distributed to
       <%= distribution.partner_name %>
     <% end %>
   </div>


### PR DESCRIPTION
Resolves #360

### Description
Changed "shipped" to "distributed" on dashboard

### Screenshots
<img width="733" alt="distributed" src="https://user-images.githubusercontent.com/17165242/41161816-0b02cc7e-6b02-11e8-8448-64e98c443905.png">
