### PR TITLE
Code cleanup: delete unnecessary TODO

### DIFF
--- a/TODO
+++ b/TODO
@@ -41,9 +41,6 @@ spec/features/item_spec.rb:
 spec/models/distribution_spec.rb:
   * [ 89] [TODO] Can this be replaced with the `combine!` method from `Itemizable`?
 
-spec/models/storage_location_spec.rb:
-  * [157] [TODO] This should probably be DRYed out with a shared_example
-
 spec/support/authorization_specs.rb:
   * [  1] [TODO] Why are there two groups that are doing the same thing?
   * [ 18] [FIXME] Not all controllers have `edit` actions (or other), and this should be able to adapt to that

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe StorageLocation, type: :model do
           }.to change{storage_location.size}.by(5)
           .and change{InventoryItem.count}.by(1)
         end
-      
+
         it "removes the inventory item from the DB if the item's removal results in a 0 count" do
           donation.line_items.first.update(quantity: 0)
 
@@ -154,11 +154,10 @@ RSpec.describe StorageLocation, type: :model do
           .and change{InventoryItem.count}.by(-1)
         end
       end
-       # TODO: This should probably be DRYed out with a shared_example
       context "With purchases" do
         before(:each) do
           storage_location.intake!(purchase)
-          storage_location.items.reload  
+          storage_location.items.reload
         end
         it "add additional line item" do
           item = create(:item)
@@ -175,7 +174,7 @@ RSpec.describe StorageLocation, type: :model do
           }.to change{storage_location.size}.by(5)
           .and change{InventoryItem.count}.by(1)
         end
-  
+
         it "removes the inventory item from the DB if the item's removal results in a 0 count" do
           purchase.line_items.first.update(quantity: 0)
 


### PR DESCRIPTION
### Description
https://github.com/rubyforgood/diaper/issues/310 is to go through TODO items in the codebase. This PR addresses one of those TODO items by deleting the TODO item.

### Notes on why delete TODO item with no code change
These specs shouldn't be DRYed further.
While the `expect{...}` looks repeated, everything else in the specs are different.

# Checklist:

- [x] I have performed a self-review of my own code,
- [x] ~I have commented my code, particularly in hard-to-understand areas,~
- [x] I have made corresponding changes to the documentation,
- [x] ~I have added tests that prove my fix is effective or that my feature works,~
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] ~Title include "WIP" if work is in progress.~

