### PR TITLE
Fixes #565 - Booping barcodes now sets the fields correctly and actually creates the barcodes successfully

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -48,6 +48,26 @@ $( document ).ready(function() {
     });
 });
 $(document).on("click", '#awesomebutton', function(e){
+    /*
     $('#newBarcode').modal('hide');
+    source_field = $('#trigger-field-id').val();
+
+    // Clear out the fields, capturing the quantity and item_id
+    item_id = $('#barcode_item_barcodeable_id').val();
+    quantity = $('#barcode_item_quantity').val();
+    $('#barcode_item_quantity').val('');
+    $('#barcode_item_barcodeable_id').val('');
+    $('#barcode_item_value').val('');
+    $('#trigger-field-id').val('');
+
+    // Notify the user
     toastr.success("Barcode Added to Inventory");
+
+    // Locate the row where the barcode was entered from
+    line_item = $('#' + source_field).closest('.nested-fields');
+    // Set the values in the form. This is replicating some logic from barcode_items.js.erb
+    $(line_item).find('input[type=number]').val(quantity);
+    $(line_item).find('[value="' + item_id + '"]').attr("selected", true);
+    $(line_item).parent().find('.nested-fields:last-child input.__barcode_item_lookup').focus();
+    */
 });

--- a/app/assets/javascripts/barcode_items.js.erb
+++ b/app/assets/javascripts/barcode_items.js.erb
@@ -28,11 +28,12 @@ $(document).ready(function() {
     $.getJSON("/" + organization_id + "/barcode_items/find.json?barcode_item[value]=" + value, function(data) {
          // Preserve this for reference of where we came from.
          data['src'] = src;
+         data['value'] = value;
          // Pass it all along to the .done() method
          return data;
       })
       .done(fill_fields_with_barcode_results)
-      .fail(prompt_for_new_barcode_item)
+      .fail(function(data) { prompt_for_new_barcode_item(data, value, src); } )
       .always(function(data){
         // ...
     });
@@ -76,8 +77,11 @@ $(document).ready(function() {
     $(line_item).parent().find('.nested-fields:last-child input.__barcode_item_lookup').focus();
   }
 
-  function prompt_for_new_barcode_item(data) {
-    $(data['src']).val('');
+  function prompt_for_new_barcode_item(data, value, src) {
+    // Pre-fill the barcode field with the value
+    $("#barcode_item_value").val(value);
+    // Saving this to the modal so the modal knows which field to trigger when it's done.
+    $("#trigger-field-id").val($(src).attr('id'));
     $("#newBarcode").modal();
     // TODO: Prompt the user with a dialog to create a new barcode entry, then add that to the form
   }

--- a/app/controllers/barcode_items_controller.rb
+++ b/app/controllers/barcode_items_controller.rb
@@ -16,6 +16,7 @@ class BarcodeItemsController < ApplicationController
       msg += barcode_item_params[:global] == "true" ? " globally!" : " to your private set!"
       respond_to do |format|
         format.json { render json: @barcode_item.to_json }
+        format.js
         format.html { redirect_to barcode_items_path, notice: msg }
       end
     else

--- a/app/views/barcode_items/create.js.erb
+++ b/app/views/barcode_items/create.js.erb
@@ -1,0 +1,20 @@
+$('#newBarcode').modal('hide');
+source_field = $('#trigger-field-id').val();
+
+// Clear out the fields, capturing the quantity and item_id
+item_id = $('#barcode_item_barcodeable_id').val();
+quantity = $('#barcode_item_quantity').val();
+$('#barcode_item_quantity').val('');
+$('#barcode_item_barcodeable_id').val('');
+$('#barcode_item_value').val('');
+$('#trigger-field-id').val('');
+
+// Notify the user
+toastr.success("Barcode Added to Inventory");
+
+// Locate the row where the barcode was entered from
+line_item = $('#' + source_field).closest('.nested-fields');
+// Set the values in the form. This is replicating some logic from barcode_items.js.erb
+$(line_item).find('input[type=number]').val(quantity);
+$(line_item).find('[value="' + item_id + '"]').attr("selected", true);
+$(line_item).parent().find('.nested-fields:last-child input.__barcode_item_lookup').focus();

--- a/app/views/diaper_drive_participants/_form.html.erb
+++ b/app/views/diaper_drive_participants/_form.html.erb
@@ -25,6 +25,6 @@
       <%= f.input_field :address, class: "form-control" %>
     <% end %>
 
-    <%= submit_button %>
+    <%= submit_button({ id: "diaper-drive-participant-submit" }) %>
   <% end %>
 </div>

--- a/app/views/donations/_barcode_modal.html.erb
+++ b/app/views/donations/_barcode_modal.html.erb
@@ -34,6 +34,7 @@
         <%= submit_button({ id: "awesomebutton" }) %>
       </div><!-- /.box-body -->
       <% end #form %>
+      <input type="hidden" value="" id="trigger-field-id" />
     </div>
   </div>
 </div>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,7 +37,7 @@ Capybara.ignore_hidden_elements = true
 
 # https://docs.travis-ci.com/user/chrome
 Capybara.register_driver :chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu])
+  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu window-size=1680,1050])
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end


### PR DESCRIPTION
This does a few things.
The primary need is from the issue: setting the barcode value when the modal closes after creating a new barcode.

But it also sets the quantity and item in the selectbox, whicih it wasn't doing before.

I also discovered that the barcode modal wasn't even creating anything at all. It was previously set to remote=true but the controller didn't have a JS route. It appeared to be working correctly because of some JS logic in the `application.js` but the round-trip to the server wasn't working right. I added an additional format handler in the `BarcodeItemsController#create` action for `:js` format, and created a `create.js.erb` view in `barcode_items` -- I moved the initial javascript from the `awesomebutton` handler, as well as the additional JS I wrote, to this new view. This ensures that the JS isn't executed until the barcode is successfully created.

I tested it manually first to ensure it worked right, then fixed the test to pass. It passes now. 

The JS could probably be optimized, there's a lot of redundancies with these functions, and that could be DRYed, but it works and is not overly obtuse. 