### PR TITLE
Dashboard add diaper drive info

### DIFF
--- a/app/views/dashboard/_diaper_drive.html.erb
+++ b/app/views/dashboard/_diaper_drive.html.erb
@@ -1,0 +1,7 @@
+<div class="row">
+  <div class="pull-left">
+    <%= link_to donation do %>
+      <%= donation.line_items.total %> from <%= donation.diaper_drive_participant.name %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -46,7 +46,7 @@
                   <%= link_to "Make an adjustment", new_adjustment_path, class: "btn btn-primary btn-xs" %>
                 </div>
               </div>
-            </div>          
+            </div>
           </div>
         </div>
       </div>
@@ -119,6 +119,26 @@
               </div>
             </div>
           </div>
+          <div class="box box-success">
+            <div class="box-header with-border">
+              <h3 class="box-title">Diaper Drives</h3>
+              <div class="box-tools pull-right">
+                <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-minus"></i>
+                </button>
+                <button type="button" class="btn btn-box-tool" data-widget="remove"><i class="fa fa-times"></i></button>
+              </div>
+            </div>
+            <div class="box-body text-center float-center">
+              <h3 class="text-center"><%= @recent_donations.by_source(:diaper_drive).count %> Diaper Drives <%= display_interval %> for a total of <%= number_with_delimiter(@recent_donations.by_source(:diaper_drive).sum { |d| d.line_items.total }) %> items collected</h3>
+            </div>
+            <div class="box-body">
+              <div class="box-body text-center float-center">
+              <h4>Recent Donations from Diaper Drives</h4>
+              <%= render partial: "diaper_drive", collection: @recent_donations.by_source(:diaper_drive), as: :donation %>
+              <%= link_to "See more...", donations_path %>
+              </div>
+            </div>
+          </div>
           <div class="box box-info">
             <div class="box-header with-border">
               <h3 class="box-title">Purchases</h3>
@@ -161,12 +181,12 @@
             <div class="box-body">
               <div class="chart">
                 <h5 class="text-center">Item categories on hand <%= display_interval %></h5>
-                <%= pie_chart pie_chart_data, legend: "right" %> 
+                <%= pie_chart pie_chart_data, legend: "right" %>
               </div>
             </div>
           </div>
         </div>
       </div>
     </div>
-  </div>  
+  </div>
 </section>

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -43,6 +43,7 @@ RSpec.feature "Dashboard", type: :feature do
     visit @url_prefix + "/dashboard"
     expect(page).to have_content("210 items received year to date")
     expect(page).to have_content("105 items distributed year to date")
+    expect(page).to have_content("0 Diaper Drives")
 
     # Scope it down to just today, should omit the first donation
     #select "Yesterday", from: "dashboard_filter_interval" # LET'S PRETEND BECAUSE OF REASONS!
@@ -75,10 +76,19 @@ RSpec.feature "Dashboard", type: :feature do
     fill_in "donation_line_items_attributes_0_quantity", with: "100"
     click_button "Create Donation"
 
+    # Make a diaper drive donation
+    visit @url_prefix + "/donations/new"
+    select "Diaper Drive", from: "donation_source"
+    select DiaperDriveParticipant.first.name, from: "donation_diaper_drive_participant_id"
+    select StorageLocation.first.name, from: "donation_storage_location_id"
+    select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
+    fill_in "donation_line_items_attributes_0_quantity", with: "100"
+    click_button "Create Donation"
+
     # Check the dashboard now
     visit @url_prefix + "/dashboard"
-    expect(page).to have_content("100 items received")
-    expect(page).to have_content("100 items on-hand")
+    expect(page).to have_content("200 items received")
+    expect(page).to have_content("200 items on-hand")
 
     # Check distributions
     visit @url_prefix + "/distributions/new"
@@ -93,8 +103,9 @@ RSpec.feature "Dashboard", type: :feature do
 
     # Check the dashboard now
     visit @url_prefix + "/dashboard"
-    expect(page).to have_content("100 items received")
+    expect(page).to have_content("200 items received")
     expect(page).to have_content("50 items distributed")
-    expect(page).to have_content("50 items on-hand")
+    expect(page).to have_content("150 items on-hand")
+    expect(page).to have_content("1 Diaper Drives")
   end
 end


### PR DESCRIPTION

Resolves #362 

### Description
Adds information about donations specific to diaper drives including how many diaper drives took place and how many items were collected from those diaper drives. Change was requested by Stakeholder.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Feature specs added and click tested

### Screenshots
<img width="575" alt="screen shot 2018-06-08 at 2 27 35 pm" src="https://user-images.githubusercontent.com/2354079/41175023-c25a40a6-6b29-11e8-8634-10b6bec43ecf.png">

