### PR TITLE
Fixing organization logo to work with ActiveStorage

### DIFF
--- a/app/helpers/distributions_helper.rb
+++ b/app/helpers/distributions_helper.rb
@@ -1,9 +1,0 @@
-module DistributionsHelper
-  def logo_file_path(organization = nil)
-    if organization&.logo&.attached?
-      organization.logo.path
-    else
-      Rails.root.join("app", "assets", "images", "DiaperBase-Logo.png")
-    end
-  end
-end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -17,6 +17,8 @@
 #
 
 class Organization < ApplicationRecord
+  DIAPER_APP_LOGO = Rails.root.join("app", "assets", "images", "DiaperBase-Logo.png")
+
   validates :name, presence: true
   validates :short_name, presence: true, format: /\A[a-z0-9_]+\z/i
   validates :url, format: { with: URI::DEFAULT_PARSER.make_regexp, message: "it should look like 'http://www.example.com'" }, allow_blank: true
@@ -93,6 +95,14 @@ class Organization < ApplicationRecord
       i.organization_id = org_id
     end
     org.reload
+  end
+
+  def logo_path
+    if logo.attached?
+      ActiveStorage::Blob.service.send(:path_for, logo.key).to_s
+    else
+      Organization::DIAPER_APP_LOGO.to_s
+    end
   end
 
   private

--- a/app/views/distributions/print.pdf.prawn
+++ b/app/views/distributions/print.pdf.prawn
@@ -1,5 +1,5 @@
 prawn_document do |pdf|
-  pdf.image logo_file_path(current_organization), height: 110
+  pdf.image current_organization.logo_path, fit: [325, 110]
 
   pdf.bounding_box [pdf.bounds.right - 225, pdf.bounds.top - 20], width: 225 do
     pdf.text current_organization.name, align: :right
@@ -117,7 +117,7 @@ prawn_document do |pdf|
       logo_offset = (pdf.bounds.width - 190) / 2
       pdf.bounding_box([logo_offset, 0], width: 190, height: 33) do
         pdf.text "Lovingly created with", valign: :center
-        pdf.image logo_file_path, width: 75, vposition: :center, position: :right
+        pdf.image Organization::DIAPER_APP_LOGO, width: 75, vposition: :center, position: :right
       end
     end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -75,4 +75,19 @@ RSpec.describe Organization, type: :model do
       expect(organization.total_inventory).to eq(0)
     end
   end
+
+  describe "logo_path" do
+    it "returns the the default logo path when no logo attached" do
+      org = build(:organization, logo: nil)
+      expect(org.logo_path).to include("app/assets/images/DiaperBase-Logo.png")
+    end
+
+    it "returns the logo path attached for the organization" do
+      org = build(:organization,
+                  logo: Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/logo.jpg"),
+                                                     "image/jpeg"))
+
+      expect(org.logo_path).to include(Rails.root.join("tmp/storage").to_s)
+    end
+  end
 end


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

-->

Resolves #459 

### Description
There was a bug where retrieving Organization logos were throwing errors because the `path` method did not exist on the new ActiveStorage::Blob object. The code has been refactored to retrieve the base diaper app logo if the organization does not have a logo and use the organization provided one otherwise. 

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added tests for the `logo_path` method on the `organization_spec.rb` 
