### PR TITLE
reclaim! does not destroy the distribution

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -7,10 +7,14 @@ class DistributionsController < ApplicationController
   end
 
   def reclaim
-    @distribution = Distribution.find(params[:id])
-    @distribution.storage_location.reclaim!(@distribution)
+    ActiveRecord::Base.transaction do
+      @distribution_id = params[:id]
+      distribution = Distribution.find(params[:id])
+      distribution.storage_location.reclaim!(distribution)
+      distribution.destroy!
+    end
 
-    flash[:notice] = "Distribution #{@distribution.id} has been reclaimed!"
+    flash[:notice] = "Distribution #{@distribution_id} has been reclaimed!"
     redirect_to distributions_path
   end
 

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -229,7 +229,6 @@ class StorageLocation < ApplicationRecord
         inventory_item.update(quantity: inventory_item.quantity + line_item.quantity)
       end
     end
-    distribution.destroy
   end
 
   def self.csv_export_headers

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -261,6 +261,13 @@ RSpec.describe StorageLocation, type: :model do
         storage_location.reclaim!(distribution)
         expect(storage_location.inventory_items.first.quantity).to eq 350
       end
+
+      it "does not destroy the distribution" do
+        storage_location = create :storage_location, :with_items, item_quantity: 300
+        distribution = create :distribution, :with_items, storage_location: storage_location, item_quantity: 50
+        storage_location.reclaim!(distribution)
+        expect(Distribution.find(distribution.id)).to eql distribution
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves #471 

The reclaim! method will no longer destroy the underlying distribution.
This:
- will make #338 significantly cleaner to implement


Tested by running the full test suite and by manually using the reclaim button and ensuring it still works and still destroys the distribution (which is instead done in the controller)