### PR TITLE
Fixes #523 - falls through to created_at on distribution.issued_at being nil

### DIFF
--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= distribution_row.partner.name %></td>
-  <td><%= distribution_row.issued_at.strftime("%m/%d/%Y") %> </td>
+  <td><%= (distribution_row.issued_at.presence || distribution_row.created_at).strftime("%m/%d/%Y") %> </td>
   <td><%= distribution_row.storage_location.name %></td>
   <td><%= distribution_row.line_items.total %></td>
   <td class="text-right">


### PR DESCRIPTION
Simple switch - just adds a fall-through if/when issued_at is nil. Normally this shouldn't be an issue, but if it were to come up the app shouldn't die.