### PR TITLE
Fixes #526 - Increment barcode entry field ids

### DIFF
--- a/app/assets/javascripts/adjustments.coffee
+++ b/app/assets/javascripts/adjustments.coffee
@@ -22,6 +22,7 @@ $ ->
 
   $(document).on "cocoon:after-insert", "form#new_adjustment", (e, insertedItem) ->
     control = $(control_id)
+    insertedItem.find('#_barcode-lookup-new_line_items').attr('id', '_barcode-lookup-' + ($('.nested-fields').size() - 1))
     $.ajax
       url: control.data("storage-location-inventory-path").replace(":id", control.val())
       dataType: "json"

--- a/app/assets/javascripts/distributions_and_transfers.coffee
+++ b/app/assets/javascripts/distributions_and_transfers.coffee
@@ -29,6 +29,7 @@ $ ->
         populate_dropdowns $("#distribution_line_items select, #donation_line_items select"), data
 
   $(document).on "cocoon:after-insert", "form#new_transfer, form#new_distribution", (e, insertedItem) ->
+    insertedItem.find('#_barcode-lookup-new_line_items').attr('id', '_barcode-lookup-' + ($('.nested-fields').size() - 1))
     control = $("select#transfer_from_id, select#distribution_storage_location_id")
     $.ajax
       url: control.data("storage-location-inventory-path").replace(":id", control.val())

--- a/app/assets/javascripts/donations.coffee.erb
+++ b/app/assets/javascripts/donations.coffee.erb
@@ -35,3 +35,6 @@ $ ->
       $(donation_site_container_id).hide()
 
   $(control_id).change()
+
+  $(document).on "cocoon:after-insert", "form#new_donation", (e, insertedItem) ->
+    insertedItem.find('#_barcode-lookup-new_line_items').attr('id', '_barcode-lookup-' + ($('.nested-fields').size() - 1))

--- a/app/views/barcode_items/_barcode_item_lookup.html.erb
+++ b/app/views/barcode_items/_barcode_item_lookup.html.erb
@@ -1,4 +1,2 @@
 <% # Increment a counter on how many we've seen so that we can create a unique ID -- really only necessary for test hooks # %>
-<% barcode_lookup_id = "_barcode-lookup-" + (@barcode_item_lookup_count = (@barcode_item_lookup_count || -1) + 1).to_s %>
-<input type="text" id="<%= barcode_lookup_id %>" class="__barcode_item_lookup form-control" value="" placeholder="Barcode Entry" data-organization-id="<%= params[:organization_id] %>" />
-
+<input type="text" id=<%= "_barcode-lookup-#{index}" %> class="__barcode_item_lookup form-control" value="" placeholder="Barcode Entry" data-organization-id="<%= params[:organization_id] %>" />

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,9 +1,9 @@
 <div class="nested-fields">
-  <%= render partial: "barcode_items/barcode_item_lookup" %>
+  <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
   <label>OR</label>
   <%= f.input_field :item_id, collection: @items, prompt: "Choose an item", class: 'form-control' %>
   <%= f.input_field :quantity, placeholder: "Quantity", class: 'form-control' %>
   <%= link_to_remove_association f, class: "btn btn-sm btn-danger"  do %>
     <%= fa_icon "trash" %> Delete
-  <% end %> 
+  <% end %>
 </div>

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -237,13 +237,11 @@ RSpec.feature "Donations", type: :feature, js: true do
       end
 
       # Bug fix -- Issue #526
-      scenario "Bar code fields have unique ids"
-        within "#donation_line_items" do
-          click_button "__add_line_item"
-          click_button "__add_line_item"
-          expect(page).to have_xpath("//input[@id='_barcode-lookup-1']")
-          expect(page).to have_xpath("//input[@id='_barcode-lookup-2']")
-        end
+      scenario "Bar code fields have unique ids" do
+        click_button "__add_line_item"
+        click_button "__add_line_item"
+        expect(page).to have_xpath("//input[@id='_barcode-lookup-1']")
+        expect(page).to have_xpath("//input[@id='_barcode-lookup-2']")
       end
     end
 

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -238,8 +238,8 @@ RSpec.feature "Donations", type: :feature, js: true do
 
       # Bug fix -- Issue #526
       scenario "Bar code fields have unique ids" do
-        click_button "__add_line_item"
-        click_button "__add_line_item"
+        page.find(:css, "#__add_line_item").click
+        page.find(:css, "#__add_line_item").click
         expect(page).to have_xpath("//input[@id='_barcode-lookup-1']")
         expect(page).to have_xpath("//input[@id='_barcode-lookup-2']")
       end

--- a/spec/features/donation_spec.rb
+++ b/spec/features/donation_spec.rb
@@ -235,6 +235,16 @@ RSpec.feature "Donations", type: :feature, js: true do
         expect(page).to have_content("error")
         expect(page).to have_xpath("//select[@id='donation_line_items_attributes_0_item_id']/option", count: item_count)
       end
+
+      # Bug fix -- Issue #526
+      scenario "Bar code fields have unique ids"
+        within "#donation_line_items" do
+          click_button "__add_line_item"
+          click_button "__add_line_item"
+          expect(page).to have_xpath("//input[@id='_barcode-lookup-1']")
+          expect(page).to have_xpath("//input[@id='_barcode-lookup-2']")
+        end
+      end
     end
 
     context "via barcode entry" do


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #526 

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
Adds a cocoon callback to increment the id of the barcode field when entering line items.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added an automated test to donation_spec.

Verified behavior in browser. Also added callback to all forms I could find that use the same partial. To verify in brower: Go to new inventory page (or other page with the "Add new items" button) add a few line items and then inspect the HTML to verify that each one has a unique id on the barcode input field.
<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
