### PR TITLE
Adding helper for deletion actions

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -41,7 +41,6 @@ class PartnersController < ApplicationController
       flash[:error] = "No file was attached!"
     else
       filepath = params[:file].read
-      byebug
       Partner.import_csv(filepath, current_organization.id)
       flash[:notice] = "Partners were imported successfully!"
       redirect_back(fallback_location: partners_path(organization_id: current_organization))

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -41,6 +41,7 @@ class PartnersController < ApplicationController
       flash[:error] = "No file was attached!"
     else
       filepath = params[:file].read
+      byebug
       Partner.import_csv(filepath, current_organization.id)
       flash[:notice] = "Partners were imported successfully!"
       redirect_back(fallback_location: partners_path(organization_id: current_organization))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,4 +44,8 @@ module ApplicationHelper
 
   # def after_sign_out_path_for(resource)
   # end
+  
+  def confirm_delete_msg(resource)
+    "Are you sure you want to delete #{resource}?"
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -44,7 +44,7 @@ module ApplicationHelper
 
   # def after_sign_out_path_for(resource)
   # end
-  
+
   def confirm_delete_msg(resource)
     "Are you sure you want to delete #{resource}?"
   end

--- a/app/views/admins/_organization_row.html.erb
+++ b/app/views/admins/_organization_row.html.erb
@@ -1,12 +1,13 @@
 <tr>
-  <td><%= organization_row.name %></td>
+  <% org_name = organization_row.name %>
+  <td><%= org_name %></td>
   <td><%= link_to organization_row.email, "mailto:#{organization_row.email}" %></td>
   <td class="text-right">
       <%= link_to "View", admin_path(organization_row.id), class: "btn btn-primary btn-xs" %>
       <%= link_to edit_admin_path(organization_row.id), class: "btn btn-info btn-xs" do %>
         <%= fa_icon "edit" %> Edit
       <% end %>
-      <%= link_to admin_path(organization_row.id), method: :delete,  data: { confirm: 'Are you sure?' },  class: "btn btn-danger btn-xs" do %>
+      <%= link_to admin_path(organization_row.id), method: :delete,  data: { confirm: confirm_delete_msg(org_name) },  class: "btn btn-danger btn-xs" do %>
         <%= fa_icon "trash" %> Delete
       <% end unless (Organization.count <= 1) %>
   </td>

--- a/app/views/admins/_organization_row.html.erb
+++ b/app/views/admins/_organization_row.html.erb
@@ -1,13 +1,12 @@
 <tr>
-  <% org_name = organization_row.name %>
-  <td><%= org_name %></td>
+  <td><%= organization_row.name %></td>
   <td><%= link_to organization_row.email, "mailto:#{organization_row.email}" %></td>
   <td class="text-right">
       <%= link_to "View", admin_path(organization_row.id), class: "btn btn-primary btn-xs" %>
       <%= link_to edit_admin_path(organization_row.id), class: "btn btn-info btn-xs" do %>
         <%= fa_icon "edit" %> Edit
       <% end %>
-      <%= link_to admin_path(organization_row.id), method: :delete,  data: { confirm: confirm_delete_msg(org_name) },  class: "btn btn-danger btn-xs" do %>
+      <%= link_to admin_path(organization_row.id), method: :delete,  data: { confirm: confirm_delete_msg(organization_row.name) },  class: "btn btn-danger btn-xs" do %>
         <%= fa_icon "trash" %> Delete
       <% end unless (Organization.count <= 1) %>
   </td>

--- a/app/views/barcode_items/_barcode_item_row.html.erb
+++ b/app/views/barcode_items/_barcode_item_row.html.erb
@@ -1,5 +1,6 @@
 <tr>
-  <td><%= barcode_item_row.item.name %></td>
+  <% barcode_name = barcode_item_row.item.name %>
+  <td><%= barcode_name %></td>
   <td><%= barcode_item_row.quantity %></td>
   <td><%= barcode_item_row.value %></td>
   <td class="text-right">
@@ -7,7 +8,7 @@
       <%= link_to edit_barcode_item_path(barcode_item_row), class: "btn btn-info btn-xs" do %>
         <i class="fa fa-edit"></i> Edit
       <% end %>
