### PR TITLE
Fixes #546 Fixes the 3 failing specs

### DIFF
--- a/app/assets/javascripts/distributions_and_transfers.coffee
+++ b/app/assets/javascripts/distributions_and_transfers.coffee
@@ -20,7 +20,7 @@ populate_dropdowns = (objects, inventory) ->
     $(element).find("option").remove().end().append(options)
 
 request_storage_location_and_populate_item = (item_to_populate) ->
-  control = $("select#transfer_from_id, select#distribution_storage_location_id")
+  control = $("select.storage-location-source")
   return if (control.length is 0 || !control.val())
 
   $.ajax
@@ -30,19 +30,20 @@ request_storage_location_and_populate_item = (item_to_populate) ->
       populate_dropdowns item_to_populate, data
 
 $ ->
-  control = $("select#transfer_from_id, select#distribution_storage_location_id")
-  default_item = $("#distribution_line_items select, #donation_line_items select")
+  control = $("select.storage-location-source")
+  storage_location_required = $("form.storage-location-required").length > 0
+  default_item = $(".line-item-fields select")
 
-  $(document).on "change", "select#transfer_from_id, select#distribution_storage_location_id", ->
-    $('#__add_line_item').addClass('disabled') if !control.val()
-    $('#__add_line_item').removeClass('disabled') if control.val()
+  $(document).on "change", "select.storage-location-source", ->
+    $('#__add_line_item').addClass('disabled') if storage_location_required && !control.val()
+    $('#__add_line_item').removeClass('disabled') if storage_location_required && control.val()
 
     request_storage_location_and_populate_item(default_item)
 
-  $(document).on "cocoon:after-insert", "form#new_transfer, form#new_distribution", (e, insertedItem) ->
+  $(document).on "cocoon:after-insert", "form.storage-location-required", (e, insertedItem) ->
     request_storage_location_and_populate_item($("select", insertedItem))
     insertedItem.find('#_barcode-lookup-new_line_items').attr('id', '_barcode-lookup-' + ($('.nested-fields').size() - 1))
-    control = $("select#transfer_from_id, select#distribution_storage_location_id")
+    control = $("select.storage-location-source")
     $.ajax
       url: control.data("storage-location-inventory-path").replace(":id", control.val())
       dataType: "json"
@@ -50,6 +51,6 @@ $ ->
         populate_dropdowns $("select", insertedItem), data
 
   $ ->
-    $('#__add_line_item').addClass('disabled') if !control.val()
+    $('#__add_line_item').addClass('disabled') if storage_location_required && !control.val()
 
     request_storage_location_and_populate_item(default_item)

--- a/app/views/adjustments/new.html.erb
+++ b/app/views/adjustments/new.html.erb
@@ -26,36 +26,23 @@
   <div class="box-body">
 <p class="help">Enter a negative (-) amount for <code>quantity</code> if you want to subtract that kind of item.</p>
 <p class="help">Simply enter an amount for <code>quantity</code> if you want to add that kind of item.</p>
-<%= simple_form_for @adjustment do |f| %>
+<%= simple_form_for @adjustment, html: { class: "storage-location-required" } do |f| %>
 
-  <%= f.association :storage_location,
-    collection: @storage_locations,
-    label: "From storage location",
-    error: "Which location are you moving inventory from?",
-    input_html: {
-      data: {
-        storage_location_inventory_path: inventory_storage_location_path(
-          organization_id: current_organization,
-          id: ":id",
-          format: :json
-        )
-      }
-    }
-  %>
+  <%= render partial: "storage_locations/source", object: f %>
 
   <%= f.input :comment %>
 
 
     <fieldset style="margin-bottom: 2rem;" class="form-inline">
-      <legend>Items in this donation</legend>
+      <legend>Items in this adjustment</legend>
       <%= f.simple_fields_for :line_items do |item| %>
-        <div id="donation_line_items" data-capture-barcode="true">
+        <div id="adjustment_line_items" class="line-item-fields" data-capture-barcode="true">
           <%= render 'line_items/line_item_fields', f: item %>
         </div>
       <% end %>
       <div class="row links">
         <div class="col-xs-12">
-          <%= add_line_item_button f, "#donation_line_items" %>
+          <%= add_line_item_button f, "#adjustment_line_items" %>
         </div>
       </div>
 

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -21,7 +21,7 @@
 <div class="box">
   <div class="box-body">
 
-  <%= simple_form_for @distribution do |f| %>
+  <%= simple_form_for @distribution, html: { class: "storage-location-required" } do |f| %>
 
     <%= f.association :partner,
       collection: current_organization.partners,    
@@ -31,28 +31,15 @@
       <%= f.input :issued_at, as: :date, label: "Distribution date" %>
       <%= f.input :agency_rep, label: "Agency representative" %>
 
