### PR TITLE
Clean up static attribute deprecation warnings for FactoryBot 5.0

### DIFF
--- a/spec/factories/adjustments.rb
+++ b/spec/factories/adjustments.rb
@@ -13,8 +13,8 @@
 FactoryBot.define do
   factory :adjustment do
     organization { Organization.try(:first) || create(:organization) }
-    storage_location nil
-    comment "A comment"
+    storage_location { nil }
+    comment { "A comment" }
 
     after(:build) do |instance, evaluator|
       instance.storage_location = evaluator.storage_location || create(:storage_location, organization: instance.organization)
@@ -22,8 +22,8 @@ FactoryBot.define do
 
     trait :with_items do
       transient do
-        item_quantity 100
-        item nil
+        item_quantity { 100 }
+        item { nil }
       end
 
       after(:build) do |instance, evaluator|

--- a/spec/factories/barcode_items.rb
+++ b/spec/factories/barcode_items.rb
@@ -16,9 +16,9 @@
 FactoryBot.define do
   factory :global_barcode_item, class: "BarcodeItem" do
     sequence(:value) { (SecureRandom.random_number * (10**12)).to_i } # 037000863427
-    quantity 50
+    quantity { 50 }
     barcodeable { create(:canonical_item) }
-    global true
+    global { true }
     # after(:build) do |instance, evaluator|
     #   instance.barcodeable = evaluator.barcodeable || create(:canonical_item, organization: instance.organization)
     # end
@@ -27,9 +27,9 @@ FactoryBot.define do
   factory :barcode_item, class: "BarcodeItem" do
     organization { Organization.try(:first) || create(:organization) }
     sequence(:value) { (SecureRandom.random_number * (10**12)).to_i } # 037000863427
