### PR TITLE
Removed timestamp from Inventory Adjustments page

### DIFF
--- a/app/views/adjustments/index.html.erb
+++ b/app/views/adjustments/index.html.erb
@@ -59,7 +59,7 @@
               <tbody>
                 <% @adjustments.each do |adjustment| %>
                   <tr>
-                    <td><time datetime="<%= adjustment.created_at %>"><%= adjustment.created_at.strftime("%B %e, %Y (%l:%M%P %Z)") %></time></td>
+                    <td><time datetime="<%= adjustment.created_at %>"><%= adjustment.created_at.strftime("%B %e, %Y") %></time></td>
                     <td><%= adjustment.organization.name %></td>
                     <td><%= adjustment.storage_location.name %></td>
                     <td><%= adjustment.comment %></td>


### PR DESCRIPTION
Resolves #357 

**Description**

Removed timestamp from create_at attribute display.

**Screenshots**
<img width="1571" alt="screen shot 2018-06-08 at 3 12 02 pm" src="https://user-images.githubusercontent.com/9901121/41176434-5a846902-6b2e-11e8-85e8-79dbf17f5e8f.png">
