### PR TITLE
Persist active storage uploads between deployments

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -98,7 +98,11 @@ class Organization < ApplicationRecord
   end
 
   def logo_path
-    Organization::DIAPER_APP_LOGO.to_s
+    if logo.attached?
+      ActiveStorage::Blob.service.send(:path_for, logo.key).to_s
+    else
+      Organization::DIAPER_APP_LOGO.to_s
+    end
   end
 
   private

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -33,7 +33,7 @@ set :branch, ENV["BRANCH"] || :master
 
 ## Linked Files & Directories (Default None):
 set :linked_files, %w{config/database.yml}
-set :linked_dirs,  %w{log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
+set :linked_dirs,  %w{log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system storage}
 
 namespace :puma do
   desc "Create Directories for Puma Pids and Socket"


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #001 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

With the introduction of Active Storage in Rails 5, each new deployment was causing the images that have been uploaded to be lost. This fix ensures that uploads managed by Active Storage are persisted and carried along between deployments so logos don't need to be re-uploaded. 

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

To test this, deploy a version of the site without using the fix (i.e., without the updated `linked_dirs` setting in capistrano). This is actually easy to do since capistrano cues off of the code in your working directory rather than in the branch you are trying to deploy.

On the remote server, you'll need to delete the `~/apps/diaper_base/shared/storage` folder, since it's existence in combination with the code in the branch fixes the issue.

```
 # This is so your local capistrano config has the fix
git checkout --track origin/active_storage_prawn  

# this will break the logos by creating a new release, leaving the previously updated
# logos in the previous release directory. But this will also create a new storage folder
# in shared/ and symlink it to the new deployment. Since the is a fresh setup, the logos 
# will be broken.
cap production deploy BRANCH=active_storage_prawn

# go to the test site and re-upload a logo. 

# Deploy a 2nd time and the logo should persist
cap production deploy BRANCH=active_storage_prawn
```
