### PR TITLE
Cleans up authorization spec shared examples

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_10_152822) do
+ActiveRecord::Schema.define(version: 2018_07_04_003450) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,6 +118,22 @@ ActiveRecord::Schema.define(version: 2018_06_10_152822) do
     t.index ["donation_site_id"], name: "index_donations_on_donation_site_id"
     t.index ["organization_id"], name: "index_donations_on_organization_id"
     t.index ["storage_location_id"], name: "index_donations_on_storage_location_id"
+  end
+
+  create_table "flipper_features", force: :cascade do |t|
+    t.string "key", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_flipper_features_on_key", unique: true
+  end
+
+  create_table "flipper_gates", force: :cascade do |t|
+    t.string "feature_key", null: false
+    t.string "key", null: false
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "inventory_items", id: :serial, force: :cascade do |t|

--- a/spec/controllers/barcode_items_controller_spec.rb
+++ b/spec/controllers/barcode_items_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe BarcodeItemsController, type: :controller do
     describe "GET #index" do
       subject { get :index, params: default_params }
       it "returns http success" do
-        expect(subject).to have_http_status(:success)
+        expect(subject).to be_successful
       end
     end
 
@@ -25,7 +25,7 @@ RSpec.describe BarcodeItemsController, type: :controller do
     describe "GET #edit" do
       subject { get :edit, params: default_params.merge(id: create(:barcode_item, global: true)) }
       it "returns http success" do
-        expect(subject).to have_http_status(:success)
+        expect(subject).to be_successful
       end
     end
 

--- a/spec/controllers/dashboard_controller_spec.rb
+++ b/spec/controllers/dashboard_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe DashboardController, type: :controller do
     describe "GET #show" do
       it "returns http success" do
         get :index, params: default_params
-        expect(response).to have_http_status(:success)
+        expect(response).to be_successful
       end
 
       context "for another org" do

--- a/spec/controllers/diaper_drive_participants_controller_spec.rb
+++ b/spec/controllers/diaper_drive_participants_controller_spec.rb
@@ -79,6 +79,6 @@ RSpec.describe DiaperDriveParticipantsController, type: :controller do
   context "While not signed in" do
     let(:object) { create(:diaper_drive_participant) }
 
-    include_examples "requiring authentication"
+    include_examples "requiring authorization"
   end
 end

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -74,6 +74,6 @@ RSpec.describe DistributionsController, type: :controller do
   context "While not signed in" do
     let(:object) { create(:distribution) }
 
-    include_examples "requiring authentication"
+    include_examples "requiring authorization"
   end
 end

--- a/spec/controllers/donation_sites_controller_spec.rb
+++ b/spec/controllers/donation_sites_controller_spec.rb
@@ -54,6 +54,6 @@ RSpec.describe DonationSitesController, type: :controller do
   context "While not signed in" do
     let(:object) { create(:donation_site) }
 
-    include_examples "requiring authentication"
+    include_examples "requiring authorization"
   end
 end

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -146,8 +146,7 @@ RSpec.describe DonationsController, type: :controller do
   context "While not signed in" do
     let(:object) { create(:donation) }
 
-    include_examples "requiring authentication"
-
+    include_examples "requiring authorization"
     it "redirects the user to the sign-in page for Donation specific actions" do
       single_params = { organization_id: object.organization.to_param, id: object.id }
 

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe DonationsController, type: :controller do
     describe "GET #edit" do
       subject { get :edit, params: default_params.merge(id: create(:donation)) }
       it "returns http success" do
-        expect(subject).to have_http_status(:success)
+        expect(subject).to be_successful
       end
     end
 

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -51,6 +51,6 @@ RSpec.describe ItemsController, type: :controller do
   context "While not signed in" do
     let(:object) { create(:item) }
 
-    include_examples "requiring authentication"
+    include_examples "requiring authorization"
   end
 end

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -109,7 +109,7 @@ RSpec.describe PurchasesController, type: :controller do
     describe "GET #edit" do
       subject { get :edit, params: default_params.merge(id: create(:purchase, organization: @organization)) }
       it "returns http success" do
-        expect(subject).to have_http_status(:success)
+        expect(subject).to be_successful
       end
     end
 

--- a/spec/controllers/storage_locations_spec.rb
+++ b/spec/controllers/storage_locations_spec.rb
@@ -52,6 +52,6 @@ RSpec.describe StorageLocationsController, type: :controller do
   context "While not signed in" do
     let(:object) { create(:storage_location) }
 
-    include_examples "requiring authentication"
+    include_examples "requiring authorization"
   end
 end

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -54,15 +54,13 @@ RSpec.describe TransfersController, type: :controller do
                from: create(:storage_location, organization: org),
                organization: org)
       end
-      let!(:skip) { [:edit] }
-      include_examples "requiring authorization"
+      include_examples "requiring authorization", except: [:edit, :update, :destroy]
     end
   end
 
   context "While not signed in" do
     let(:object) { create(:transfer) }
-    let!(:skip) { [:edit] }
 
-    include_examples "requiring authentication"
+    include_examples "requiring authorization", except: [:edit, :update, :destroy]
   end
 end

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -54,13 +54,13 @@ RSpec.describe TransfersController, type: :controller do
                from: create(:storage_location, organization: org),
                organization: org)
       end
-      include_examples "requiring authorization", except: [:edit, :update, :destroy]
+      include_examples "requiring authorization", except: %i(edit update destroy)
     end
   end
 
   context "While not signed in" do
     let(:object) { create(:transfer) }
 
