### PR TITLE
Onboarding Design for Importing Partners

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -53,3 +53,37 @@ tr.negative {
 tr.positive {
   background-color: #DFD;
 }
+
+
+/* ONBOARDING MODAL BOX */
+
+.modal-dialog h4.modal-title {
+	font-family: 'Source Sans Pro',sans-serif;
+}
+
+.modal-dialog.onboarding_steps .modal-body,
+.modal-dialog.onboarding_steps .modal-footer {
+	font-family: 'Source Sans Pro',sans-serif;
+	text-align: center;
+}
+
+.modal-dialog.onboarding_steps .modal-body h3 {
+	margin-top: 30px;
+}
+
+.modal-dialog.onboarding_steps .modal-body ul {
+	list-style: none; 
+	padding: 0;
+}
+
+.modal-dialog.onboarding_steps .modal-body li {
+	line-height: 1.25em;
+	margin-bottom: 15px;
+	color: #555;
+}
+
+@media (min-width: 768px) {
+	.modal-dialog.onboarding_steps {
+	  width: 700px;
+	}
+}

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -103,38 +103,3 @@
     </div><!-- /.box-body -->
   </div><!-- /.box -->
 </section><!-- /.content -->
-
-
-<style>
-
-  @media (min-width: 768px) {
-    .modal-dialog.onboarding_steps {
-      width: 700px;
-    }
-  }
-
-  .modal-dialog h4.modal-title {
-    font-family: 'Source Sans Pro',sans-serif;
-  }
-
-  .modal-dialog.onboarding_steps .modal-body {
-    font-family: 'Source Sans Pro',sans-serif;
-    text-align: center;
-  } 
-  .modal-dialog.onboarding_steps .modal-body h3 {
-    margin-top: 30px;
-  }
-
-  .modal-dialog.onboarding_steps .modal-body ul {
-    list-style: none; 
-    padding: 0;
-  }
-  .modal-dialog.onboarding_steps .modal-body li {
-    line-height: 1.25em;
-    margin-bottom: 15px;
-    color: #555;
-  }
-  .modal-dialog.onboarding_steps .modal-footer {
-    text-align: center;
-  }  
-</style>

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -31,49 +31,51 @@
 
           <!-- Modal HTML -->
           <div id="importPartnerModal" class="modal fade">
-          <div class="modal-dialog">
+          <div class="modal-dialog onboarding_steps">
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h2 class="modal-title">Import Partners Instructions:</h4>
+                    <h4 class="modal-title">Import Partners Instructions:</h4>
                 </div><!-- /.modal-header -->
-                <div class="modal-body onboarding_steps" style="text-align: center;padding-top: 20px;">
+                <div class="modal-body">
                   <div class="row">
-                    <div class="col-lg-6 col-md-12">
-                      <i class="fa fa-download fa-5x" aria-hidden="true"></i>
-                      <h3>Download example CSV file</h3>
-                      <ul style="list-style: none; padding: 0;">
+                    <div class="col-md-6 col-sm-12" style="padding-top: 30px;">
+                      <i class="fa fa-download fa-4x" aria-hidden="true"></i>
+                      <h3 class="text-info">1. Download example CSV file</h3>
+                      <ul>
                         <li>Open the csv file with excel <br>or your favourite spreadsheet program.</li>
                         <li>Delete the sample data and <br>enter your partner agency names and <br>addresses in the appropriate columns.</li>
-                        <li>Save the file as a csv file.</sli>
+                        <li>Save the file as a csv file.</li>
                         <li><%= link_to "/partners.csv", :format => :csv, :class => "btn btn-md btn-info" do %><i class="fa fa-download"></i> Download example CSV <% end %></li>
                       </ul>
                     </div>
-                    <div class="col-lg-6 col-md-12">
-                      <i class="fa fa-file-text-o fa-5x" aria-hidden="true"></i>
-                      <h3>Upload your CSV file.</h3>
-                      <ul style="list-style: none; padding: 0;">
+                    <div class="col-md-6 col-sm-12" style="padding-top: 30px;">
+                      <i class="fa fa-file-text-o fa-4x" aria-hidden="true"></i>
+                      <h3 class="text-info">2. Upload your CSV file</h3>
+                      <ul>
                         <li>Click the choose file button and <br>navigate to the saved file and select it.</li>
                         <li>
                           <%= form_tag import_csv_partners_path, multipart: true do %>
-                          <div class="form-group">
+                          <div class="form-group" style="margin: 0 auto 15px; width: 202px;">
                             <%= file_field_tag :file, :accept => 'text/csv', class: "form-control-file" %>
                           </div>
                           <% end #form %>
                         </li>
-                        <li>Then click the "Import CSV" button <br>to import your storage locations.</li>
-                        <li><small>Note: You're only able to run the import one time to prevent accidental imports or writing over existing locations!</small></li>
-                        <%= form_tag import_csv_partners_path, multipart: true do %>
-                          <li>
-                            <%= button_tag :class => "btn btn-md btn-primary" do %>
+                        <li style="margin-bottom: 27px;">Then click the "Import CSV" button <br>to import your storage locations.</li>
+                        <li>
+                          <%= form_tag import_csv_partners_path, multipart: true do %>
+                            <%= button_tag :class => "btn btn-md btn-info" do %>
                               <i class="fa fa-upload"></i> Import CSV
                             <% end #button %>
-                          </li>
-                        <% end #form %>
+                          <% end #form %>
+                        </li>
                       </ul>
                     </div>
-                  </div>
+                  </div><!-- / row -->
                 </div><!-- /.modal-body -->
+                <div class="modal-footer">
+                  <small>Note: You're only able to run the import one time to prevent accidental imports or writing over existing locations!</small>
+                </div><!-- /.modal-footer -->
               </div><!-- /.modal-content -->
             </div><!-- /.modal-dialog -->
           </div><!-- /.modal -->
@@ -101,3 +103,38 @@
     </div><!-- /.box-body -->
   </div><!-- /.box -->
 </section><!-- /.content -->
+
+
+<style>
+
+  @media (min-width: 768px) {
+    .modal-dialog.onboarding_steps {
+      width: 700px;
+    }
+  }
+
+  .modal-dialog h4.modal-title {
+    font-family: 'Source Sans Pro',sans-serif;
+  }
+
+  .modal-dialog.onboarding_steps .modal-body {
+    font-family: 'Source Sans Pro',sans-serif;
+    text-align: center;
+  } 
+  .modal-dialog.onboarding_steps .modal-body h3 {
+    margin-top: 30px;
+  }
+
+  .modal-dialog.onboarding_steps .modal-body ul {
+    list-style: none; 
+    padding: 0;
+  }
+  .modal-dialog.onboarding_steps .modal-body li {
+    line-height: 1.25em;
+    margin-bottom: 15px;
+    color: #555;
+  }
+  .modal-dialog.onboarding_steps .modal-footer {
+    text-align: center;
+  }  
+</style>

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -45,50 +45,35 @@
                       <ul style="list-style: none; padding: 0;">
                         <li>Open the csv file with excel <br>or your favourite spreadsheet program.</li>
                         <li>Delete the sample data and <br>enter your partner agency names and <br>addresses in the appropriate columns.</li>
-                        <li>Save the file as a csv file.</li>
-                        <li><%= link_to "/partners.csv", :format => :csv, :class => "btn btn-xs btn-info" do %><i class="fa fa-download"></i> Download example CSV <% end %></li>
+                        <li>Save the file as a csv file.</sli>
+                        <li><%= link_to "/partners.csv", :format => :csv, :class => "btn btn-md btn-info" do %><i class="fa fa-download"></i> Download example CSV <% end %></li>
                       </ul>
                     </div>
                     <div class="col-lg-6 col-md-12">
                       <i class="fa fa-file-text-o fa-5x" aria-hidden="true"></i>
                       <h3>Upload your CSV file.</h3>
                       <ul style="list-style: none; padding: 0;">
-                        <li>Click the choose file button and <br>navigate to the saved file and select it.<br>
+                        <li>Click the choose file button and <br>navigate to the saved file and select it.</li>
+                        <li>
+                          <%= form_tag import_csv_partners_path, multipart: true do %>
+                          <div class="form-group">
+                            <%= file_field_tag :file, :accept => 'text/csv', class: "form-control-file" %>
+                          </div>
+                          <% end #form %>
                         </li>
                         <li>Then click the "Import CSV" button <br>to import your storage locations.</li>
-                        <div>
-                          <%= form_tag import_csv_partners_path, multipart: true do %>
-                            <div class="form-group">
-                              <%= file_field_tag :file, :accept => 'text/csv', class: "form-control-file" %>
-                            </div>
-                            <%= button_tag :class => "btn btn-lg btn-primary" do %>
+                        <li><small>Note: You're only able to run the import one time to prevent accidental imports or writing over existing locations!</small></li>
+                        <%= form_tag import_csv_partners_path, multipart: true do %>
+                          <li>
+                            <%= button_tag :class => "btn btn-md btn-primary" do %>
                               <i class="fa fa-upload"></i> Import CSV
                             <% end #button %>
-                          <% end #form %>
-                        </div><!-- /.modal-footer -->                        
+                          </li>
+                        <% end #form %>
                       </ul>
-                      <ol>
-                        <li><%= link_to "/partners.csv", :format => :csv, :class => "btn btn-xs btn-info" do %><i class="fa fa-download"></i> Download example CSV <% end %></li>
-                        <li>Open the csv file with excel or your favourite spreadsheet program.</li>
-                        <li>Delete the sample data and enter your partner agency names and addresses in the appropriate columns.</li>
-                        <li>Save the file as a csv file.</li>
-                        <li>Click the choose file button and navigate to the saved file and select it.</li>
-                        <li>Then click the Import CSV button to import your storage locations.</li>
-                      </ol>
-                      <p class="text-warning"><small>Note: You're only able to run the import one time to prevent accidental imports or writing over existing locations!</small></p>
                     </div>
                   </div>
                 </div><!-- /.modal-body -->
-                <div class="modal-footer">
-                  <%= form_tag import_csv_partners_path, multipart: true do %>
-                    <div class="form-group">
-                      <%= file_field_tag :file, :accept => 'text/csv', class: "form-control-file" %>
-                    </div>
-                    <%= button_tag :class => "btn btn-lg btn-primary" do %>
-                      <i class="fa fa-upload"></i> Import CSV
-                    <% end #button %>
-                  <% end #form %>
-                </div><!-- /.modal-footer -->
               </div><!-- /.modal-content -->
             </div><!-- /.modal-dialog -->
           </div><!-- /.modal -->

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -37,16 +37,47 @@
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                     <h2 class="modal-title">Import Partners Instructions:</h4>
                 </div><!-- /.modal-header -->
-                <div class="modal-body">
-                  <ol>
-                    <li><%= link_to "/partners.csv", :format => :csv, :class => "btn btn-xs btn-info" do %><i class="fa fa-download"></i> Download example CSV <% end %></li>
-                    <li>Open the csv file with excel or your favourite spreadsheet program.</li>
-                    <li>Delete the sample data and enter your partner agency names and addresses in the appropriate columns.</li>
-                    <li>Save the file as a csv file.</li>
-                    <li>Click the choose file button and navigate to the saved file and select it.</li>
-                    <li>Then click the Import CSV button to import your storage locations.</li>
-                  </ol>
-                  <p class="text-warning"><small>Note: You're only able to run the import one time to prevent accidental imports or writing over existing locations!</small></p>
+                <div class="modal-body onboarding_steps" style="text-align: center;padding-top: 20px;">
+                  <div class="row">
+                    <div class="col-lg-6 col-md-12">
+                      <i class="fa fa-download fa-5x" aria-hidden="true"></i>
+                      <h3>Download example CSV file</h3>
+                      <ul style="list-style: none; padding: 0;">
+                        <li>Open the csv file with excel <br>or your favourite spreadsheet program.</li>
+                        <li>Delete the sample data and <br>enter your partner agency names and <br>addresses in the appropriate columns.</li>
+                        <li>Save the file as a csv file.</li>
+                        <li><%= link_to "/partners.csv", :format => :csv, :class => "btn btn-xs btn-info" do %><i class="fa fa-download"></i> Download example CSV <% end %></li>
+                      </ul>
+                    </div>
+                    <div class="col-lg-6 col-md-12">
+                      <i class="fa fa-file-text-o fa-5x" aria-hidden="true"></i>
+                      <h3>Upload your CSV file.</h3>
+                      <ul style="list-style: none; padding: 0;">
+                        <li>Click the choose file button and <br>navigate to the saved file and select it.<br>
+                        </li>
+                        <li>Then click the "Import CSV" button <br>to import your storage locations.</li>
+                        <div>
+                          <%= form_tag import_csv_partners_path, multipart: true do %>
+                            <div class="form-group">
+                              <%= file_field_tag :file, :accept => 'text/csv', class: "form-control-file" %>
+                            </div>
+                            <%= button_tag :class => "btn btn-lg btn-primary" do %>
+                              <i class="fa fa-upload"></i> Import CSV
+                            <% end #button %>
+                          <% end #form %>
+                        </div><!-- /.modal-footer -->                        
+                      </ul>
+                      <ol>
+                        <li><%= link_to "/partners.csv", :format => :csv, :class => "btn btn-xs btn-info" do %><i class="fa fa-download"></i> Download example CSV <% end %></li>
+                        <li>Open the csv file with excel or your favourite spreadsheet program.</li>
+                        <li>Delete the sample data and enter your partner agency names and addresses in the appropriate columns.</li>
+                        <li>Save the file as a csv file.</li>
+                        <li>Click the choose file button and navigate to the saved file and select it.</li>
+                        <li>Then click the Import CSV button to import your storage locations.</li>
+                      </ol>
+                      <p class="text-warning"><small>Note: You're only able to run the import one time to prevent accidental imports or writing over existing locations!</small></p>
+                    </div>
+                  </div>
                 </div><!-- /.modal-body -->
                 <div class="modal-footer">
                   <%= form_tag import_csv_partners_path, multipart: true do %>


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #001 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

• The "Import Partners" button currently links to a modal with detailed download & upload instructions. To improve the user experience, the instructions have been divided into two major steps and the design now includes font awesome icons, a modern font, and a clean, padded look. These design changes only effect the modal structure and style on the app/views/partners/index.html.erb file. Application.scss currently holds the updates modal's styles. This was requested during Ruby for Good 2018.  


### Type of change

• Design change


### How Has This Been Tested?

• This has been tested in Chrome, Firefox, and Safari. IE has NOT been tested but the HTML and CSS changes shouldn't present a problem in IE11 or IEedge. The responsive flow is perfect.
<img width="942" alt="onboarding-partners_after" src="https://user-images.githubusercontent.com/1447452/41197554-cc894ea2-6c30-11e8-8c92-3a4027c41ef2.png">
<img width="686" alt="onboarding-partners_before" src="https://user-images.githubusercontent.com/1447452/41197555-cc916d12-6c30-11e8-881a-da45d41c5629.png">


### Screenshots

• Before and After screenshots are attached.