### PR TITLE
Fixes #532 - fix exception when storage location is nil

### DIFF
--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -76,6 +76,7 @@ module Itemizable
 
   def line_item_items_exist_in_inventory
     return if storage_location.nil?
+
     line_items.each do |line_item|
       next unless line_item.item
 

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -75,6 +75,7 @@ module Itemizable
   private
 
   def line_item_items_exist_in_inventory
+    return if storage_location.nil?
     line_items.each do |line_item|
       next unless line_item.item
 

--- a/spec/features/distribution_spec.rb
+++ b/spec/features/distribution_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Distributions", type: :feature, focus: true do
+RSpec.feature "Distributions", type: :feature do
   before do
     sign_in(@user)
     @url_prefix = "/#{@organization.to_param}"
@@ -27,20 +27,8 @@ RSpec.feature "Distributions", type: :feature, focus: true do
     select @partner.name, from: "Partner"
     select "", from: "From storage location"
 
-    click_button "Preview Distribution"
+    click_button "Save", match: :first
     expect(page).to have_content "An error occurred, try again?"
-  end
-
-  scenario "User can create a distribution from donation" do
-    @donation = create :donation, :with_items
-
-    visit @url_prefix + "/donations/#{@donation.id}"
-    click_on "Create distribution"
-    select @partner.name, from: "Partner"
-    click_button "Preview Distribution"
-    expect(page).to have_content "Distribution Manifest for"
-    click_button "Confirm Distribution"
-    expect(page.find(".alert-info")).to have_content "reated"
   end
 
   context "When creating a distribution from a donation" do

--- a/spec/features/distribution_spec.rb
+++ b/spec/features/distribution_spec.rb
@@ -1,4 +1,4 @@
-RSpec.feature "Distributions", type: :feature do
+RSpec.feature "Distributions", type: :feature, focus: true do
   before do
     sign_in(@user)
     @url_prefix = "/#{@organization.to_param}"
@@ -17,8 +17,29 @@ RSpec.feature "Distributions", type: :feature do
 
     fill_in "Comment", with: "Take my wipes... please"
     click_button "Save", match: :first
-
     expect(page).to have_content "Distributions"
+    expect(page.find(".alert-info")).to have_content "reated"
+  end
+
+  scenario "User doesn't fill storage_location" do
+    visit @url_prefix + "/distributions/new"
+
+    select @partner.name, from: "Partner"
+    select "", from: "From storage location"
+
+    click_button "Preview Distribution"
+    expect(page).to have_content "An error occurred, try again?"
+  end
+
+  scenario "User can create a distribution from donation" do
+    @donation = create :donation, :with_items
+
+    visit @url_prefix + "/donations/#{@donation.id}"
+    click_on "Create distribution"
+    select @partner.name, from: "Partner"
+    click_button "Preview Distribution"
+    expect(page).to have_content "Distribution Manifest for"
+    click_button "Confirm Distribution"
     expect(page.find(".alert-info")).to have_content "reated"
   end
 


### PR DESCRIPTION
Resolves #532 

### Description
Just adding a return on method (like a pre-condition), so that we avoid 500 because `storage_location` is `nil`

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested manually, seems like there is no 500 anymore on this, still, any idea on how to test that part?

