### PR TITLE
Removes massive, oversized, bloated diaper from Invitation#accept page

### DIFF
--- a/app/controllers/users/invitations_controller.rb
+++ b/app/controllers/users/invitations_controller.rb
@@ -1,0 +1,3 @@
+class Users::InvitationsController < Devise::SessionsController
+  layout "login"
+end

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,11 +1,18 @@
 <h2><%= t 'devise.invitations.edit.header' %></h2>
-
+<p>Welcome to Diaperbase! Before we get started, please set a new password for yourself.</p>
+<p>We recommend a password that is:</p>
+<ul>
+  <li>Memorable to you</li>
+  <li>At least 10 characters long</li>
+  <li>Uses some mix of letters, punctuation, numbers, spaces, etc.</li>
+</ul>
+<p>An easy one would be to pick a line from a poem or a favorite quote!</p>
 <%= simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f| %>
   <%= devise_error_messages! %>
   <%= f.hidden_field :invitation_token %>
 
   <%= f.input :password %>
-  <%= f.input :password_confirmation %>
+  <%= f.input :password_confirmation, label: "Type the same password again" %>
 
-  <%= f.button :submit, t("devise.invitations.edit.submit_button") %>
+  <%= f.button :submit, t("devise.invitations.edit.submit_button"), class: "btn-success" %>
 <% end %>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>Diaperbase | Log in</title>
+  <!-- Tell the browser to be responsive to screen width -->
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+  <!-- Bootstrap 3.3.7 -->
+  <%= csrf_meta_tags %>
+  <%= javascript_include_tag 'application' %>
+  <%= stylesheet_link_tag    'application', media: 'all' %>
+  <!-- iCheck -->
+  <link rel="stylesheet" href="/assets/blue.css">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
+  <style>
+  .checkbox label{
+    padding-left: 0px;
+  }
+</style>
+</head>
+<body id="devise" class="hold-transition login-page">
+<div class="login-box">
+  <div class="login-logo">
+
+    <img src="/img/DiaperBase-Logo.png" style="width: 85%; height: 85%" alt="" title="" class="serv_icon">
+  </div>
+  <!-- /.login-logo -->
+  <div class="login-box-body">
+    <div class="form-group has-feedback">
+      <%= yield %>
+    </div>
+  </div>
+  <!-- /.login-box-body -->
+</div>
+<!-- /.login-box -->
+
+<script src="/assets/icheck.min.js"></script>
+<script>
+  $(function () {
+    $('input').iCheck({
+      checkboxClass: 'icheckbox_square-blue',
+      radioClass: 'iradio_square-blue',
+      increaseArea: '20%' // optional
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
The issue was that it was using the standard layout, which has a bunch of extraneous AdminLTE framing, and something was preventing the sizing. So even with the logo hidden, it still had a junk layout.

I created a new `devise` layout, based on the existing `login` layout. Also created an issue to fix all these layouts. 

I added some additional copy to the page to provide better context for the user about where they're at, since the page, as-is, doesn't fit within the continuity of "accepting an invitation", and our users are unlikely to be tech-savvy.

I made the button green, because I think that's teh direction we're going in for "saving to database" buttons. 