### PR TITLE
Fixes #564 - Distributions now re-activate a deleted item

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -271,6 +271,9 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 Style/FormatStringToken:
   Enabled: false
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"  
 Lint/EachWithObjectArgument:
   Description: Check for immutable argument given to each_with_object.
   Enabled: true

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -231,6 +231,10 @@ class StorageLocation < ApplicationRecord
   def reclaim!(distribution)
     ActiveRecord::Base.transaction do
       distribution.line_items.each do |line_item|
+        if line_item.item.nil? || !line_item.item.active?
+          Item.unscoped.find(line_item.item_id).update(active: true)
+          line_item.reload
+        end
         inventory_item = inventory_items.find_by(item: line_item.item)
         inventory_item.update!(quantity: inventory_item.quantity + line_item.quantity)
       end

--- a/app/views/items/_item_row.html.erb
+++ b/app/views/items/_item_row.html.erb
@@ -1,4 +1,4 @@
-<tr>
+<tr data-item-id="<%= item_row.id %>">
   <td><%= item_row.name %></td>
   <td><%= item_row.category %></td>
   <td><%= item_row.barcode_count %></td>

--- a/spec/features/distribution_spec.rb
+++ b/spec/features/distribution_spec.rb
@@ -40,17 +40,17 @@ RSpec.feature "Distributions", type: :feature do
 
     scenario "the user can make changes to it" do
       click_on "Edit", match: :first
-      expect {
+      expect do
         fill_in "Agency representative", with: "SOMETHING DIFFERENT"
         click_on "Save", match: :first
         distribution.reload
-      }.to change{ distribution.agency_rep }.to("SOMETHING DIFFERENT")
+      end.to change { distribution.agency_rep }.to("SOMETHING DIFFERENT")
     end
 
     scenario "the user can reclaim it" do
-      expect {
+      expect do
         click_on "Reclaim"
-      }.to change{Distribution.count}.by(-1)
+      end.to change { Distribution.count }.by(-1)
       expect(page).to have_content "reclaimed"
     end
 
@@ -58,10 +58,10 @@ RSpec.feature "Distributions", type: :feature do
       scenario "the user can still reclaim it and it reactivates the item" do
         item = distribution.line_items.first.item
         item.destroy
-        expect {
+        expect do
           click_on "Reclaim"
           page.find ".alert"
-        }.to change{Distribution.count}.by(-1).and change{Item.count}.by(1)
+        end.to change { Distribution.count }.by(-1).and change { Item.count }.by(1)
         expect(page).to have_content "reclaimed"
       end
     end

--- a/spec/features/item_spec.rb
+++ b/spec/features/item_spec.rb
@@ -66,11 +66,11 @@ RSpec.feature "Item management", type: :feature do
   scenario "User can delete an item" do
     item = create(:item, organization: @user.organization)
     visit url_prefix + "/items"
-    expect {
+    expect do
       within "tr[data-item-id='#{item.id}']" do
-       click_on "Delete", match: :first
+        click_on "Delete", match: :first
       end
-    }.to change{Item.count}.by(-1)
+    end.to change { Item.count }.by(-1)
   end
 
   scenario "A user can 'delete' an item that has history, but it only soft-deletes it" do
@@ -78,11 +78,11 @@ RSpec.feature "Item management", type: :feature do
     create(:donation, :with_items, item: item)
     visit url_prefix + "/items"
     expect(page).to have_content("DELETEME")
-    expect {
+    expect do
       within "tr[data-item-id='#{item.id}']" do
-       click_on "Delete", match: :first
+        click_on "Delete", match: :first
       end
-    }.not_to change{Item.unscoped.count}
+    end.not_to change { Item.unscoped.count }
     item.reload
     expect(item).not_to be_active
     visit url_prefix + "/items"

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -160,7 +160,7 @@ RSpec.describe Item, type: :model do
 
       it "only hides an item that has history" do
         item = create(:line_item).item
-        expect { item.destroy }.to change { Item.unscoped.count }.by(0)
+        expect { item.destroy }.to change { Item.unscoped.count }.by(0).and change { Item.count }.by(-1)
         expect(item).not_to be_active
       end
     end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -264,6 +264,19 @@ RSpec.describe StorageLocation, type: :model do
         expect(storage_location.inventory_items.first.quantity).to eq 350
       end
 
+      it "re-activates items that were previously deleted" do
+        storage_location = create :storage_location, :with_items, item_quantity: 200
+        distribution = create :distribution, :with_items, storage_location: storage_location, item_quantity: 50
+        item = distribution.line_items.first.item
+        expect {
+          item.destroy
+        }.to change{item.active}.from(true).to(false)
+        expect {
+          storage_location.reclaim!(distribution)
+          item.reload
+        }.to change{item.active}.from(false).to(true)
+      end
+
       it "does not destroy the distribution" do
         storage_location = create :storage_location, :with_items, item_quantity: 300
         distribution = create :distribution, :with_items, storage_location: storage_location, item_quantity: 50

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -268,13 +268,13 @@ RSpec.describe StorageLocation, type: :model do
         storage_location = create :storage_location, :with_items, item_quantity: 200
         distribution = create :distribution, :with_items, storage_location: storage_location, item_quantity: 50
         item = distribution.line_items.first.item
-        expect {
+        expect do
           item.destroy
-        }.to change{item.active}.from(true).to(false)
-        expect {
+        end.to change { item.active }.from(true).to(false)
+        expect do
           storage_location.reclaim!(distribution)
           item.reload
-        }.to change{item.active}.from(false).to(true)
+        end.to change { item.active }.from(false).to(true)
       end
 
       it "does not destroy the distribution" do


### PR DESCRIPTION
So there was some discussion about this, but here's what I settled on:

When an item is de-activated, if a distribution had it previously and is re-claimed, it will re-activate that item.

There's tests added to StorageLocation model and Distribution feature specs