### PR TITLE
fix(DonationForm) Prevent editing of the `issued at` field for existing donations

### DIFF
--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -55,14 +55,15 @@
      label: "Issued on",
      as: :date,
      html5: true,
-     wrapper: :vertical_input_group %>
+     wrapper: :vertical_input_group,
+     disabled: !@donation.new_record? %>
 </div>
 </div>
 
 <fieldset style="margin-bottom: 2rem;" class="form-inline">
   <legend>Items in this donation</legend>
   <div id="donation_line_items" data-capture-barcode="true">
-    
+
     <%= f.simple_fields_for :line_items do |item| %>
       <%= render 'line_items/line_item_fields', f: item %>
     <% end %>


### PR DESCRIPTION
This PR is meant to solve the issue for this Github Issue: https://github.com/rubyforgood/diaper/issues/456

The `new_record` check will allow the input to be used for the creation of new donations, while preventing users from editing the field while editing an existing donation.

<img width="1437" alt="screen shot 2018-07-27 at 11 41 44 am" src="https://user-images.githubusercontent.com/4826610/43334135-1dcc1e3a-9192-11e8-9833-87f022ebc79b.png">
