### PR TITLE
Bug inventory updating problem when removing line item

### DIFF
--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -64,8 +64,7 @@ module Itemizable
 
   def line_items_quantities
     line_items.inject(Hash.new) do |hash, line_item|
-      hash[line_item.id] = OpenStruct
-        .new(quantity: line_item.quantity, item_id: line_item.item_id)
+      hash[line_item.id] = OpenStruct.new(quantity: line_item.quantity, item_id: line_item.item_id)
       hash
     end
   end

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -63,8 +63,9 @@ module Itemizable
   end
 
   def line_items_quantities
-    line_items.inject(Hash.new) do |hash, item|
-      hash[item.id] = item.quantity
+    line_items.inject(Hash.new) do |hash, line_item|
+      hash[line_item.id] = OpenStruct
+        .new(quantity: line_item.quantity, item_id: line_item.item_id)
       hash
     end
   end

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -101,15 +101,22 @@ class StorageLocation < ApplicationRecord
     log
   end
 
-  def adjust_from_past!(donation_or_purchase, previous_quantities)
+  def adjust_from_past!(donation_or_purchase, previous_line_item_values)
     donation_or_purchase.line_items.each do |line_item|
       inventory_item = InventoryItem.find_or_create_by(storage_location_id: self.id, item_id: line_item.item_id)
-      if previous_quantity = previous_quantities[line_item.id]
+      if previous_line_item_value = previous_line_item_values.delete(line_item.id)
         inventory_item.quantity += line_item.quantity
-        inventory_item.quantity -= previous_quantity
+        inventory_item.quantity -= previous_line_item_value.quantity
         inventory_item.save!
       end
       inventory_item.destroy! if inventory_item.quantity == 0
+    end
+    # Update storage for line items that are no longer persisted because they
+    # were removed durring the updated/delete process.
+    previous_line_item_values.each do |key, value|
+      inventory_item = InventoryItem
+        .find_or_create_by(storage_location_id: self.id, item_id: value.item_id)
+      inventory_item.decrement!(:quantity, value.quantity)
     end
   end
 

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -114,8 +114,7 @@ class StorageLocation < ApplicationRecord
     # Update storage for line items that are no longer persisted because they
     # were removed durring the updated/delete process.
     previous_line_item_values.values.each do |value|
-      inventory_item = InventoryItem
-        .find_or_create_by(storage_location_id: self.id, item_id: value.item_id)
+      inventory_item = InventoryItem.find_or_create_by(storage_location_id: self.id, item_id: value.item_id)
       inventory_item.decrement!(:quantity, value.quantity)
       inventory_item.destroy! if inventory_item.quantity == 0
     end

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -113,10 +113,11 @@ class StorageLocation < ApplicationRecord
     end
     # Update storage for line items that are no longer persisted because they
     # were removed durring the updated/delete process.
-    previous_line_item_values.each do |key, value|
+    previous_line_item_values.values.each do |value|
       inventory_item = InventoryItem
         .find_or_create_by(storage_location_id: self.id, item_id: value.item_id)
       inventory_item.decrement!(:quantity, value.quantity)
+      inventory_item.destroy! if inventory_item.quantity == 0
     end
   end
 

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -104,6 +104,8 @@ class StorageLocation < ApplicationRecord
   def adjust_from_past!(donation_or_purchase, previous_line_item_values)
     donation_or_purchase.line_items.each do |line_item|
       inventory_item = InventoryItem.find_or_create_by(storage_location_id: self.id, item_id: line_item.item_id)
+      # If the item wasn't deleted by the user, then it will be present to be deleted
+      # here, and delete returns the item as a return value.
       if previous_line_item_value = previous_line_item_values.delete(line_item.id)
         inventory_item.quantity += line_item.quantity
         inventory_item.quantity -= previous_line_item_value.quantity

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -69,6 +69,24 @@ RSpec.describe DonationsController, type: :controller do
           put :update, params: default_params.merge(id: donation.id, donation: donation_params)
         }.to change { donation.storage_location.inventory_items.first.quantity }.by(5)
       end
