### PR TITLE
Switches to depend on chrome-headless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,9 @@ RUN sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ jessie-pgdg main" 
 RUN apt-get update
 RUN apt-get install -y postgresql-client-9.5
 
-# Install phantomjs for rspec
-ARG PHANTOM_VERSION=2.1.1
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install -y curl fontconfig cmake \
-    && cd /tmp \
-    && curl -L -O https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOM_VERSION}-linux-x86_64.tar.bz2 \
-    && tar xvjf phantomjs-${PHANTOM_VERSION}-linux-x86_64.tar.bz2 \
-    && cp /tmp/phantomjs-*/bin/phantomjs /usr/local/bin/phantomjs
+# Install Chrome for headless testing
+COPY /bin/install-chrome.sh /bin/install-chrome.sh
+RUN /bin/install-chrome.sh
 
 RUN mkdir /app
 WORKDIR /app

--- a/bin/install-chrome.sh
+++ b/bin/install-chrome.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -xeo pipefail
+
+
+curl -sS -L https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google.list
+
+apt-get update -q
+env DEBIAN_FRONTEND="noninteractive" apt-get install -y unzip google-chrome-stable
+rm -rf /var/lib/apt/lists/*
+
+
+# Install ChromeDriver
+wget -q https://chromedriver.storage.googleapis.com/2.40/chromedriver_linux64.zip
+unzip chromedriver_linux64.zip -d /usr/local/bin
+rm -f chromedriver_linux64.zip


### PR DESCRIPTION
Previously we pulled in poltergeist, but with #328 we need to change the dependency to get docker-dev working again. Travis worked because it pulls in its own chrome dependency in .travis.yml