### PR TITLE
Fixes #540: Refactor `import_csv` behavior into a concern 

### DIFF
--- a/app/controllers/concerns/importable.rb
+++ b/app/controllers/concerns/importable.rb
@@ -1,6 +1,24 @@
 module Importable
   extend ActiveSupport::Concern
 
+  # Importable adds an `import_csv` action that that responds to routes like this:
+  #
+  #  resources :storage_locations do
+  #    collection do
+  #      post :import_csv
+  #    end
+  #  end
+  #
+  # If the model doing the import doesn't match the controller's name, you
+  # should update the add a `resource_model` method and to override the default
+  # class, e.g.
+  #
+  #  class Admin::LocationsController
+  #    def resource_model
+  #      Location
+  #    end
+  #  end
+
   included do
     helper_method :current_organization, :current_user
   end
@@ -9,7 +27,7 @@ module Importable
     if params[:file].present?
       data = File.read(params[:file].path, encoding: "BOM|UTF-8")
       resource_model.import_csv(data, current_organization.id)
-      flash[:notice] = "#{resource_model_name_plural} were imported successfully!"
+      flash[:notice] = "#{resource_model_humanized} were imported successfully!"
     else
       flash[:error] = "No file was attached!"
     end
@@ -22,7 +40,7 @@ module Importable
     controller_name.classify.constantize
   end
 
-  def resource_model_name_plural
+  def resource_model_humanized
     controller_name.humanize
   end
 end

--- a/app/controllers/concerns/importable.rb
+++ b/app/controllers/concerns/importable.rb
@@ -1,0 +1,28 @@
+module Importable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :current_organization, :current_user
+  end
+
+  def import_csv
+    if params[:file].present?
+      data = File.read(params[:file].path, encoding: "BOM|UTF-8")
+      resource_model.import_csv(data, current_organization.id)
+      flash[:notice] = "#{resource_model_name_plural} were imported successfully!"
+    else
+      flash[:error] = "No file was attached!"
+    end
+    redirect_back(fallback_location: { action: :index, organization_id: current_organization })
+  end
+
+  private
+
+  def resource_model
+    controller_name.classify.constantize
+  end
+
+  def resource_model_name_plural
+    controller_name.humanize
+  end
+end

--- a/app/controllers/diaper_drive_participants_controller.rb
+++ b/app/controllers/diaper_drive_participants_controller.rb
@@ -1,4 +1,6 @@
 class DiaperDriveParticipantsController < ApplicationController
+  include Importable
+
   def index
     @diaper_drive_participants = current_organization.diaper_drive_participants.includes(:donations).all.order(:business_name)
   end
