### PR TITLE
Get rid of "missing blue.png" RoutingError

### DIFF
--- a/app/assets/stylesheets/blue.css
+++ b/app/assets/stylesheets/blue.css
@@ -9,7 +9,6 @@
     padding: 0;
     width: 22px;
     height: 22px;
-    background: url(blue.png) no-repeat;
     border: none;
     cursor: pointer;
 }


### PR DESCRIPTION
### Description
There is a persistent missing asset error on the rails console. It is pointing out that a `blue.png` cannot be fetched on `GET` requests. The asset indeed does not exist in the repo, so removing it as a stylesheet dependency.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

It doesn't make sense to write tests for this issue since it is a valid error we are cleaning up.

I do see a `blue@2x.png` in the images folder, but it doesn't look like something you'd want as a background image so I'm assuming it's not what you want here.

### Stacktrace

This fix will eliminate errors like the one below.

```
web_1       | ActionController::RoutingError (No route matches [GET] "/assets/blue.png"):
web_1       |   
web_1       | actionpack (5.2.0) lib/action_dispatch/middleware/debug_exceptions.rb:65:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | web-console (3.6.2) lib/web_console/middleware.rb:135:in `call_app'
web_1       | web-console (3.6.2) lib/web_console/middleware.rb:30:in `block in call'
web_1       | web-console (3.6.2) lib/web_console/middleware.rb:20:in `catch'
web_1       | web-console (3.6.2) lib/web_console/middleware.rb:20:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | actionpack (5.2.0) lib/action_dispatch/middleware/show_exceptions.rb:33:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | railties (5.2.0) lib/rails/rack/logger.rb:38:in `call_app'
web_1       | railties (5.2.0) lib/rails/rack/logger.rb:26:in `block in call'
web_1       | activesupport (5.2.0) lib/active_support/tagged_logging.rb:71:in `block in tagged'
web_1       | activesupport (5.2.0) lib/active_support/tagged_logging.rb:28:in `tagged'
web_1       | activesupport (5.2.0) lib/active_support/tagged_logging.rb:71:in `tagged'
web_1       | railties (5.2.0) lib/rails/rack/logger.rb:26:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:11:in `block in call'
web_1       | activesupport (5.2.0) lib/active_support/logger_silence.rb:21:in `silence'
web_1       | activesupport (5.2.0) lib/active_support/logger.rb:65:in `block (3 levels) in broadcast'
web_1       | activesupport (5.2.0) lib/active_support/logger_silence.rb:21:in `silence'
web_1       | activesupport (5.2.0) lib/active_support/logger.rb:63:in `block (2 levels) in broadcast'
web_1       | sprockets-rails (3.2.1) lib/sprockets/rails/quiet_assets.rb:11:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | actionpack (5.2.0) lib/action_dispatch/middleware/remote_ip.rb:81:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | actionpack (5.2.0) lib/action_dispatch/middleware/request_id.rb:27:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/action_dispatch/request_id.rb:12:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | rack (2.0.5) lib/rack/method_override.rb:22:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | rack (2.0.5) lib/rack/runtime.rb:22:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | activesupport (5.2.0) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | actionpack (5.2.0) lib/action_dispatch/middleware/executor.rb:14:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | actionpack (5.2.0) lib/action_dispatch/middleware/static.rb:127:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | rack (2.0.5) lib/rack/sendfile.rb:111:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | skylight-core (2.0.1) lib/skylight/core/probes/middleware.rb:29:in `call'
web_1       | railties (5.2.0) lib/rails/engine.rb:524:in `call'
web_1       | newrelic_rpm (5.1.0.344) lib/new_relic/agent/instrumentation/middleware_tracing.rb:92:in `call'
web_1       | puma (3.11.4) lib/puma/configuration.rb:225:in `call'
web_1       | puma (3.11.4) lib/puma/server.rb:632:in `handle_request'
web_1       | puma (3.11.4) lib/puma/server.rb:446:in `process_client'
web_1       | puma (3.11.4) lib/puma/server.rb:306:in `block in run'
web_1       | puma (3.11.4) lib/puma/thread_pool.rb:120:in `block in spawn_thread'
```