-    include_examples "requiring authorization", except: [:edit, :update, :destroy]
+    include_examples "requiring authorization", except: %i(edit update destroy)
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe UsersController, type: :controller do
   describe "GET #new" do
     it "returns http success" do
       get :new, params: default_params
-      expect(response).to have_http_status(:success)
+      expect(response).to be_successful
     end
   end
 end

--- a/spec/support/authorization_specs.rb
+++ b/spec/support/authorization_specs.rb
@@ -15,21 +15,3 @@ RSpec.shared_examples "requiring authentication" do
     expect(response).to be_redirect
   end
 end
-
-RSpec.shared_examples "requiring authorization" do
-  it "Disallows all access for CRUD actions" do
-    single_params = { organization_id: object.organization.to_param, id: object.id }
-
-    get :index, params: { organization_id: object.organization.to_param }
-    expect(response).to be_redirect
-
-    get :new, params: { organization_id: object.organization.to_param }
-    expect(response).to be_redirect
-
-    get :show, params: single_params
-    expect(response).to be_redirect
-
-    post :create, params: { organization_id: object.organization.to_param }
-    expect(response).to be_redirect
-  end
-end

--- a/spec/support/authorization_specs.rb
+++ b/spec/support/authorization_specs.rb
@@ -1,17 +1,44 @@
-RSpec.shared_examples "requiring authentication" do
+RSpec.shared_examples "requiring authorization" do |constraints|
   it "redirects the user to the sign-in page for CRUD actions" do
-    single_params = { organization_id: object.organization.to_param, id: object.id }
+    member_params = { organization_id: object.organization.to_param, id: object.id }
+    collection_params = { organization_id: object.organization.to_param }
 
-    get :index, params: { organization_id: object.organization.to_param }
-    expect(response).to be_redirect
+    (constraints ||= {}).merge!({ except: [], only: [] })
+    skip_these = constraints[:except] + ([:index, :new, :create, :show, :edit, :update, :destroy] - constraints[:only])
 
-    get :new, params: { organization_id: object.organization.to_param }
-    expect(response).to be_redirect
+    unless skip_these.include?(:index)
+        get :index, params: collection_params
+        expect(response).to be_redirect
+    end
 
-    post :create, params: { organization_id: object.organization.to_param }
-    expect(response).to be_redirect
+    unless skip_these.include?(:new)
+        get :new, params: collection_params
+        expect(response).to be_redirect
+    end
 
-    get :show, params: single_params
-    expect(response).to be_redirect
+    unless skip_these.include?(:create)
+        post :create, params: collection_params
+        expect(response).to be_redirect
+    end
+
+    unless skip_these.include?(:show)
+        get :show, params: member_params
+        expect(response).to be_redirect
+    end
+
+    unless skip_these.include?(:edit)
+        get :edit, params: member_params
+        expect(response).to be_redirect
+    end
+
+    unless skip_these.include?(:update)
+        get :update, params: member_params
+        expect(response).to be_redirect
+    end
+
+    unless skip_these.include?(:destroy)
+        delete :destroy, params: member_params
+        expect(response).to be_redirect
+    end
   end
 end

--- a/spec/support/authorization_specs.rb
+++ b/spec/support/authorization_specs.rb
@@ -3,42 +3,42 @@ RSpec.shared_examples "requiring authorization" do |constraints|
     member_params = { organization_id: object.organization.to_param, id: object.id }
     collection_params = { organization_id: object.organization.to_param }
 
-    (constraints ||= {}).merge!({ except: [], only: [] })
-    skip_these = constraints[:except] + ([:index, :new, :create, :show, :edit, :update, :destroy] - constraints[:only])
+    (constraints ||= {}).merge!(except: [], only: [])
+    skip_these = constraints[:except] + (%i(index new create show edit update destroy) - constraints[:only])
 
     unless skip_these.include?(:index)
-        get :index, params: collection_params
-        expect(response).to be_redirect
+      get :index, params: collection_params
+      expect(response).to be_redirect
     end
 
     unless skip_these.include?(:new)
-        get :new, params: collection_params
-        expect(response).to be_redirect
+      get :new, params: collection_params
+      expect(response).to be_redirect
     end
 
     unless skip_these.include?(:create)
-        post :create, params: collection_params
-        expect(response).to be_redirect
+      post :create, params: collection_params
+      expect(response).to be_redirect
     end
 
     unless skip_these.include?(:show)
-        get :show, params: member_params
-        expect(response).to be_redirect
+      get :show, params: member_params
+      expect(response).to be_redirect
     end
 
     unless skip_these.include?(:edit)
-        get :edit, params: member_params
-        expect(response).to be_redirect
+      get :edit, params: member_params
+      expect(response).to be_redirect
     end
 
     unless skip_these.include?(:update)
-        get :update, params: member_params
-        expect(response).to be_redirect
+      get :update, params: member_params
+      expect(response).to be_redirect
     end
 
     unless skip_these.include?(:destroy)
-        delete :destroy, params: member_params
-        expect(response).to be_redirect
+      delete :destroy, params: member_params
+      expect(response).to be_redirect
     end
   end
 end


### PR DESCRIPTION
Fixes #451 

*NB* some specs fail with database cleaner / PG bad connection, but I think it's a local config issue. If CI passes, we should be good.

This PR addresses the issues in #451 and resolves them. 

 - Removes the now-redundant authentication-spec shared example
 - Adds parameterization to the remaining authorization-spec shared example
 - Adds the ability to do "except" or "only" as parameters
 - Re-adds `edit`, `update`, and `destroy` expectations
 - Updates all controller specs that were using this shared example