-    quantity 50
-    barcodeable nil # { create(:item, organization: organization) }
-    global false
+    quantity { 50 }
+    barcodeable { nil } # { create(:item, organization: organization) }
+    global { false }
 
     after(:build) do |instance, evaluator|
       instance.barcodeable = evaluator.barcodeable || create(:item,

--- a/spec/factories/canonical_items.rb
+++ b/spec/factories/canonical_items.rb
@@ -16,8 +16,8 @@
 FactoryBot.define do
   factory :canonical_item do
     sequence(:name) { |size| "#{size}T Diapers" }
-    category "Infant Diapers"
-    size nil
+    category { "Infant Diapers" }
+    size { nil }
     sequence(:partner_key) { |n| "#{n}t_diapers" }
   end
 end

--- a/spec/factories/diaper_drive_participants.rb
+++ b/spec/factories/diaper_drive_participants.rb
@@ -19,10 +19,10 @@
 FactoryBot.define do
   factory :diaper_drive_participant do
     organization { Organization.try(:first) || create(:organization) }
-    contact_name "Don Draper"
-    business_name "Awesome Business"
+    contact_name { "Don Draper" }
+    business_name { "Awesome Business" }
     sequence(:email) { |n| "don#{n}@scdp.com" }
-    phone "212-555-1111"
-    comment "A bit of a lush and philanderer."
+    phone { "212-555-1111" }
+    comment { "A bit of a lush and philanderer." }
   end
 end

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -18,12 +18,12 @@ FactoryBot.define do
     storage_location
     partner
     organization { Organization.try(:first) || create(:organization) }
-    issued_at nil
+    issued_at { nil }
 
     trait :with_items do
       transient do
-        item_quantity 100
-        item nil
+        item_quantity { 100 }
+        item { nil }
       end
 
       storage_location { create :storage_location, :with_items, item: item }

--- a/spec/factories/donation_site.rb
+++ b/spec/factories/donation_site.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :donation_site do
     organization { Organization.try(:first) || create(:organization) }
-    name "Smithsonian Conservation Center"
-    address "1111 Panda ave. Front Royal, VA 12345"
+    name { "Smithsonian Conservation Center" }
+    address { "1111 Panda ave. Front Royal, VA 12345" }
   end
 end

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -20,17 +20,17 @@ FactoryBot.define do
     donation_site
     diaper_drive_participant
     source { Donation::SOURCES[:misc] }
-    comment "It's a fine day for diapers."
+    comment { "It's a fine day for diapers." }
     storage_location
     organization { Organization.try(:first) || create(:organization) }
-    issued_at nil
+    issued_at { nil }
 
     trait :with_items do
       storage_location { create :storage_location, :with_items, item: item || create(:item), organization: organization }
 
       transient do
-        item_quantity 100
-        item nil
+        item_quantity { 100 }
+        item { nil }
       end
 
       after(:build) do |instance, evaluator|

--- a/spec/factories/inventory_items.rb
+++ b/spec/factories/inventory_items.rb
@@ -12,7 +12,7 @@
 
 FactoryBot.define do
   factory :inventory_item do
-    quantity 300
+    quantity { 300 }
     item
     storage_location
   end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -17,7 +17,7 @@ FactoryBot.define do
   factory :item do
     canonical_item { CanonicalItem.first }
     sequence(:name) { |n| "#{n}T Diapers" }
-    category "disposable"
+    category { "disposable" }
     organization { Organization.try(:first) || create(:organization) }
   end
 end

--- a/spec/factories/line_items.rb
+++ b/spec/factories/line_items.rb
@@ -13,9 +13,9 @@
 
 FactoryBot.define do
   factory :line_item do
-    quantity 1
+    quantity { 1 }
     item
-    itemizable_type "Donation"
+    itemizable_type { "Donation" }
     itemizable_id { create(:donation).id }
 
     trait :donation do
@@ -25,7 +25,7 @@ FactoryBot.define do
     end
 
     trait :distribution do
-      itemizable_type "Distribution"
+      itemizable_type { "Distribution" }
       itemizable_id { create(:distribution).id }
     end
   end

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -15,24 +15,24 @@
 
 FactoryBot.define do
   factory :purchase do
-    comment "It's a fine day for diapers."
-    purchased_from "Google"
+    comment { "It's a fine day for diapers." }
+    purchased_from { "Google" }
     storage_location
     organization { Organization.try(:first) || create(:organization) }
-    issued_at nil
-    amount_spent 10
+    issued_at { nil }
+    amount_spent { 10 }
 
     transient do
-      item_quantity 10
-      item_id nil
+      item_quantity { 10 }
+      item_id { nil }
     end
 
     trait :with_items do
       storage_location { create :storage_location, :with_items }
 
       transient do
-        item_quantity 100
-        item nil
+        item_quantity { 100 }
+        item { nil }
       end
 
       after(:build) do |instance, evaluator|

--- a/spec/factories/request.rb
+++ b/spec/factories/request.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     partner { Partner.try(:first) || create(:partner) }
     organization { Organization.try(:first) || create(:organization) }
     request_items { random_keys(3).collect { |k| [k, rand(3..10)] }.to_h }
-    status "Active"
-    comments "Urgent"
+    status { "Active" }
+    comments { "Urgent" }
   end
 end

--- a/spec/factories/storage_locations.rb
+++ b/spec/factories/storage_locations.rb
@@ -14,14 +14,14 @@
 
 FactoryBot.define do
   factory :storage_location do
-    name "Smithsonian Institute"
-    address "1500 Remount Road, Front Royal, VA"
+    name { "Smithsonian Institute" }
+    address { "1500 Remount Road, Front Royal, VA" }
     organization { Organization.try(:first) || create(:organization) }
 
     trait :with_items do
       transient do
-        item_quantity 100
-        item nil
+        item_quantity { 100 }
+        item { nil }
       end
 
       after(:create) do |storage_location, evaluator|

--- a/spec/factories/transfers.rb
+++ b/spec/factories/transfers.rb
@@ -14,12 +14,12 @@
 FactoryBot.define do
   factory :transfer do
     transient do
-      storage_location nil
+      storage_location { nil }
     end
     organization { Organization.try(:first) || create(:organization) }
-    from nil
-    to nil
-    comment "A comment"
+    from { nil }
+    to { nil }
+    comment { "A comment" }
 
     after(:build) do |instance, evaluator|
       # the Itemizable shared_example needs `storage_location` to be an option
@@ -29,8 +29,8 @@ FactoryBot.define do
 
     trait :with_items do
       transient do
-        item_quantity 100
-        item nil
+        item_quantity { 100 }
+        item { nil }
       end
 
       after(:build) do |instance, evaluator|

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -31,20 +31,20 @@
 
 FactoryBot.define do
   factory :user do
-    name "Diaper McDiaperface"
+    name { "Diaper McDiaperface" }
     sequence(:email, 100) { |n| "person#{n}@example.com" }
-    password "password"
-    password_confirmation "password"
+    password { "password" }
+    password_confirmation { "password" }
     organization { Organization.try(:first) || create(:organization) }
 
     factory :organization_admin do
-      name "Very Organized Admin"
-      organization_admin true
+      name { "Very Organized Admin" }
+      organization_admin { true }
     end
 
     factory :super_admin do
-      name "Administrative User"
-      super_admin true
+      name { "Administrative User" }
+      super_admin { true }
     end
   end
 end


### PR DESCRIPTION
### Description
Cleaning up the deprecation warnings coming from FactoryBot regarding static attributes being removed in FactoryBot 5.0

More info: https://robots.thoughtbot.com/deprecating-static-attributes-in-factory_bot-4-11

This seemed like an easy place to start, and a nice way to clean up test output as I was trying to diagnose a few failing specs.

### Type of change
* Test fixture update

### How Has This Been Tested?
I ran the full test suite and verified no change from the previous run. This is not a full green run due to aforementioned test failures (present in master) but I verified no other tests were failing.