+
+      describe "when removing a line item" do
+        it "updates storage quantity correctly" do
+          donation = create(:donation, :with_items, item_quantity: 10)
+          line_item = donation.line_items.first
+          line_item_params = {
+            "0" => {
+              "_destroy" => "true",
+              item_id: line_item.item_id,
+              id: line_item.id
+            }
+          }
+          donation_params = { source: "Donation Site", line_items_attributes: line_item_params }
+          expect {
+            put :update, params: default_params.merge(id: donation.id, donation: donation_params)
+          }.to change { donation.storage_location.inventory_items.first.quantity }.by(-10)
+        end
+      end
     end
 
     describe "GET #edit" do

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe DonationsController, type: :controller do
       end
 
       describe "when removing a line item" do
-        it "updates storage quantity correctly" do
+        it "updates storage invetory item quantity correctly" do
           donation = create(:donation, :with_items, item_quantity: 10)
           line_item = donation.line_items.first
           line_item_params = {
@@ -85,6 +85,23 @@ RSpec.describe DonationsController, type: :controller do
           expect {
             put :update, params: default_params.merge(id: donation.id, donation: donation_params)
           }.to change { donation.storage_location.inventory_items.first.quantity }.by(-10)
+        end
+
+        it "deletes inventory item if line item and inventory item quantities are equal" do
+          donation = create(:donation, :with_items, item_quantity: 1)
+          line_item = donation.line_items.first
+          inventory_item = donation.storage_location.inventory_items.first
+          inventory_item.update(quantity: line_item.quantity)
+          line_item_params = {
+            "0" => {
+              "_destroy" => "true",
+              item_id: line_item.item_id,
+              id: line_item.id
+            }
+          }
+          donation_params = { source: "Donation Site", line_items_attributes: line_item_params }
+          put :update, params: default_params.merge(id: donation.id, donation: donation_params)
+          expect { inventory_item.reload }.to raise_error(ActiveRecord::RecordNotFound)
         end
       end
     end

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe PurchasesController, type: :controller do
 
       describe "when removing a line item" do
         it "updates storage invetory item quantity correctly" do
-          inventory_item = purchase.storage_location.inventory_items.first
           purchase = create(:purchase, :with_items, item_quantity: 10)
           line_item = purchase.line_items.first
           line_item_params = {
@@ -86,7 +85,7 @@ RSpec.describe PurchasesController, type: :controller do
           purchase_params = { source: "Purchase Site", line_items_attributes: line_item_params }
           expect {
             put :update, params: default_params.merge(id: purchase.id, purchase: purchase_params)
-          }.to change { inventory.reload.quantity }.by(-10)
+          }.to change { purchase.storage_location.inventory_items.first.quantity }.by(-10)
         end
 
         it "deletes inventory item if line item and inventory item quantities are equal" do

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -70,6 +70,24 @@ RSpec.describe PurchasesController, type: :controller do
           put :update, params: default_params.merge(id: purchase.id, purchase: purchase_params)
         }.to change { purchase.storage_location.inventory_items.first.quantity }.by(-5)
       end
+
+      describe "when removing a line item" do
+        it "updates storage quantity correctly" do
+          purchase = create(:purchase, :with_items, item_quantity: 10)
+          line_item = purchase.line_items.first
+          line_item_params = {
+            "0" => {
+              "_destroy" => "true",
+              item_id: line_item.item_id,
+              id: line_item.id
+            }
+          }
+          purchase_params = { source: "Purchase Site", line_items_attributes: line_item_params }
+          expect {
+            put :update, params: default_params.merge(id: purchase.id, purchase: purchase_params)
+          }.to change { purchase.storage_location.inventory_items.first.quantity }.by(-10)
+        end
+      end
     end
 
     describe "GET #edit" do


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #407 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
When we remove a line item from a donation or a purchase, we now update the storage `InventoryQuantity` to reflect the correct value.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- controller specs for donations and purchases
<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
