### PR TITLE
Only use items with inventory when creating distribution from request

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -77,7 +77,7 @@ class Distribution < ApplicationRecord
     request.request_items.each do |key, quantity|
       line_items.new(
         quantity: quantity,
-        item: Item.eager_load(:canonical_item).find_by(organization: request.organization, canonical_items: { partner_key: key }),
+        item: Item.joins(:inventory_items).eager_load(:canonical_item).find_by(organization: request.organization, canonical_items: { partner_key: key }),
         itemizable_id: request.id,
         itemizable_type: "Distribution"
       )


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/diaper/issues/576

### Description

I tracked down the intermittent failure to `spec/factories/organizations.rb` which calls `Organization.seed_items` to create items which aren't associated to any storage locations, these are then picked up in `Distribution.copy_from_request` which causes the spec failure.

This PR changes the code in `copy_from_request` to only consider items that actually have an inventory (using an INNER JOIN).

A better fix might be to get rid of `Organization.seed_items` and create the necessary items in the relevant specs. I tried to remove the call from the factory and only ended up with a couple of failing specs as a result, but I'm not familiar with the app so I opted for the easier fix :)

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Specs only.