### PR TITLE
Updates the request show page to display inventory amounts across storage locations

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -33,5 +33,4 @@ class RequestsController < ApplicationController
   def sum_inventory(partner_key)
     current_organization.inventory_items.by_partner_key(partner_key).sum(:quantity)
   end
-
 end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -9,7 +9,7 @@ class RequestsController < ApplicationController
   def show
     @request = Request.find(params[:id])
     @items = @request.items_hash
-    @inventory_items = current_organization.inventory_items
+    @request_items = get_items(@request.request_items)
   end
 
   # Clicking the "Fullfill" button will set the the request to fulfilled
@@ -20,6 +20,22 @@ class RequestsController < ApplicationController
     request.update(status: "Fulfilled")
     flash[:notice] = "Request marked as fulfilled"
     redirect_to new_distribution_path(request_id: request.id)
+  end
+
+  def get_items(request_items)
+    array = []
+    request_items.each do |key, quantity|
+      array << {
+        name: @request.items_hash[key].name,
+        quantity: quantity,
+        on_hand: sum_inventory(key)
+      }
+    end
+    array
+  end
+
+  def sum_inventory(partner_key)
+    current_organization.inventory_items.by_partner_key(partner_key).sum(:quantity)
   end
 
 end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -9,6 +9,7 @@ class RequestsController < ApplicationController
   def show
     @request = Request.find(params[:id])
     @items = @request.items_hash
+    @inventory_items = current_organization.inventory_items
   end
 
   # Clicking the "Fullfill" button will set the the request to fulfilled
@@ -20,4 +21,5 @@ class RequestsController < ApplicationController
     flash[:notice] = "Request marked as fulfilled"
     redirect_to new_distribution_path(request_id: request.id)
   end
+
 end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -23,15 +23,11 @@ class RequestsController < ApplicationController
   end
 
   def get_items(request_items)
-    array = []
-    request_items.each do |key, quantity|
-      array << {
-        name: @request.items_hash[key].name,
-        quantity: quantity,
-        on_hand: sum_inventory(key)
-      }
+    # using Struct vs Hash so we can use dot notation in the view
+    Struct.new('Item', :name, :quantity, :on_hand)
+    request_items.map do |key, quantity|
+      Struct::Item.new(@request.items_hash[key].name, quantity, sum_inventory(key))
     end
-    array
   end
 
   def sum_inventory(partner_key)

--- a/app/models/canonical_item.rb
+++ b/app/models/canonical_item.rb
@@ -20,4 +20,6 @@ class CanonicalItem < ApplicationRecord
   validates :name, presence: true, uniqueness: true
   validates :category, presence: true
   validates :partner_key, presence: true, uniqueness: true
+
+  scope :by_partner_key, -> (partner_key) { where(partner_key: partner_key) }
 end

--- a/app/models/canonical_item.rb
+++ b/app/models/canonical_item.rb
@@ -21,5 +21,5 @@ class CanonicalItem < ApplicationRecord
   validates :category, presence: true
   validates :partner_key, presence: true, uniqueness: true
 
-  scope :by_partner_key, -> (partner_key) { where(partner_key: partner_key) }
+  scope :by_partner_key, ->(partner_key) { where(partner_key: partner_key) }
 end

--- a/app/models/inventory_item.rb
+++ b/app/models/inventory_item.rb
@@ -19,6 +19,8 @@ class InventoryItem < ApplicationRecord
   validates :item_id, presence: true
   validates :quantity, numericality: { only_integer: true, greater_than_or_equal_to: 0 }
 
+  scope :by_partner_key, ->(partner_key) { joins(:item).merge(Item.by_canonical_item(CanonicalItem.by_partner_key(partner_key))) }
+
   delegate :name, to: :item, prefix: true
 
   def self.quantity_by_category

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -34,11 +34,16 @@
                   <thead>
                     <th>Item</th>
                     <th>Quantity</th>
+                    <th>Estimated on-hand</th>
                   </thead>
 
                   <tbody>
                     <% @request.request_items.each do |key,quantity| %>
-                      <tr><td><%= @request.items_hash[key].name %></td><td><%= quantity %></td></tr>
+                      <tr>
+                        <td><%= @request.items_hash[key].name %></td>
+                        <td><%= quantity %></td>
+                        <td><%= @inventory_items.where(item: Item.where(canonical_item: CanonicalItem.where(partner_key: key))).sum(:quantity) %></td>
+                      </tr>
                     <% end %>
                   </tbody>
                 </table>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -38,11 +38,11 @@
                   </thead>
 
                   <tbody>
-                    <% @request.request_items.each do |key,quantity| %>
+                    <% @request_items.each do |item| %>
                       <tr>
-                        <td><%= @request.items_hash[key].name %></td>
-                        <td><%= quantity %></td>
-                        <td><%= @inventory_items.where(item: Item.where(canonical_item: CanonicalItem.where(partner_key: key))).sum(:quantity) %></td>
+                        <td><%= item[:name] %></td>
+                        <td><%= item[:quantity] %></td>
+                        <td><%= item[:on_hand] %></td>
                       </tr>
                     <% end %>
                   </tbody>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -40,9 +40,9 @@
                   <tbody>
                     <% @request_items.each do |item| %>
                       <tr>
