### PR TITLE
Add local ip addresses so web-console works under docker mac

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -57,4 +57,13 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  # Web-console wants us to only connect from localhost for safety, but in
+  # mac-docker we get separate ip addresses. So this grabs ALL our local ips
+  # and adds them to the OK list
+  require 'socket'
+  require 'ipaddr'
+  config.web_console.whitelisted_ips = Socket.ip_address_list.reduce([]) do |res, addrinfo|
+    addrinfo.ipv4? ? res << IPAddr.new(addrinfo.ip_address).mask(24) : res
+  end
 end


### PR DESCRIPTION
Web-console only wants to listen on localhost by default, but with the networking in docker on mac this gets a little weird -- there are error messages in the log about web-console trying to be accessed from 172.18.0.1 or similar. This change gets the local addresses from the machine and adds them to the whitelist.

Helps with #430

HOWEVER! This currently has `.mask(24)` which I _think_ might allow other members of your local network to access your web console, which would not be good if they are evil. I don't know if that matters at all in this case, because they might not get routed there. I had someone with a mac try it without the `.mask(24)` and it didn't work, and I don't have a mac handy to test on at the moment. I can probably test on one later this week if nobody else is available.

* Bug fix (non-breaking change which fixes an issue)
