### PR TITLE
Initialize issued_at before save to avoid error in new donation update

### DIFF
--- a/app/models/concerns/issued_at.rb
+++ b/app/models/concerns/issued_at.rb
@@ -2,7 +2,7 @@ module IssuedAt
   extend ActiveSupport::Concern
 
   included do
-    before_create :initialize_issued_at
+    before_save :initialize_issued_at
     scope :by_issued_at, ->(issued_at) { where(issued_at: issued_at.beginning_of_month..issued_at.end_of_month) }
   end
 


### PR DESCRIPTION
# Checklist:
- [x]  I have performed a self-review of my own code,
- [ ]  I have commented my code, particularly in hard-to-understand areas,
- [ ]  I have made corresponding changes to the documentation,
- [ ] I have added tests that prove my fix is effective or that my feature works,
- [ ]  New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [ ] Title include "WIP" if work is in progress.
 
[Resolves #456
](https://github.com/rubyforgood/diaper/issues/456)

### Description
Initialize issued_at before save instead of after create to ensure a value is always present (this prevents potential errors with updating a donation - see issue)
   
### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manual testing locally: created a donation, updated the donation and deleted the issued at date, confirmed that the date saved as the current dates and no error was thrown