-    <%= f.association :storage_location,
-      collection: @storage_locations,
-      label: "From storage location",
-      error: "Which location are you moving inventory from?",
-      input_html: {
-        data: {
-          storage_location_inventory_path: inventory_storage_location_path(
-            organization_id: current_organization,
-            id: ":id",
-            format: :json
-          )
-        }
-      }
-    %>
-
+    <%= render partial: "storage_locations/source", object: f %>
+    
     <%= f.input :comment, label: "Comment" %>
 
 
     <fieldset style="margin-bottom: 2rem;" class="form-inline">
       <legend>Items in this distribution</legend>
       <%= f.simple_fields_for :line_items do |item| %>
-        <div id="distribution_line_items" data-capture-barcode="true">
+        <div id="distribution_line_items" class="line-item-fields" data-capture-barcode="true">
           <%= render 'line_items/line_item_fields', f: item %>
         </div>
       <% end %>

--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -21,7 +21,7 @@
 <div class="box">
   <div class="box-body">
 
-  <%= simple_form_for @distribution do |f| %>
+  <%= simple_form_for @distribution, html: { class: "storage-location-required" } do |f| %>
 
     <%= f.association :partner,
       collection: current_organization.partners,    
@@ -31,28 +31,15 @@
       <%= f.input :issued_at, as: :date, label: "Distribution pick-up date" %>
       <%= f.input :agency_rep, label: "Agency representative" %>
 
-    <%= f.association :storage_location,
-      collection: @storage_locations,
-      label: "From storage location",
-      error: "Which location are you moving inventory from?",
-      input_html: {
-        data: {
-          storage_location_inventory_path: inventory_storage_location_path(
-            organization_id: current_organization,
-            id: ":id",
-            format: :json
-          )
-        }
-      }
-    %>
-
+    <%= render partial: "storage_locations/source", object: f %>
+    
     <%= f.input :comment, label: "Comment" %>
 
 
     <fieldset style="margin-bottom: 2rem;" class="form-inline">
       <legend>Items in this distribution</legend>
       <%= f.simple_fields_for :line_items do |item| %>
-        <div id="distribution_line_items" data-capture-barcode="true">
+        <div id="distribution_line_items" class="line-item-fields" data-capture-barcode="true">
           <%= render 'line_items/line_item_fields', f: item %>
         </div>
       <% end %>

--- a/app/views/storage_locations/_source.html.erb
+++ b/app/views/storage_locations/_source.html.erb
@@ -1,0 +1,21 @@
+<%
+  storage_locations ||= @storage_locations
+  label ||= "From storage location"
+  error ||= "Which location are you moving inventory from?"
+  association_field ||= :storage_location
+%>
+<%= source.association association_field,
+  collection: storage_locations,
+  label: label,
+  error: error,
+  input_html: {
+    data: {
+      storage_location_inventory_path: inventory_storage_location_path(
+        organization_id: current_organization,
+        id: ":id",
+        format: :json
+      )
+    },
+    class: "storage-location-source"
+  }
+%>

--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -26,22 +26,8 @@
 
   <div class="box-body">
 
-  <%= simple_form_for @transfer do |f| %>
-
-    <%= f.association :from,
-      collection: @storage_locations,
-      label: "From storage location",
-      error: "Which location are you moving inventory from?",
-      input_html: {
-        data: {
-          storage_location_inventory_path: inventory_storage_location_path(
-            organization_id: current_organization,
-            id: ":id",
-            format: :json
-          )
-        }
-      }
-    %>
+  <%= simple_form_for @transfer, html: { class: "storage-location-required" } do |f| %>
+    <%= render partial: "storage_locations/source", object: f, locals: { label: "From storage location", error: "Which location are you moving inventory from?", association_field: :from } %>
 
     <%= f.association :to,
       collection: @storage_locations,
@@ -53,7 +39,7 @@
     <fieldset style="margin-bottom: 2rem;" class="form-inline">
       <legend>Items in this donation</legend>
       <%= f.simple_fields_for :line_items do |item| %>
-        <div id="donation_line_items" data-capture-barcode="true">
+        <div id="donation_line_items" class="line-item-fields" data-capture-barcode="true">
           <%= render 'line_items/line_item_fields', f: item %>
         </div>
       <% end %>


### PR DESCRIPTION
There were 3 failing specs.

What was happening was that `distributions-and-transfers.js.coffee` was *always* disabling the "add line item" button, but it was only re-enabling it on the Distributions and Transfers views (id-specific).

I refactored the association selector for storage location to a partial and added a class to the select box, and generalized it with some parameters, and added a `donation-source-required` class to the forms that should require a donation source be chosen before line items can be added. 

I modified the JS to hook into the classes to wire up all the events. If the view doesn't have the appropriate classes, it's left alone.

Specs run clean now.