### PR TITLE
Code cleanup: Remove unnecessary TODO item

### DIFF
--- a/TODO
+++ b/TODO
@@ -21,7 +21,6 @@ app/models/inventory_item.rb:
   * [ 30] [TODO] is there a reason for doing this instead of setting a DB default?
 
 app/models/storage_location.rb:
-  * [ 68] [TODO] Can remove! and adjust_from_past! be refactored into one method?
   * [146] [TODO] - this action is happening in the Transfer model/controller - does this method belong here?
   * [170] [TODO] - this is called from the AdjustmentsController, should probably be in a service, not this model
   * [193] [TODO] - this action is happening in the DistributionsController. Is this model the correct place for this method?

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -87,7 +87,6 @@ class StorageLocation < ApplicationRecord
     log
   end
 
-  # TODO: Can remove! and adjust_from_past! be refactored into one method?
   def remove!(donation_or_purchase)
     log = {}
     donation_or_purchase.line_items.each do |line_item|


### PR DESCRIPTION
### Description
https://github.com/rubyforgood/diaper/issues/310 is to go through TODO items in the codebase. This PR addresses one of those TODO items by deleting the TODO item.

### Notes on why delete TODO item with no code change
Seems like it's fine to keep these two methods separate.
* remove! gets called from methods like "delete_inventory"
* adjust_from_past! gets called from "update" methods
* There's overlap in their functions, but they're two different ideas
* specs would get more complicated with overlap
  * Less easy for a new dev to read the purpose of the combined function

https://github.com/rubyforgood/diaper/issues/310

# Checklist:

- [x] I have performed a self-review of my own code,
- [x] ~I have commented my code, particularly in hard-to-understand areas,~
- [x] I have made corresponding changes to the documentation,
- [x] ~I have added tests that prove my fix is effective or that my feature works,~
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] ~Title include "WIP" if work is in progress.~

