### PR TITLE
fix reading csv data with BOM encodings

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -40,7 +40,7 @@ class PartnersController < ApplicationController
       redirect_back(fallback_location: partners_path(organization_id: current_organization))
       flash[:error] = "No file was attached!"
     else
-      filepath = params[:file].read
+      filepath = params[:file].path
       Partner.import_csv(filepath, current_organization.id)
       flash[:notice] = "Partners were imported successfully!"
       redirect_back(fallback_location: partners_path(organization_id: current_organization))

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -23,10 +23,11 @@ class Partner < ApplicationRecord
   include DiaperPartnerClient
   after_create :update_diaper_partner
 
-  def self.import_csv(filename,organization)
-    CSV.parse(filename, :headers => true) do |row|
+  def self.import_csv(filepath, organization_id)
+    data = File.read(filepath, encoding: "BOM|UTF-8")
+    CSV.parse(data, headers: true) do |row|
       loc = Partner.new(row.to_hash)
-      loc.organization_id = organization
+      loc.organization_id = organization_id
       loc.save!
     end
   end

--- a/spec/fixtures/partners_with_bom_encoding.csv
+++ b/spec/fixtures/partners_with_bom_encoding.csv
@@ -1,0 +1,21 @@
+﻿name,email
+Beaverton Police Department,krodriguez@beavertonoregon.gov
+Catholic Charities,lcrombie@catholiccharitiesoregon.org
+Clackamas Service Center,debramason@cscoregon.org
+Healthy Familes of Clackamas County,bkersens@healthyfamiliescc.org
+Dollar for Portland,jared@dollorfor.org
+Emmanuel Housing Center,shauntemeyers@emmanuelpdx.org
+Helensview School,hgandee@mesd.k12.or.us
+JOIN,ccarroll@joinpdx.org
+Job Corps (PIVOT),zutz.kayla@jobcorps.org
+NARA,christman@naranw.org
+NW Housing Alternatives,doty@nwhousing.org
+Pregnancy Resource Center,debbie@portlandprc.org
+Portland Homeless Family Solutions,emma@pdxhfs.org
+Raphael House,lvold@raphaelhouse.com
+The Rebecca Foundation's Cloth Diaper Closet,portland@clothforall.org
+Rose Haven,adeol@rosehaven.org
+Self Enhancement Inc.,stephaniep@selfenhancement.org
+Teen Parent Services (PPS),lgovan@pps.net
+Volunteers of America,cross@voaor.org
+Central City Concern,lindsey.ramsey@ccconcern.org

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -62,9 +62,9 @@ RSpec.describe Partner, type: :model do
 
     it "imports storage locations from a csv file with BOM encodings" do
       import_file_path = Rails.root.join("spec", "fixtures", "partners_with_bom_encoding.csv")
-      expect {
+      expect do
         Partner.import_csv(import_file_path, organization.id)
-      }.to change{ Partner.count }.by(20)
+      end.to change { Partner.count }.by(20)
     end
   end
 end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -51,12 +51,20 @@ RSpec.describe Partner, type: :model do
     end
   end
   describe "import_csv" do
+    let(:organization) { create(:organization) }
+
     it "imports storage locations from a csv file" do
-      organization = create(:organization)
       before_import = Partner.count
-      import_file_path = Rails.root.join("spec", "fixtures", "partners.csv").read
+      import_file_path = Rails.root.join("spec", "fixtures", "partners.csv")
       Partner.import_csv(import_file_path, organization.id)
       expect(Partner.count).to eq before_import + 3
+    end
+
+    it "imports storage locations from a csv file with BOM encodings" do
+      import_file_path = Rails.root.join("spec", "fixtures", "partners_with_bom_encoding.csv")
+      expect {
+        Partner.import_csv(import_file_path, organization.id)
+      }.to change{ Partner.count }.by(20)
     end
   end
 end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #351 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Instead of passing in the filepath, we were actually passing in a string. We now pass in a filepath and ensure that we convert any BOM encodings to UTF-8 before we parse the CSV.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- added a new fixture file containing bad encodings and wrote a test to parse that file

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->