### PR TITLE
Moves the delete function to the right and adds a nice trashcan icon …

### DIFF
--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,7 +1,9 @@
 <div class="nested-fields">
-  <%= link_to_remove_association "X", f, class: "btn btn-sm btn-danger" %>
   <%= render partial: "barcode_items/barcode_item_lookup" %>
   <label>OR</label>
   <%= f.input_field :item_id, collection: @items, prompt: "Choose an item", class: 'form-control' %>
   <%= f.input_field :quantity, placeholder: "Quantity", class: 'form-control' %>
+  <%= link_to_remove_association f, class: "btn btn-sm btn-danger"  do %>
+    <%= fa_icon "trash" %> Delete
+  <% end %> 
 </div>

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -133,7 +133,7 @@ RSpec.feature "Donations", type: :feature, js: true do
         page.find(:css, "#__add_line_item").click
         select_id = page.find(:xpath, '//*[@id="donation_line_items"]/div[2]/select')[:id]
         select Item.alphabetized.first.name, from: select_id
-        text_id = page.find(:xpath, '//*[@id="donation_line_items"]/div[2]/input[3]')[:id]
+        text_id = page.find(:xpath, '//*[@id="donation_line_items"]/div[2]/input[2]')[:id]
         fill_in text_id, with: "10"
 
         expect {

--- a/spec/features/purchase_spec.rb
+++ b/spec/features/purchase_spec.rb
@@ -66,7 +66,7 @@ RSpec.feature "Purchases", type: :feature, js: true do
         page.find(:css, "#__add_line_item").click
         select_id = page.find(:xpath, '//*[@id="purchase_line_items"]/div[2]/select')[:id]
         select Item.alphabetized.first.name, from: select_id
-        text_id = page.find(:xpath, '//*[@id="purchase_line_items"]/div[2]/input[3]')[:id]
+        text_id = page.find(:xpath, '//*[@id="purchase_line_items"]/div[2]/input[2]')[:id]
         fill_in text_id, with: "10"
         fill_in "purchase_amount_spent", with: "10"
 

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Donation, type: :model do
     describe "contains_item_id?" do
       it "returns true if the item_id already exists" do
         donation = create(:donation, :with_items)
-        expect(donation.contains_item_id?(donation.items.first.id)).to be_truthy
+        expect(donation.contains_item_id?(donation.items.last.id)).to be_truthy
       end
     end
 
@@ -179,7 +179,7 @@ RSpec.describe Donation, type: :model do
         expect {
           donation.destroy
         }.to change{donation.storage_location.size}.by(-donation.total_quantity)
-      end  
+      end
     end
   end
 


### PR DESCRIPTION
Resolves issue #395 

### Description

Moves the delete function to the right and adds a nice trashcan icon. @armahillo  and I spoke to a UX expert and this suggestion came up to make the delete button here consistent with the other delete buttons in the app. The stakeholder @pdxdiaperbank also wanted this change. 
   
### Type of change

* New feature (non-breaking change which adds functionality)


