### PR TITLE
Load Organizations on Super Admin User Create

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,4 +1,6 @@
 class Admin::UsersController < AdminController
+  before_action :load_organizations, only: %i[new create]
+
   def index
     @users = User.all
   end
@@ -7,7 +9,6 @@ class Admin::UsersController < AdminController
 
   def new
     @user = User.new
-    @organizations = Organization.all
   end
 
   def create
@@ -36,5 +37,9 @@ class Admin::UsersController < AdminController
 
   def user_params
     params.require(:user).permit(:name, :organization_id, :email, :password, :password_confirmation)
+  end
+
+  def load_organizations
+    @organizations = Organization.all
   end
 end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -2,6 +2,78 @@ RSpec.describe Admin::UsersController, type: :controller do
   let(:default_params) do
     { organization_id: @organization.id }
   end
+  context "When logged in as a super admin" do
+    before do
+      sign_in(@super_admin)
+      create(:organization)
+    end
+
+    describe "GET #new" do
+      it "renders new template" do
+        get :new
+        expect(response).to render_template(:new)
+      end
+
+      it "preloads organizations" do
+        get :new
+        expect(assigns(:organizations)).to eq(Organization.all)
+      end
+    end
+
+    describe "POST #create" do
+      it "returns http success" do
+        post :create, params: { user: { organization_id: 1 } }
+        expect(response).to be_successful
+      end
+
+      it "preloads organizations" do
+        post :create, params: { user: { organization_id: 1 } }
+        expect(assigns(:organizations)).to eq(Organization.all)
+      end
+    end
+  end
+
+  context "When logged in as an organization_admin" do
+    before do
+      sign_in @organization_admin
+      create(:organization)
+    end
+
+    describe "GET #new" do
+      it "redirects" do
+        get :new
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
+
+    describe "POST #create" do
+      it "redirects" do
+        post :create, params: { user: { organization_id: 1 } }
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
+  end
+
+  context "When logged in as a non-admin user" do
+    before do
+      sign_in @user
+      create(:organization)
+    end
+
+    describe "GET #new" do
+      it "redirects" do
+        get :new
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
+
+    describe "POST #create" do
+      it "redirects" do
+        post :create, params: { user: { organization_id: 1 } }
+        expect(response).to redirect_to(dashboard_path)
+      end
+    end
+  end
 =begin
   context "When logged in as an organization admin" do
     before do


### PR DESCRIPTION
Resolves #512 

### Description
There was a bug when a super admin attempted to create a new user but had an error in the form such as non-matching passwords. This would show the form errors and redirect the user back to the form but the organization select dropdown would change to numbers. In that case, it was only hitting the create action instead of the new, but the controller only set the `@organizations` var in the new action. I added a `before_action` for both new and create to make sure that the organizations variable gets set in both cases.  
   

### Type of change

* Bug fix 

### How Has This Been Tested?

Previously all of the tests in the admin/users_controller were commented out. I left those but added new ones for the new/create actions for each type of user. Super admin user is the only one allowed to see the page, so those cases test that the organizations variable gets set properly. Without the before_action change, the 'preloads organization' test under the create section will fail. Other users should not be able to access the page, so those tests ensure a redirect to the dashboard.

### Screenshots
Now, when there is a form error, the organizations dropdown will still have the correct options as expected:
<img width="1134" alt="screen shot 2018-10-20 at 12 00 27 pm" src="https://user-images.githubusercontent.com/13934832/47259732-bd24f700-d462-11e8-8dfc-909ef0b3eda5.png">