@@ -42,18 +44,6 @@ class DiaperDriveParticipantsController < ApplicationController
     else
       flash[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
-    end
-  end
-
-  def import_csv
-    if params[:file].nil?
-      redirect_back(fallback_location: diaper_drive_participants_path(organization_id: current_organization))
-      flash[:error] = "No file was attached!"
-    else
-      filepath = params[:file].read
-      DiaperDriveParticipant.import_csv(filepath, current_organization.id)
-      flash[:notice] = "Diaper drive participants were imported successfully!"
-      redirect_back(fallback_location: diaper_drive_participants_path(organization_id: current_organization))
     end
   end
 

--- a/app/controllers/donation_sites_controller.rb
+++ b/app/controllers/donation_sites_controller.rb
@@ -1,4 +1,6 @@
 class DonationSitesController < ApplicationController
+  include Importable
+
   def index
     @donation_sites = current_organization.donation_sites.all.order(:name)
     @donation_site = current_organization.donation_sites.new
@@ -41,18 +43,6 @@ class DonationSitesController < ApplicationController
     else
       flash[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
-    end
-  end
-
-  def import_csv
-    if params[:file].nil?
-      redirect_back(fallback_location: donation_sites_path(organization_id: current_organization))
-      flash[:error] = "No file was attached!"
-    else
-      filepath = params[:file].read
-      DonationSite.import_csv(filepath, current_organization.id)
-      flash[:notice] = "Donation sites were imported successfully!"
-      redirect_back(fallback_location: donation_sites_path(organization_id: current_organization))
     end
   end
 

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -1,4 +1,6 @@
 class PartnersController < ApplicationController
+  include Importable
+
   def index
     @partners = current_organization.partners.order(:name)
   end
@@ -43,18 +45,6 @@ class PartnersController < ApplicationController
     else
       flash[:error] = "Something didn't work quite right -- try again?"
       render action: :edit
-    end
-  end
-
-  def import_csv
-    if params[:file].present?
-      filepath = params[:file].path
-      Partner.import_csv(filepath, current_organization.id)
-      flash[:notice] = "Partners were imported successfully!"
-      redirect_back(fallback_location: partners_path(organization_id: current_organization))
-    else
-      redirect_back(fallback_location: partners_path(organization_id: current_organization))
-      flash[:error] = "No file was attached!"
     end
   end
 

--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -1,4 +1,6 @@
 class StorageLocationsController < ApplicationController
+  include Importable
+
   def index
     @items = current_organization.storage_locations.items_inventoried
     @storage_locations = current_organization.storage_locations.includes(:inventory_items).filter(filter_params)
@@ -79,18 +81,6 @@ LEFT OUTER JOIN transfers ON transfers.id = line_items.itemizable_id AND line_it
       filepath = params[:file].read
       StorageLocation.import_inventory(filepath, current_organization.id, params[:storage_location])
       flash[:notice] = "Inventory imported successfully!"
-      redirect_back(fallback_location: storage_locations_path(organization_id: current_organization))
-    end
-  end
-
-  def import_csv
-    if params[:file].nil?
-      redirect_back(fallback_location: storage_locations_path(organization_id: current_organization))
-      flash[:error] = "No file was attached!"
-    else
-      filepath = params[:file].read
-      StorageLocation.import_csv(filepath, current_organization.id)
-      flash[:notice] = "Storage locations were imported successfully!"
       redirect_back(fallback_location: storage_locations_path(organization_id: current_organization))
     end
   end

--- a/app/models/diaper_drive_participant.rb
+++ b/app/models/diaper_drive_participant.rb
@@ -39,8 +39,8 @@ class DiaperDriveParticipant < ApplicationRecord
     donations.map { |d| d.line_items.total }.reduce(:+)
   end
 
-  def self.import_csv(filename, organization)
-    CSV.parse(filename, headers: true) do |row|
+  def self.import_csv(data, organization)
+    CSV.parse(data, headers: true) do |row|
       loc = DiaperDriveParticipant.new(row.to_hash)
       loc.organization_id = organization
       loc.save!

--- a/app/models/donation_site.rb
+++ b/app/models/donation_site.rb
@@ -28,8 +28,8 @@ class DonationSite < ApplicationRecord
       .order(:name)
   }
 
-  def self.import_csv(filename, organization)
-    CSV.parse(filename, headers: true) do |row|
+  def self.import_csv(data, organization)
+    CSV.parse(data, headers: true) do |row|
       loc = DonationSite.new(row.to_hash)
       loc.organization_id = organization
       loc.save!

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -29,8 +29,7 @@ class Partner < ApplicationRecord
   include DiaperPartnerClient
   after_create :update_diaper_partner
   # better to extract this outside of the model
-  def self.import_csv(filepath, organization_id)
-    data = File.read(filepath, encoding: "BOM|UTF-8")
+  def self.import_csv(data, organization_id)
     CSV.parse(data, headers: true) do |row|
       hash_rows = Hash[row.to_hash.map { |k, v| [k.downcase, v] }]
       loc = Partner.new(hash_rows)

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -155,8 +155,8 @@ class StorageLocation < ApplicationRecord
     update_inventory_inventory_items(updated_quantities)
   end
 
-  def self.import_csv(filename, organization)
-    CSV.parse(filename, headers: true) do |row|
+  def self.import_csv(data, organization)
+    CSV.parse(data, headers: true) do |row|
       loc = StorageLocation.new(row.to_hash)
       loc.organization_id = organization
       loc.save!

--- a/spec/controllers/diaper_drive_participants_controller_spec.rb
+++ b/spec/controllers/diaper_drive_participants_controller_spec.rb
@@ -29,6 +29,37 @@ RSpec.describe DiaperDriveParticipantsController, type: :controller do
       end
     end
 
+    describe "POST #import_csv" do
+      context "with a csv file" do
+        let(:file) { Rack::Test::UploadedFile.new "spec/fixtures/diaper_drive_participants.csv", "text/csv" }
+        subject { post :import_csv, params: default_params.merge(file: file) }
+
+        it "invokes DiaperDriveParticipant.import_csv" do
+          expect(DiaperDriveParticipant).to respond_to(:import_csv).with(2).arguments
+        end
+
+        it "redirects to :index" do
+          expect(subject).to redirect_to(diaper_drive_participants_path(organization_id: @organization))
+        end
+
+        it "presents a flash notice message" do
+          expect(subject.request.flash[:notice]).to eq "Diaper drive participants were imported successfully!"
+        end
+      end
+
+      context "without a csv file" do
+        subject { post :import_csv, params: default_params }
+
+        it "redirects to :index" do
+          expect(subject).to redirect_to(diaper_drive_participants_path(organization_id: @organization))
+        end
+
+        it "presents a flash error message" do
+          expect(subject.request.flash[:error]).to eq "No file was attached!"
+        end
+      end
+    end
+
     describe "GET #show" do
       subject { get :show, params: default_params.merge(id: create(:diaper_drive_participant, organization: @organization)) }
       it "returns http success" do

--- a/spec/controllers/diaper_drive_participants_controller_spec.rb
+++ b/spec/controllers/diaper_drive_participants_controller_spec.rb
@@ -30,34 +30,8 @@ RSpec.describe DiaperDriveParticipantsController, type: :controller do
     end
 
     describe "POST #import_csv" do
-      context "with a csv file" do
-        let(:file) { Rack::Test::UploadedFile.new "spec/fixtures/diaper_drive_participants.csv", "text/csv" }
-        subject { post :import_csv, params: default_params.merge(file: file) }
-
-        it "invokes DiaperDriveParticipant.import_csv" do
-          expect(DiaperDriveParticipant).to respond_to(:import_csv).with(2).arguments
-        end
-
-        it "redirects to :index" do
-          expect(subject).to redirect_to(diaper_drive_participants_path(organization_id: @organization))
-        end
-
-        it "presents a flash notice message" do
-          expect(subject.request.flash[:notice]).to eq "Diaper drive participants were imported successfully!"
-        end
-      end
-
-      context "without a csv file" do
-        subject { post :import_csv, params: default_params }
-
-        it "redirects to :index" do
-          expect(subject).to redirect_to(diaper_drive_participants_path(organization_id: @organization))
-        end
-
-        it "presents a flash error message" do
-          expect(subject.request.flash[:error]).to eq "No file was attached!"
-        end
-      end
+      let(:model_class) { DiaperDriveParticipant }
+      it_behaves_like "csv import"
     end
 
     describe "GET #show" do

--- a/spec/controllers/donation_sites_controller_spec.rb
+++ b/spec/controllers/donation_sites_controller_spec.rb
@@ -30,34 +30,8 @@ RSpec.describe DonationSitesController, type: :controller do
     end
 
     describe "POST #import_csv" do
-      context "with a csv file" do
-        let(:file) { Rack::Test::UploadedFile.new "spec/fixtures/donation_sites.csv", "text/csv" }
-        subject { post :import_csv, params: default_params.merge(file: file) }
-
-        it "invokes DonationSite.import_csv" do
-          expect(DonationSite).to respond_to(:import_csv).with(2).arguments
-        end
-
-        it "redirects to :index" do
-          expect(subject).to redirect_to(donation_sites_path(organization_id: @organization))
-        end
-
-        it "presents a flash notice message" do
-          expect(subject.request.flash[:notice]).to eq "Donation sites were imported successfully!"
-        end
-      end
-
-      context "without a csv file" do
-        subject { post :import_csv, params: default_params }
-
-        it "redirects to :index" do
-          expect(subject).to redirect_to(donation_sites_path(organization_id: @organization))
-        end
-
-        it "presents a flash error message" do
-          expect(subject.request.flash[:error]).to eq "No file was attached!"
-        end
-      end
+      let(:model_class) { DonationSite }
+      it_behaves_like "csv import"
     end
 
     describe "GET #show" do

--- a/spec/controllers/donation_sites_controller_spec.rb
+++ b/spec/controllers/donation_sites_controller_spec.rb
@@ -29,6 +29,37 @@ RSpec.describe DonationSitesController, type: :controller do
       end
     end
 
+    describe "POST #import_csv" do
+      context "with a csv file" do
+        let(:file) { Rack::Test::UploadedFile.new "spec/fixtures/donation_sites.csv", "text/csv" }
+        subject { post :import_csv, params: default_params.merge(file: file) }
+
+        it "invokes DonationSite.import_csv" do
+          expect(DonationSite).to respond_to(:import_csv).with(2).arguments
+        end
+
+        it "redirects to :index" do
+          expect(subject).to redirect_to(donation_sites_path(organization_id: @organization))
+        end
+
+        it "presents a flash notice message" do
+          expect(subject.request.flash[:notice]).to eq "Donation sites were imported successfully!"
+        end
+      end
+
+      context "without a csv file" do
+        subject { post :import_csv, params: default_params }
+
+        it "redirects to :index" do
+          expect(subject).to redirect_to(donation_sites_path(organization_id: @organization))
+        end
+
+        it "presents a flash error message" do
+          expect(subject.request.flash[:error]).to eq "No file was attached!"
+        end
+      end
+    end
+
     describe "GET #show" do
       subject { get :show, params: default_params.merge(id: create(:donation_site, organization: @organization)) }
       it "returns http success" do

--- a/spec/controllers/partners_controller_spec.rb
+++ b/spec/controllers/partners_controller_spec.rb
@@ -36,34 +36,8 @@ RSpec.describe PartnersController, type: :controller do
   end
 
   describe "POST #import_csv" do
-    context "with a csv file" do
-      let(:file) { Rack::Test::UploadedFile.new "spec/fixtures/partners.csv", "text/csv" }
-      subject { post :import_csv, params: default_params.merge(file: file) }
-
-      it "invokes Partner.import_csv" do
-        expect(Partner).to respond_to(:import_csv).with(2).arguments
-      end
-
-      it "redirects to :index" do
-        expect(subject).to redirect_to(partners_path(organization_id: @organization))
-      end
-
-      it "presents a flash notice message" do
-        expect(subject.request.flash[:notice]).to eq "Partners were imported successfully!"
-      end
-    end
-
-    context "without a csv file" do
-      subject { post :import_csv, params: default_params }
-
-      it "redirects to :index" do
-        expect(subject).to redirect_to(partners_path(organization_id: @organization))
-      end
-
-      it "presents a flash error message" do
-        expect(subject.request.flash[:error]).to eq "No file was attached!"
-      end
-    end
+    let(:model_class) { Partner }
+    it_behaves_like "csv import"
   end
 
   describe "DELETE #destroy" do

--- a/spec/controllers/partners_controller_spec.rb
+++ b/spec/controllers/partners_controller_spec.rb
@@ -35,6 +35,37 @@ RSpec.describe PartnersController, type: :controller do
     end
   end
 
+  describe "POST #import_csv" do
+    context "with a csv file" do
+      let(:file) { Rack::Test::UploadedFile.new "spec/fixtures/partners.csv", "text/csv" }
+      subject { post :import_csv, params: default_params.merge(file: file) }
+
+      it "invokes Partner.import_csv" do
+        expect(Partner).to respond_to(:import_csv).with(2).arguments
+      end
+
+      it "redirects to :index" do
+        expect(subject).to redirect_to(partners_path(organization_id: @organization))
+      end
+
+      it "presents a flash notice message" do
+        expect(subject.request.flash[:notice]).to eq "Partners were imported successfully!"
+      end
+    end
+
+    context "without a csv file" do
+      subject { post :import_csv, params: default_params }
+
+      it "redirects to :index" do
+        expect(subject).to redirect_to(partners_path(organization_id: @organization))
+      end
+
+      it "presents a flash error message" do
+        expect(subject.request.flash[:error]).to eq "No file was attached!"
+      end
+    end
+  end
+
   describe "DELETE #destroy" do
     subject { delete :destroy, params: default_params.merge(id: create(:partner, organization: @organization)) }
     it "redirects to #index" do

--- a/spec/controllers/storage_locations_controller_spec.rb
+++ b/spec/controllers/storage_locations_controller_spec.rb
@@ -30,34 +30,8 @@ RSpec.describe StorageLocationsController, type: :controller do
     end
 
     describe "POST #import_csv" do
-      context "with a csv file" do
-        let(:file) { Rack::Test::UploadedFile.new "spec/fixtures/storage_locations.csv", "text/csv" }
-        subject { post :import_csv, params: default_params.merge(file: file) }
-
-        it "invokes StorageLocation.import_csv" do
-          expect(StorageLocation).to respond_to(:import_csv).with(2).arguments
-        end
-
-        it "redirects to :index" do
-          expect(subject).to redirect_to(storage_locations_path(organization_id: @organization))
-        end
-
-        it "presents a flash notice message" do
-          expect(subject.request.flash[:notice]).to eq "Storage locations were imported successfully!"
-        end
-      end
-
-      context "without a csv file" do
-        subject { post :import_csv, params: default_params }
-
-        it "redirects to :index" do
-          expect(subject).to redirect_to(storage_locations_path(organization_id: @organization))
-        end
-
-        it "presents a flash error message" do
-          expect(subject.request.flash[:error]).to eq "No file was attached!"
-        end
-      end
+      let(:model_class) { StorageLocation }
+      it_behaves_like "csv import"
     end
 
     describe "GET #show" do

--- a/spec/controllers/storage_locations_controller_spec.rb
+++ b/spec/controllers/storage_locations_controller_spec.rb
@@ -29,6 +29,37 @@ RSpec.describe StorageLocationsController, type: :controller do
       end
     end
 
+    describe "POST #import_csv" do
+      context "with a csv file" do
+        let(:file) { Rack::Test::UploadedFile.new "spec/fixtures/storage_locations.csv", "text/csv" }
+        subject { post :import_csv, params: default_params.merge(file: file) }
+
+        it "invokes StorageLocation.import_csv" do
+          expect(StorageLocation).to respond_to(:import_csv).with(2).arguments
+        end
+
+        it "redirects to :index" do
+          expect(subject).to redirect_to(storage_locations_path(organization_id: @organization))
+        end
+
+        it "presents a flash notice message" do
+          expect(subject.request.flash[:notice]).to eq "Storage locations were imported successfully!"
+        end
+      end
+
+      context "without a csv file" do
+        subject { post :import_csv, params: default_params }
+
+        it "redirects to :index" do
+          expect(subject).to redirect_to(storage_locations_path(organization_id: @organization))
+        end
+
+        it "presents a flash error message" do
+          expect(subject.request.flash[:error]).to eq "No file was attached!"
+        end
+      end
+    end
+
     describe "GET #show" do
       subject { get :show, params: default_params.merge(id: create(:storage_location, organization: @organization)) }
       it "returns http success" do

--- a/spec/models/diaper_drive_participant_spec.rb
+++ b/spec/models/diaper_drive_participant_spec.rb
@@ -50,8 +50,9 @@ RSpec.describe DiaperDriveParticipant, type: :model do
     it "imports storage locations from a csv file" do
       before_import = DiaperDriveParticipant.count
       organization = create(:organization)
-      import_file_path = Rails.root.join("spec", "fixtures", "diaper_drive_participants.csv").read
-      DiaperDriveParticipant.import_csv(import_file_path, organization.id)
+      import_file_path = Rails.root.join("spec", "fixtures", "diaper_drive_participants.csv")
+      data = File.read(import_file_path, encoding: "BOM|UTF-8")
+      DiaperDriveParticipant.import_csv(data, organization.id)
       expect(DiaperDriveParticipant.count).to eq before_import + 3
     end
   end

--- a/spec/models/donation_site_spec.rb
+++ b/spec/models/donation_site_spec.rb
@@ -27,8 +27,9 @@ RSpec.describe DonationSite, type: :model do
   describe "import_csv" do
     it "imports storage locations from a csv file" do
       organization = create(:organization)
-      import_file_path = Rails.root.join("spec", "fixtures", "donation_sites.csv").read
-      DonationSite.import_csv(import_file_path, organization.id)
+      import_file_path = Rails.root.join("spec", "fixtures", "donation_sites.csv")
+      data = File.read(import_file_path, encoding: "BOM|UTF-8")
+      DonationSite.import_csv(data, organization.id)
       expect(DonationSite.count).to eq 3
     end
   end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -57,14 +57,16 @@ RSpec.describe Partner, type: :model do
     it "imports storage locations from a csv file" do
       before_import = Partner.count
       import_file_path = Rails.root.join("spec", "fixtures", "partners.csv")
-      Partner.import_csv(import_file_path, organization.id)
+      data = File.read(import_file_path, encoding: "BOM|UTF-8")
+      Partner.import_csv(data, organization.id)
       expect(Partner.count).to eq before_import + 3
     end
 
     it "imports storage locations from a csv file with BOM encodings" do
       import_file_path = Rails.root.join("spec", "fixtures", "partners_with_bom_encoding.csv")
+      data = File.read(import_file_path, encoding: "BOM|UTF-8")
       expect do
-        Partner.import_csv(import_file_path, organization.id)
+        Partner.import_csv(data, organization.id)
       end.to change { Partner.count }.by(20)
     end
   end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -195,8 +195,9 @@ RSpec.describe StorageLocation, type: :model do
       it "imports storage locations from a csv file" do
         organization
         before_import = StorageLocation.count
-        import_file_path = Rails.root.join("spec", "fixtures", "storage_locations.csv").read
-        StorageLocation.import_csv(import_file_path, organization.id)
+        import_file_path = Rails.root.join("spec", "fixtures", "storage_locations.csv")
+        data = File.read(import_file_path, encoding: "BOM|UTF-8")
+        StorageLocation.import_csv(data, organization.id)
         expect(StorageLocation.count).to eq before_import + 3
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -134,7 +134,13 @@ RSpec.configure do |config|
      "Smithsonian Conservation Center new",
      "3700 O St NW, Washington, DC 20057",
      "1500 Remount Road Front Royal, VA",
-     "1234 Banana Drive Boston, MA 12345"].each do |address|
+     "1234 Banana Drive Boston, MA 12345",
+     "123 Donation Site Way",
+     "456 Donation Site Way",
+     "789 Donation Site Way",
+     "123 Location Way",
+     "456 Location Way",
+     "789 Location Way"].each do |address|
       Geocoder::Lookup::Test.add_stub(
         address, [
           {

--- a/spec/support/csv_import_shared_example.rb
+++ b/spec/support/csv_import_shared_example.rb
@@ -1,0 +1,30 @@
+RSpec.shared_examples "csv import" do
+  context "with a csv file" do
+    let(:file) { Rack::Test::UploadedFile.new "spec/fixtures/#{model_class.name.underscore.pluralize}.csv", "text/csv" }
+    subject { post :import_csv, params: default_params.merge(file: file) }
+
+    it "invokes .import_csv" do
+      expect(model_class).to respond_to(:import_csv).with(2).arguments
+    end
+
+    it "redirects to :index" do
+      expect(subject).to be_redirect
+    end
+
+    it "presents a flash notice message" do
+      expect(subject.request.flash[:notice]).to eq "#{model_class.name.underscore.humanize.pluralize} were imported successfully!"
+    end
+  end
+
+  context "without a csv file" do
+    subject { post :import_csv, params: default_params }
+
+    it "redirects to :index" do
+      expect(subject).to be_redirect
+    end
+
+    it "presents a flash error message" do
+      expect(subject.request.flash[:error]).to eq "No file was attached!"
+    end
+  end
+end


### PR DESCRIPTION
Resolves #540

### Description
- Created a `Importable` concern to replace similar `import_csv` actions among 4 different controllers
  - Had to extract the model name from the controller to make it generic, so I'm assuming the project follows convention over configuration.
- Normalized `<Model.import_csv` methods so all behave the same way (when called from the controller);
  - Noticed that only one of the importers was using File.read(import_file_path, encoding: "BOM|UTF-8")`, but I've made it default for all;
- While using the .csv fixtures available, some tests broke. I figured out this was because the Geocoder `:test` lookup uses hardcoded addresses;
  - I usually use a single stub for any address, but since I didn't wanted to change this radically, I've just added the necessary stubs there.
- Simplified `import_csv` controller tests with a shared_example
  - Had to change a bit the tests wrote on the first commit, since I couldn't pass the url helper to the shared example properly (it depends on one `organization_id` that is only available at a later stage. I guess this is not an issue since the two branches of these controller actions do the exact same redirect.

### Type of change

* Refactor

### How Has This Been Tested?

Wrote separate controller tests before replacing the individual actions with the `Importable` concern.
