### PR TITLE
Disable Rubocop rule enforcing double quoting strings.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -129,7 +129,7 @@ Style/SingleLineMethods:
   Enabled: false
   AllowIfMethodIsEmpty: true
 Style/StringLiterals:
-  Enabled: true
+  Enabled: false
   EnforcedStyle: double_quotes
 Style/StringLiteralsInInterpolation:
   Description: Checks if uses of quotes inside expressions in interpolated strings


### PR DESCRIPTION
Removes the Rubocop prohibition on single quoted strings.