### PR TITLE
549 - More useful user information

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -51,8 +51,8 @@ class User < ApplicationRecord
   end
 
   def kind
-    return "super" if super_admin == true
-    return "admin" if organization_admin == true
+    return "super" if super_admin?
+    return "admin" if organization_admin?
     return "normal"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,4 +39,20 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   validates :name, :email, presence: true
+
+  def most_recent_sign_in
+    [current_sign_in_at.to_s, last_sign_in_at.to_s].max
+  end
+
+  def invitation_status 
+    return "joined" if most_recent_sign_in.present? 
+    return "accepted" if invitation_accepted_at.present?
+    return "invited" if invitation_sent_at.present?
+  end
+
+  def kind
+    return "super" if super_admin == true
+    return "admin" if organization_admin == true
+    return "normal"
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,7 @@ class User < ApplicationRecord
   def kind
     return "super" if super_admin?
     return "admin" if organization_admin?
-    return "normal"
+
+    "normal"
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,8 +44,8 @@ class User < ApplicationRecord
     [current_sign_in_at.to_s, last_sign_in_at.to_s].max
   end
 
-  def invitation_status 
-    return "joined" if most_recent_sign_in.present? 
+  def invitation_status
+    return "joined" if most_recent_sign_in.present?
     return "accepted" if invitation_accepted_at.present?
     return "invited" if invitation_sent_at.present?
   end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -22,18 +22,23 @@
     <h3 class="box-title"><%= @organization.name %></h3>
   </div>
   <div class="box-body">
-    <div class="col-md-6">
+    <div class="col-md-4">
       <h4>Contact Info</h4>
       <p><%= fa_icon "envelope" %> <%= link_to @organization.email, "mailto:#{@organization.email}" %></p>
       <address><%= fa_icon "map-marker" %> <%= @organization.address %></address>      
     </div>
-    <div class="col-md-6">
+    <div class="col-md-8">
       <h4>Users</h4>
-        <ul class="list-group">
-          <li class="list-group-item">
-      <%= @organization.display_users.split(",").join("</li><li class=\"list-group-item\">").html_safe %>
-          </li>
-        </ul>
+        <table class="table table-hover">
+          <thead>
+            <tr>
+              <th>Name</th><th>Email</th><th>Role</th><th>Last Sign in</th><th>Status</th>
+            </tr>  
+          </thead>          
+          <tbody>
+            <%= render partial: "/users/organization_user", collection: @organization.users, as: :user %>
+          </tbody>
+        </table>
 
       <%= modal_button_to("#addUserModal", { text: "Invite User to this Organization" }) if can_administrate? %>
 

--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -1,0 +1,7 @@
+<tr>
+  <td><%= user.name %></td>
+  <td><%= user.email %></td>
+  <td><%= user.kind %></td>
+  <td><%= user.most_recent_sign_in %></td>
+  <td><%= user.invitation_status %></td>
+</tr>

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe User, type: :model do
   end
 
   context "Methods >" do
-    it "#most_recent_sign_in" do 
+    it "#most_recent_sign_in" do
       expect(build(:user, current_sign_in_at: Time.zone.parse("2018-10-23 00:00:00"), last_sign_in_at: Time.zone.parse("2018-10-20 00:00:00 UTC")).most_recent_sign_in).to eq("2018-10-23 00:00:00 UTC")
       expect(build(:user, current_sign_in_at: Time.zone.parse("2018-10-24 00:00:00"), last_sign_in_at: nil).most_recent_sign_in).to eq("2018-10-24 00:00:00 UTC")
       expect(build(:user).most_recent_sign_in).to eq("")
@@ -52,9 +52,9 @@ RSpec.describe User, type: :model do
       expect(build(:user, invitation_sent_at: Time.zone.parse("2018-10-10 00:00:00"), invitation_accepted_at: Time.zone.parse("2018-10-11 00:00:00"), current_sign_in_at: Time.zone.parse("2018-10-23 00:00:00")).invitation_status).to eq("joined")
     end
 
-    it "#kind" do 
+    it "#kind" do
       expect(build(:super_admin).kind).to eq("super")
-      expect(build(:organization_admin).kind).to eq("admin") 
+      expect(build(:organization_admin).kind).to eq("admin")
       expect(build(:user).kind).to eq("normal")
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,4 +38,24 @@ RSpec.describe User, type: :model do
       expect(build(:user, email: nil)).not_to be_valid
     end
   end
+
+  context "Methods >" do
+    it "#most_recent_sign_in" do 
+      expect(build(:user, current_sign_in_at: Time.zone.parse("2018-10-23 00:00:00"), last_sign_in_at: Time.zone.parse("2018-10-20 00:00:00 UTC")).most_recent_sign_in).to eq("2018-10-23 00:00:00 UTC")
+      expect(build(:user, current_sign_in_at: Time.zone.parse("2018-10-24 00:00:00"), last_sign_in_at: nil).most_recent_sign_in).to eq("2018-10-24 00:00:00 UTC")
+      expect(build(:user).most_recent_sign_in).to eq("")
+    end
+
+    it "#invitation_status" do
+      expect(build(:user, invitation_sent_at: Time.zone.parse("2018-10-10 00:00:00")).invitation_status).to eq("invited")
+      expect(build(:user, invitation_sent_at: Time.zone.parse("2018-10-10 00:00:00"), invitation_accepted_at: Time.zone.parse("2018-10-11 00:00:00")).invitation_status).to eq("accepted")
+      expect(build(:user, invitation_sent_at: Time.zone.parse("2018-10-10 00:00:00"), invitation_accepted_at: Time.zone.parse("2018-10-11 00:00:00"), current_sign_in_at: Time.zone.parse("2018-10-23 00:00:00")).invitation_status).to eq("joined")
+    end
+
+    it "#kind" do 
+      expect(build(:super_admin).kind).to eq("super")
+      expect(build(:organization_admin).kind).to eq("admin") 
+      expect(build(:user).kind).to eq("normal")
+    end
+  end
 end


### PR DESCRIPTION
Adds `#kind`, `#invitation_status` and `#most_recent_sign_in` methods to `user.rb` and displays the data in an organization's users list.

Resolves #549 : Part 1

### Description
Display more useful user information on the Organizations#show page.

This is part 1 of #549.
### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Specs added for new `user.rb` methods. 

### Screenshots
![image](https://user-images.githubusercontent.com/200333/47618608-1dd7b380-daa3-11e8-886b-184410da8c44.png)
