### PR TITLE
Fix image name for home page testimonials

### DIFF
--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -122,7 +122,7 @@
     <!--  Start Quote Section  -->
     <section class="quote">
         <blockquote>
-          <h4>No one is useless in this world who lightens the burdens of another.</h4>
+          <p>No one is useless in this world who lightens the burdens of another.</p>
           <hr/>
           <span class="author">Charles Dickens</span>
         </blockquote>
@@ -136,14 +136,14 @@
           <div id="carousel">
             
             <div class="tesimonial">
-              <img src="img/diaper_small.png" title="Diaperbase Logo" alt="Diaperbase Logo">
+              <img src="img/diaper_small.old.png" title="Diaperbase Logo" alt="Diaperbase Logo">
               <!-- <span class="name">Mashable</span> -->
               <p>Finally, an inventory management system designed specifically for the unique needs of diaper banks!</p>
               <span class="author">Rachel Alston, PDX Diaper Bank</span>
             </div>
 
             <div class="tesimonial">
-              <img src="img/diaper_small.png" title="Diaperbase Logo" alt="Diaperbase Logo">
+              <img src="img/diaper_small.old.png" title="Diaperbase Logo" alt="Diaperbase Logo">
               <!-- <span class="name">Mashable_2</span> -->
               <p>DiaperBase has taken our diaper distribution to the next level. We no longer have to worry about how to track our incoming and outgoing inventory, and having all our products and data tracked in different ways in different documents and systems. DiaperBase has saved us time, money, energy and many, many headaches. The system is extremely intuitive and user-friendly and we are so grateful to have it.</p>
               <span class="author">Megan, Sweet Cheeks Diaper Bank</span>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -136,14 +136,14 @@
           <div id="carousel">
             
             <div class="tesimonial">
-              <img src="img/diaper_small.old.png" title="Diaperbase Logo" alt="Diaperbase Logo">
+              <img src="img/diaper-base-logo-icon.svg" title="Diaperbase Logo" alt="Diaperbase Logo">
               <!-- <span class="name">Mashable</span> -->
               <p>Finally, an inventory management system designed specifically for the unique needs of diaper banks!</p>
               <span class="author">Rachel Alston, PDX Diaper Bank</span>
             </div>
 
             <div class="tesimonial">
-              <img src="img/diaper_small.old.png" title="Diaperbase Logo" alt="Diaperbase Logo">
+              <img src="img/diaper-base-logo-icon.svg" title="Diaperbase Logo" alt="Diaperbase Logo">
               <!-- <span class="name">Mashable_2</span> -->
               <p>DiaperBase has taken our diaper distribution to the next level. We no longer have to worry about how to track our incoming and outgoing inventory, and having all our products and data tracked in different ways in different documents and systems. DiaperBase has saved us time, money, energy and many, many headaches. The system is extremely intuitive and user-friendly and we are so grateful to have it.</p>
               <span class="author">Megan, Sweet Cheeks Diaper Bank</span>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -195,7 +195,7 @@
         <div class="small-12 medium-4 large-4 columns">
           <div class="copyrights">
             <a class="logo" href="#">
-              <h1>diaperbase<span class="tld">.org</span></h1>
+              <h1>diaper<span class="tld">.app</span></h1>
             </a>
           </div>
         </div>


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

### Description
This change modifies the home page. It fixes the name of the testimonial image so that an image will render.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Not sure if a test is needed here 🤷‍♂️

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

Before:
<img width="788" alt="screen shot 2018-10-27 at 10 32 44 am" src="https://user-images.githubusercontent.com/13142719/47605457-b5ba9c00-d9d4-11e8-8e45-5b8c80c70b5a.png">

After:
<img width="788" alt="screen shot 2018-10-27 at 10 33 02 am" src="https://user-images.githubusercontent.com/13142719/47605459-b9e6b980-d9d4-11e8-8ce1-5ce98c5c4a26.png">

---

Also modified the font for the Charles Dickens quote (can change back if preferred).

Before:
<img width="1391" alt="screen shot 2018-10-27 at 10 34 11 am" src="https://user-images.githubusercontent.com/13142719/47605470-ce2ab680-d9d4-11e8-9bbe-3aff3408f0b7.png">

After:
<img width="1398" alt="screen shot 2018-10-27 at 10 33 59 am" src="https://user-images.githubusercontent.com/13142719/47605472-d2ef6a80-d9d4-11e8-841a-c88cb20cd640.png">