-      <%= link_to barcode_item_path(barcode_item_row), method: :delete, class: "btn btn-danger btn-xs", data: { confirm: "Are you sure?" } do %>
+      <%= link_to barcode_item_path(barcode_item_row), method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(barcode_name) } do %>
         <i class="fa fa-trash"></i> Delete
       <% end %>
 </tr>

--- a/app/views/barcode_items/_barcode_item_row.html.erb
+++ b/app/views/barcode_items/_barcode_item_row.html.erb
@@ -1,6 +1,5 @@
 <tr>
-  <% barcode_name = barcode_item_row.item.name %>
-  <td><%= barcode_name %></td>
+  <td><%= barcode_item_row.item.name %></td>
   <td><%= barcode_item_row.quantity %></td>
   <td><%= barcode_item_row.value %></td>
   <td class="text-right">
@@ -8,7 +7,7 @@
       <%= link_to edit_barcode_item_path(barcode_item_row), class: "btn btn-info btn-xs" do %>
         <i class="fa fa-edit"></i> Edit
       <% end %>
-      <%= link_to barcode_item_path(barcode_item_row), method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(barcode_name) } do %>
+      <%= link_to barcode_item_path(barcode_item_row), method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(barcode_item_row.item.name) } do %>
         <i class="fa fa-trash"></i> Delete
       <% end %>
 </tr>

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= distribution_row.partner.name %></td>
-  <td><%= distribution_row.issued_at %> </td>  
+  <td><%= distribution_row.issued_at %> </td>
   <td><%= distribution_row.storage_location.name %></td>
   <td><%= distribution_row.line_items.total %></td>
   <td class="text-right">

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -1,6 +1,5 @@
 <tr>
-  <% partner_name = distribution_row.partner.name %>
-  <td><%= partner_name %></td>
+  <td><%= distribution_row.partner.name %></td>
   <td><%= distribution_row.issued_at %> </td>  
   <td><%= distribution_row.storage_location.name %></td>
   <td><%= distribution_row.line_items.total %></td>
@@ -9,7 +8,7 @@
     <%= link_to print_distribution_path(distribution_row, format: :pdf), class: "btn btn-info btn-xs" do %>
       <i class="fa fa-print"></i> Print
     <% end %>
-    <%= link_to reclaim_distribution_path(distribution_row), method: :post, data: { confirm: confirm_delete_msg(partner_name) }, class: "btn btn-danger btn-xs" do %>
+    <%= link_to reclaim_distribution_path(distribution_row), method: :post, data: { confirm: confirm_delete_msg(distribution_row.partner.name) }, class: "btn btn-danger btn-xs" do %>
       <i class="fa fa-undo"></i> Reclaim
     <% end %>
   </td>

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -1,6 +1,7 @@
 <tr>
-  <td><%= distribution_row.partner.name %></td>
-  <td><%= distribution_row.issued_at %> </td>
+  <% partner_name = distribution_row.partner.name %>
+  <td><%= partner_name %></td>
+  <td><%= distribution_row.issued_at %> </td>  
   <td><%= distribution_row.storage_location.name %></td>
   <td><%= distribution_row.line_items.total %></td>
   <td class="text-right">
@@ -8,7 +9,7 @@
     <%= link_to print_distribution_path(distribution_row, format: :pdf), class: "btn btn-info btn-xs" do %>
       <i class="fa fa-print"></i> Print
     <% end %>
-    <%= link_to reclaim_distribution_path(distribution_row), method: :post, data: { confirm: "Are you sure?" }, class: "btn btn-danger btn-xs" do %>
+    <%= link_to reclaim_distribution_path(distribution_row), method: :post, data: { confirm: confirm_delete_msg(partner_name) }, class: "btn btn-danger btn-xs" do %>
       <i class="fa fa-undo"></i> Reclaim
     <% end %>
   </td>

--- a/app/views/donation_sites/_donation_site_row.html.erb
+++ b/app/views/donation_sites/_donation_site_row.html.erb
@@ -1,12 +1,13 @@
 <tr>
-  <td><%= donation_site_row.name %></td>
+  <% site_name = donation_site_row.name %>
+  <td><%= site_name %></td>
   <td><%= donation_site_row.address %></td>
   <td class="text-right">
       <%= link_to "View", donation_site_row, class: "btn btn-primary btn-xs" %>
       <%= link_to edit_donation_site_path(donation_site_row), class: "btn btn-info btn-xs" do %>
         <i class="fa fa-edit"></i> Edit
       <% end %>