-                        <td><%= item[:name] %></td>
-                        <td><%= item[:quantity] %></td>
-                        <td><%= item[:on_hand] %></td>
+                        <td><%= item.name %></td>
+                        <td><%= item.quantity %></td>
+                        <td><%= item.on_hand %></td>
                       </tr>
                     <% end %>
                   </tbody>

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe RequestsController, type: :controller do
+  let(:default_params) do
+    { organization_id: @organization.to_param }
+  end
+
+  context "While signed in" do
+    before do
+      sign_in(@user)
+    end
+
+    describe "GET #index" do
+      subject { get :index, params: default_params }
+      it "returns http success" do
+        expect(subject).to be_successful
+      end
+    end
+
+    describe "GET #show" do
+      subject { get :show, params: default_params.merge(id: create(:request, organization: @organization)) }
+      it "returns http success" do
+        expect(subject).to be_successful
+      end
+    end
+  end
+
+  context "While not signed in" do
+    let(:object) { create(:request) }
+
+    include_examples "requiring authorization"
+  end
+end

--- a/spec/features/request_spec.rb
+++ b/spec/features/request_spec.rb
@@ -3,6 +3,15 @@ RSpec.feature "Requests", type: :feature do
     sign_in(@user)
     @request = create(:request, organization: @organization)
     @storage_location = create(:storage_location, organization: @organization)
+    # creates an inventory item for the request's first item and gives it a quantity of 234
+    @storage_location.inventory_items.create!(
+      quantity: 234,
+      item: Item.find_by(
+        canonical_item: CanonicalItem.find_by(
+          partner_key: @request.request_items.keys.first
+        )
+      )
+    )
   end
   let!(:url_prefix) { "/#{@organization.to_param}" }
 
@@ -20,6 +29,8 @@ RSpec.feature "Requests", type: :feature do
     scenario "the request is shown", js: true do
       visit url_prefix + "/requests/#{@request.id}"
       expect(page).to have_content("Request from #{@request.partner.name}")
+      expect(page).to have_content("Estimated on-hand")
+      expect(page).to have_content("234")
     end
 
     scenario "the request is fullfillable", js: true do

--- a/spec/features/request_spec.rb
+++ b/spec/features/request_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "Requests", type: :feature do
       expect(page).to have_content("Request from #{@request.partner.name}")
       expect(page).to have_content("Estimated on-hand")
     end
-    
+
     scenario "the number of items on-hand is shown", js: true do
       ####
       # Create a secondary storage location to test the sum view of estimated on-hand items

--- a/spec/models/canonical_item_spec.rb
+++ b/spec/models/canonical_item_spec.rb
@@ -52,12 +52,9 @@ RSpec.describe CanonicalItem, type: :model do
 
   describe "Filtering >" do
     describe "->by_partner_key" do
-      before(:each) do
-        CanonicalItem.delete_all
-        @c1 = create(:canonical_item)
-      end
       it "shows the Canonical Items by partner_key" do
-        expect(CanonicalItem.by_partner_key(@c1.partner_key).size).to eq(1)
+        expect(CanonicalItem.by_partner_key(CanonicalItem.first.partner_key).size).to eq(1)
+        expect(CanonicalItem.by_partner_key("random_string").size).to eq(0)
       end
     end
   end

--- a/spec/models/canonical_item_spec.rb
+++ b/spec/models/canonical_item_spec.rb
@@ -49,4 +49,16 @@ RSpec.describe CanonicalItem, type: :model do
 
   describe "Methods >" do
   end
+
+  describe "Filtering >" do
+    describe "->by_partner_key" do
+      before(:each) do
+        CanonicalItem.delete_all
+        @c1 = create(:canonical_item)
+      end
+      it "shows the Canonical Items by partner_key" do
+        expect(CanonicalItem.by_partner_key(@c1.partner_key).size).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/models/inventory_item_spec.rb
+++ b/spec/models/inventory_item_spec.rb
@@ -37,4 +37,16 @@ RSpec.describe InventoryItem, type: :model do
   it "initializes the quantity to 0 if it was not specified" do
     expect(InventoryItem.new.quantity).to eq(0)
   end
+
+  context "Filtering >" do
+    describe "->by_partner_key" do
+      before(:each) do
+        InventoryItem.delete_all
+        @item1 = create(:inventory_item)
+      end
+      it "shows the Canonical Items by partner_key" do
+        expect(InventoryItem.by_partner_key(@item1.item.canonical_item.partner_key).size).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #573 

### Description

Grabs all the inventory_items for the current org for use in the view, adds request_controller spec and updates request feature spec to check for a value for a particular org.

*Note* There might be some opportunity for refactoring because I used nested where statements, this could cause a speed issue, but I might need some guidance on that because I'm not as familiar with the data model.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

* load the request show screen and see values for the amount of items in all storage locations
* the features/request_spec.rb tests the summed values for two different storage locations
* the controllers/requests_controller_spec.rb is kind of unnecessary here, but this file didn't exist so I made a rudimentary one; it doesn't really test output, just successful get requests.  I also didn't test the fulfill method since that's not a part of this issue.