### PR TITLE
Reduce query count and request time for GET /org/dashboard

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -48,9 +48,9 @@ module DashboardHelper
 
   def received_distributed_data(range = selected_range)
     {
-      "Received donations" => current_organization.donations.during(range).collect { |d| d.line_items.total }.reduce(:+),
-      "Purchased" => current_organization.purchases.during(range).collect { |d| d.line_items.total }.reduce(:+),
-      "Distributed" => current_organization.distributions.during(range).collect { |d| d.line_items.total }.reduce(:+)
+      "Received donations" => total_received_donations_unformatted(range),
+      "Purchased" => total_purchased_unformatted(range),
+      "Distributed" => total_distributed_unformatted(range)
     }
   end
 
@@ -63,14 +63,28 @@ module DashboardHelper
   end
 
   def total_received_donations(range = selected_range)
-    number_with_delimiter current_organization.donations.during(range).collect { |d| d.line_items.total }.reduce(0, :+)
+    number_with_delimiter total_received_donations_unformatted(range)
   end
 
   def total_purchased(range = selected_range)
-    number_with_delimiter current_organization.purchases.during(range).collect { |d| d.line_items.total }.reduce(0, :+)
+    number_with_delimiter total_purchased_unformatted(range)
   end
 
   def total_distributed(range = selected_range)
-    number_with_delimiter current_organization.distributions.during(range).collect { |d| d.line_items.total }.reduce(0, :+)
+    number_with_delimiter total_distributed_unformatted(range)
+  end
+
+  private
+
+  def total_received_donations_unformatted(range = selected_range)
+    LineItem.where(itemizable: current_organization.donations.during(range)).sum(:quantity)
+  end
+
+  def total_purchased_unformatted(range = selected_range)
+    LineItem.where(itemizable: current_organization.purchases.during(range)).sum(:quantity)
+  end
+
+  def total_distributed_unformatted(range = selected_range)
+    LineItem.where(itemizable: current_organization.distributions.during(range)).sum(:quantity)
   end
 end

--- a/app/models/organization_stats.rb
+++ b/app/models/organization_stats.rb
@@ -25,7 +25,8 @@ class OrganizationStats
 
   def locations_with_inventory
     return [] unless storage_locations
-    storage_locations.select { |location| location.inventory_items.present? }
+    inventoried_storage_location_ids = InventoryItem.where(storage_location: storage_locations).pluck(:storage_location_id)
+    storage_locations.select { |location| inventoried_storage_location_ids.include? location.id }
   end
 
   private


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Inspired by #426  <!--fill issue number-->

### Description
The work done in this pull request was originally intended to help speed up the dashboard feature spec. Ultimately it did not seem to make a difference in that context, despite measurable improvement in the dashboard route timing. It seems most of the time spent in that spec is in the overhead of automating the browser, based on looking at `test.log`, but more investigation can still be done.

Despite the lack of obvious improvement in spec times, I wanted to submitted the work as a PR because:

1. It does seem to still improve the observable time in dashboard fetch+render
2. Acceptance of this PR (with any rework) could validate an approach to additional improvements of this nature
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Performance change (non-breaking change which may improve performance)

### How Has This Been Tested?
The existing test suite has been run successfully. In addition, I manually observed that the impacted partials rendered the same before and after the changes for the seeded test data.

Performance numbers below were gathered from the `development.log` in my local environment over five reloads of `GET /pdx_bank/dashboard`. Obviously I don't know how the timing numbers will carry over to a production environment, but the results seem promising.

| | GET msec | Views msec | ActiveRecord msec | Query Count | Cached Query Count | Uncached Query Count |
|-|-|-|-|-|-|-|
| Before changes | 483 | 294.2 | 174.4 | 105 | 45 | 60 |
| After changes | 367 | 207.8 | 145.4 | 54 | 10 | 44 |

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->