-      <%= link_to donation_site_row, method: :delete, class: "btn btn-danger btn-xs", data: { confirm: "Are you sure?" } do %>
+      <%= link_to donation_site_row, method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(site_name) } do %>
         <i class="fa fa-trash"></i> Trash
       <% end %>
   </td>

--- a/app/views/donation_sites/_donation_site_row.html.erb
+++ b/app/views/donation_sites/_donation_site_row.html.erb
@@ -1,13 +1,12 @@
 <tr>
-  <% site_name = donation_site_row.name %>
-  <td><%= site_name %></td>
+  <td><%= donation_site_row.name %></td>
   <td><%= donation_site_row.address %></td>
   <td class="text-right">
       <%= link_to "View", donation_site_row, class: "btn btn-primary btn-xs" %>
       <%= link_to edit_donation_site_path(donation_site_row), class: "btn btn-info btn-xs" do %>
         <i class="fa fa-edit"></i> Edit
       <% end %>
-      <%= link_to donation_site_row, method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(site_name) } do %>
+      <%= link_to donation_site_row, method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(donation_site_row.name) } do %>
         <i class="fa fa-trash"></i> Trash
       <% end %>
   </td>

--- a/app/views/items/_item_row.html.erb
+++ b/app/views/items/_item_row.html.erb
@@ -1,5 +1,6 @@
 <tr>
-  <td><%= item_row.name %></td>
+  <% item_name = item_row.name %>
+  <td><%= item_name %></td>
   <td><%= item_row.category %></td>
   <td><%= item_row.barcode_count %></td>
   <td class="text-right">
@@ -7,8 +8,8 @@
       <%= link_to edit_item_path(item_row), class: "btn btn-info btn-xs" do %>
         <i class="fa fa-edit"></i> Edit
       <% end %>
-      <%= link_to item_path(item_row), method: :delete, class: "btn btn-danger btn-xs" do %>
-        <i class="fa fa-trash"></i> Delete
+      <%= link_to item_path(item_row), method: :delete,  data: { confirm: confirm_delete_msg(item_name) },  class: "btn btn-danger btn-xs" do %>
+        <%= fa_icon "trash" %> Delete
       <% end %>
     </td>
 </tr>

--- a/app/views/items/_item_row.html.erb
+++ b/app/views/items/_item_row.html.erb
@@ -1,6 +1,5 @@
 <tr>
-  <% item_name = item_row.name %>
-  <td><%= item_name %></td>
+  <td><%= item_row.name %></td>
   <td><%= item_row.category %></td>
   <td><%= item_row.barcode_count %></td>
   <td class="text-right">
@@ -8,7 +7,7 @@
       <%= link_to edit_item_path(item_row), class: "btn btn-info btn-xs" do %>
         <i class="fa fa-edit"></i> Edit
       <% end %>
-      <%= link_to item_path(item_row), method: :delete,  data: { confirm: confirm_delete_msg(item_name) },  class: "btn btn-danger btn-xs" do %>
+      <%= link_to item_path(item_row), method: :delete,  data: { confirm: confirm_delete_msg(item_row.name) },  class: "btn btn-danger btn-xs" do %>
         <%= fa_icon "trash" %> Delete
       <% end %>
     </td>

--- a/app/views/partners/_partner_row.html.erb
+++ b/app/views/partners/_partner_row.html.erb
@@ -1,5 +1,6 @@
 <tr>
-  <td><%= partner_row.name %></td>
+  <% partner_name = partner_row.name %>
+  <td><%= partner_name %></td>
   <td><%= link_to partner_row.email, "mailto:#{partner_row.email}" %></td>
   <!-- <td><%== (rand < 0.7) ? '<span class="label label-success">Approved</span>' :
   '<span class="label label-warning">In Progress</span>' %></td> -->
@@ -7,7 +8,7 @@
       <%= link_to edit_partner_path(partner_row), class: "btn btn-info btn-xs" do %> 
         <i class="fa fa-edit"></i> Edit
       <% end %>
