### PR TITLE
Sort requests by status

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,8 +1,6 @@
 class RequestsController < ApplicationController
   def index
-    @requests = current_organization
-                .requests
-                .order(created_at: :desc)
+    @requests = current_organization.ordered_requests
     respond_to do |format|
       format.html
     end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -59,6 +59,10 @@ class Organization < ApplicationRecord
     users.map(&:email).join(", ")
   end
 
+  def ordered_requests
+    requests.order(status: :asc, updated_at: :desc)
+  end
+
   def quantity_categories
     storage_locations.map(&:inventory_items).flatten.reject { |i| i.item.nil? }.group_by { |i| i.item.category }
                      .map { |i| [i[0], i[1].map(&:quantity).sum] }.sort_by { |_, v| -v }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -258,7 +258,8 @@ end
   end
 end
 
-20.times.each do
+20.times.each do |count|
+  status = count > 15 ? 'Fulfilled' : 'Active'
   Request.create(
     partner: random_record(Partner),
     organization: random_record(Organization),
@@ -266,7 +267,7 @@ end
                      k_size6: 2
                    },
     comments: "Urgent",
-    status: 'Active'
+    status: status
   )
 end
 

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Organization, type: :model do
 
     context "ordering of requests with matching status" do
       before do
-        old_active_request.update_attributes(updated_at: 5.minutes.after)
+        old_active_request.update(updated_at: 5.minutes.after)
       end
 
       it "puts the most recently updated request before older requests" do


### PR DESCRIPTION
* This adds sorting to the requests index action in the order of:
   -Active (sub sorted by updated_at)
   -Fulfilled (sub sorted by updated_at)
* Active requests appear first, then fulfilled -- within those sets,
  ordering should be done by updated_at, newest first
* This addresses this issue: https://github.com/rubyforgood/diaper/issues/572
* I also made it so the seed script adds in some "fulfilled" requests so that we can see the ordering
  happening.

Resolves #572  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
      See issue https://github.com/rubyforgood/diaper/issues/572
  - What alternative solutions did you consider?
        I considered adding the ordering right into the controller
  - What are the tradeoffs for your solution?
        The logic gets put into the model, but then it is much easier to test.
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
I added unit specs to the organization_spec.rb.

Do we need to do anything else to verify your changes? 
nope
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
before:
![requests_-_pdx_diaper_bank](https://user-images.githubusercontent.com/8398867/47589848-66269280-d938-11e8-8e82-2ac3890337d4.png)

after: 
![requests_-_pdx_diaper_bank](https://user-images.githubusercontent.com/8398867/47589824-57d87680-d938-11e8-9b89-006f9c8ec871.png)
