### PR TITLE
Fix brittle spec from relative date issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   gem "rspec-rails", "~> 3.5"
   gem "terminal-notifier-guard"
   gem "terminal-notifier"
+  gem "timecop"
   gem "rubocop"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,6 +403,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.9.1)
     toastr-rails (1.0.3)
       railties (>= 3.1.0)
     ttfunk (1.5.1)
@@ -494,6 +495,7 @@ DEPENDENCIES
   terminal-notifier
   terminal-notifier-guard
   therubyracer (~> 0.12)
+  timecop
   toastr-rails
   tzinfo-data (~> 1.2)
   uglifier (>= 1.3.0)
@@ -505,4 +507,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.6


### PR DESCRIPTION
*Partially* resolves #413

I'm able to resolve the brittle spec issue, but I don't have enough background
knowledge to be able to fix the capybara/XHR test issue.

### Description
Introduce Timecop gem to run this spec with current time frozen in
mid-June. This ensures no strange behavior occurs when running this spec
in January when "1.month.ago" would create the record for the previous
year.

Motivation: I was working recently with Timecop on another project, and this
looked like a quick, easy fix to help out a great project, particularly since it
was your proposed solution. Please let me know if you have other preferences as
to how I approach it, as I'm not as experienced as I'd like to be with some
aspects of rspec testing.

## List any dependencies that are required for this change. (gems, js libraries, etc.)
Introduces the timecop gem.

I considered using ActiveSupport's time helpers for testing instead, but had
some difficulty getting them to work. Timecop seems more straightforward to set
up as you can simply include it on any test files that need it.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

This isn't the easiest to reproduce, given that it only happens in January. :) 
I tested it by introducing Timecop, freezing the time to mid-June, and running
the test suite to verify everything worked correctly. I then changed it to
freeze time in mid-January, ran it again, and confirmed that doing so made the
spec fail (in other words, that it was time-traveling correctly.) After
confirming that, I changed it back freezing time to mid-June, 2018.