-      <%= link_to partner_path(partner_row), method: :delete, class: "btn btn-danger btn-xs", data: { confirm: "Are you sure?" } do %>
+      <%= link_to partner_path(partner_row), method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(partner_name) } do %>
         <i class="fa fa-trash"></i> Delete
       <% end %>
   </td>

--- a/app/views/partners/_partner_row.html.erb
+++ b/app/views/partners/_partner_row.html.erb
@@ -1,6 +1,5 @@
 <tr>
-  <% partner_name = partner_row.name %>
-  <td><%= partner_name %></td>
+  <td><%= partner_row.name %></td>
   <td><%= link_to partner_row.email, "mailto:#{partner_row.email}" %></td>
   <!-- <td><%== (rand < 0.7) ? '<span class="label label-success">Approved</span>' :
   '<span class="label label-warning">In Progress</span>' %></td> -->
@@ -8,7 +7,7 @@
       <%= link_to edit_partner_path(partner_row), class: "btn btn-info btn-xs" do %> 
         <i class="fa fa-edit"></i> Edit
       <% end %>
-      <%= link_to partner_path(partner_row), method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(partner_name) } do %>
+      <%= link_to partner_path(partner_row), method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(partner_row.name) } do %>
         <i class="fa fa-trash"></i> Delete
       <% end %>
   </td>

--- a/app/views/storage_locations/_storage_location_row.html.erb
+++ b/app/views/storage_locations/_storage_location_row.html.erb
@@ -1,6 +1,5 @@
 <tr>
-  <% loc_name = storage_location.name %>
-  <td><%= loc_name %></td>
+  <td><%= storage_location.name %></td>
   <td><%= storage_location.address %></td>
   <td><%= storage_location.size %></td>
   <td class="text-right">
@@ -8,7 +7,7 @@
   <%= link_to edit_storage_location_path(storage_location), class: "btn btn-info btn-xs" do %>
     <i class="fa fa-edit"></i> Edit
   <% end %>
-  <%= link_to storage_location, method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(loc_name) } do %>
+  <%= link_to storage_location, method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(storage_location.name) } do %>
     <i class="fa fa-trash"></i> Delete
   <% end %>
   </td>

--- a/app/views/storage_locations/_storage_location_row.html.erb
+++ b/app/views/storage_locations/_storage_location_row.html.erb
@@ -1,5 +1,6 @@
 <tr>
-  <td><%= storage_location.name %></td>
+  <% loc_name = storage_location.name %>
+  <td><%= loc_name %></td>
   <td><%= storage_location.address %></td>
   <td><%= storage_location.size %></td>
   <td class="text-right">
@@ -7,7 +8,7 @@
   <%= link_to edit_storage_location_path(storage_location), class: "btn btn-info btn-xs" do %>
     <i class="fa fa-edit"></i> Edit
   <% end %>
-  <%= link_to storage_location, method: :delete, class: "btn btn-danger btn-xs", data: { confirm: "Are you sure?" } do %>
+  <%= link_to storage_location, method: :delete, class: "btn btn-danger btn-xs", data: { confirm: confirm_delete_msg(loc_name) } do %>
     <i class="fa fa-trash"></i> Delete
   <% end %>
   </td>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe 'confirm_delete_msg' do
+    let(:item) { 'Adult Briefs (Medium/Large)' }
+
+    it "subs in string" do
+      expect(helper.confirm_delete_msg(item)).to include(item)
+    end
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,8 +1,8 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ApplicationHelper, type: :helper do
-  describe 'confirm_delete_msg' do
-    let(:item) { 'Adult Briefs (Medium/Large)' }
+  describe "confirm_delete_msg" do
+    let(:item) { "Adult Briefs (Medium/Large)" }
 
     it "subs in string" do
       expect(helper.confirm_delete_msg(item)).to include(item)


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #356 

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Currently, it is too easy to delete data. This code adds an "are you sure you want to delete?" prompt which requires the person to approve the request prior to final deletion.

### Type of change
Added a helper in `application_helper` for confirmation delete messages. I checked to make sure that we are adding confirmation messages for other delete actions and doing it consistently.

<!-- Please delete options that are not relevant. -->
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Added a spec file for `application_helper`.

### Screenshots
<img width="450" alt="screen shot 2018-06-08 at 10 34 30 am" src="https://user-images.githubusercontent.com/8137314/41163774-91388220-6b07-11e8-81e3-dca1d4c60125.png">
