### PR TITLE
590 superadmin doesnt require org

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,6 @@
 require "active_support/core_ext/module/aliasing"
 
 module ApplicationHelper
-
   def dashboard_path_from_user
     if current_user.super_admin?
       admin_dashboard_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/module/aliasing"
 
 module ApplicationHelper
+
+  def dashboard_path_from_user
+    if current_user.super_admin?
+      admin_dashboard_path
+    else
+      dashboard_path
+    end
+  end
+
   def default_title_content
     if current_organization
       current_organization.name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@
 #
 
 class User < ApplicationRecord
-  belongs_to :organization
+  belongs_to :organization , optional: Proc.new { |u| u.super_admin? }
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@
 #
 
 class User < ApplicationRecord
-  belongs_to :organization , optional: Proc.new { |u| u.super_admin? }
+  belongs_to :organization, optional: proc { |u| u.super_admin? }
 
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable

--- a/app/views/admin/canonical_items/edit.html.erb
+++ b/app/views/admin/canonical_items/edit.html.erb
@@ -4,9 +4,10 @@
   Editing Canonical Item
 </h1>
 <ol class="breadcrumb">
-<li><%= link_to(dashboard_path) do %>
-    <i class="fa fa-dashboard"></i> Home
-  <% end %>
+  <li>
+    <%= link_to(admin_dashboard_path) do %>
+      <i class="fa fa-dashboard"></i> Home
+    <% end %>
   </li>
   <li><%= link_to "All Canonical Items", (admin_canonical_items_path) %></li>
   <li class="active">Editing <%= @canonical_item.name %></li>

--- a/app/views/admin/canonical_items/index.html.erb
+++ b/app/views/admin/canonical_items/index.html.erb
@@ -4,7 +4,7 @@
     Canonical Items
   </h1>
   <ol class="breadcrumb">
-    <li><%= link_to(dashboard_path) do %>
+    <li><%= link_to(admin_dashboard_path) do %>
       <i class="fa fa-dashboard"></i> Home
     <% end %>
     </li>

--- a/app/views/admin/canonical_items/new.html.erb
+++ b/app/views/admin/canonical_items/new.html.erb
@@ -4,7 +4,7 @@
     New Canonical Item
   </h1>
   <ol class="breadcrumb">
-  <li><%= link_to(dashboard_path) do %>
+  <li><%= link_to(admin_dashboard_path) do %>
       <i class="fa fa-dashboard"></i> Home
     <% end %>
     </li>

--- a/app/views/admin/canonical_items/show.html.erb
+++ b/app/views/admin/canonical_items/show.html.erb
@@ -5,7 +5,7 @@
     <small>for <%= @canonical_item.name %></small>
   </h1>
   <ol class="breadcrumb">
-  <li><%= link_to(dashboard_path) do %>
+  <li><%= link_to(admin_dashboard_path) do %>
       <i class="fa fa-dashboard"></i> Home
     <% end %>
     </li>
@@ -30,7 +30,7 @@
 
     <h4>Items created from this Canonical Item</h4>
     <div class="row">
-      <div class="col-xs-12">      
+      <div class="col-xs-12">
         <div class="box-body table-responsive no-padding">
           <table class="table table-hover">
             <tr>
@@ -43,7 +43,7 @@
               <td><%= item.name %></td>
               <td><%= link_to item.organization.name, organization_path(item.organization) %></td>
             </tr>
-            <% end %>        
+            <% end %>
           </table>
         </div> <!-- /.box-body -->
       </div> <!-- /.col-xs-12 -->

--- a/app/views/admin/organizations/edit.html.erb
+++ b/app/views/admin/organizations/edit.html.erb
@@ -5,9 +5,10 @@ Editing
 <small><%= @organization.name %></small>
 </h1>
 <ol class="breadcrumb">
-  <li><%= link_to(dashboard_path(organization_id: current_user.organization)) do %>
-    <i class="fa fa-dashboard"></i> Home
-  <% end %>
+  <li>
+    <%= link_to(admin_dashboard_path) do %>
+      <i class="fa fa-dashboard"></i> Home
+    <% end %>
   </li>
   <li><%= link_to "Administration", (admin_organizations_path) %></li>
   <li><a href="#">Editing <%= @organization.name %></a></li>

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -5,7 +5,8 @@
     <small></small>
   </h1>
   <ol class="breadcrumb">
-    <li><%= link_to(dashboard_path(organization_id: current_user.organization)) do %>
+    <li>
+      <%= link_to(admin_dashboard_path) do %>
         <i class="fa fa-dashboard"></i> Home
       <% end %>
     </li>

--- a/app/views/admin/organizations/new.html.erb
+++ b/app/views/admin/organizations/new.html.erb
@@ -5,9 +5,10 @@ New Organization
 <small></small>
 </h1>
 <ol class="breadcrumb">
-  <li><%= link_to(dashboard_path(organization_id: current_user.organization)) do %>
-    <i class="fa fa-dashboard"></i> Home
-  <% end %>
+  <li>
+    <%= link_to(admin_dashboard_path) do %>
+      <i class="fa fa-dashboard"></i> Home
+    <% end %>
   </li>
   <li><%= link_to "Administration", new_admin_organization_path %></li>
   <li><a href="#">New Organization</a></li>

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -5,9 +5,10 @@
   <small>for <%= @organization.name %></small>
 </h1>
 <ol class="breadcrumb">
-  <li><%= link_to(dashboard_path(organization_id: current_user.organization)) do %>
-    <i class="fa fa-dashboard"></i> Home
-  <% end %>
+  <li>
+    <%= link_to(admin_dashboard_path) do %>
+      <i class="fa fa-dashboard"></i> Home
+    <% end %>
   </li>
   <li class="active"><%= @organization.name %></li>
 </ol>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -4,7 +4,8 @@
     Users
   </h1>
   <ol class="breadcrumb">
-    <li><%= link_to(dashboard_path) do %>
+    <li>
+      <%= link_to(admin_dashboard_path) do %>
         <i class="fa fa-dashboard"></i> Home
       <% end %>
     </li>
@@ -37,7 +38,7 @@
               <tbody>
               <% @users.each do |user| %>
                 <tr>
-                <td><%= user.organization.name %></td>
+                <td><%= user.organization&.name %></td>
                 <td><%= user.name %></td>
                 <td><%= user.email %></td>
                 <td class="text-right">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,9 +5,10 @@
   <small>your profile</small>
 </h1>
 <ol class="breadcrumb">
-<li><%= link_to(dashboard_path) do %>
-    <i class="fa fa-dashboard"></i> Home
-  <% end %>
+  <li>
+    <%= link_to(dashboard_path_from_user) do %>
+      <i class="fa fa-dashboard"></i> Home
+    <% end %>
   </li>
     <li><a href="#">Editing <%= current_user.name %></a></li>
 </ol>
@@ -72,7 +73,7 @@
   <br>
   <div class="form-actions medium-offset-3 medium-6">
     <%= submit_button %>
-    
+
   </div>
 <% end %>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -40,7 +40,7 @@
         <span class="icon-bar"></span>
       </a>
 
-    <% if user_signed_in? %>
+    <% if user_signed_in? && current_organization.present? %>
       <%= render partial: "layouts/lte_navbar" %>
     <% end %>
     </nav>
@@ -48,7 +48,7 @@
 
   <!-- =============================================== -->
   <% # If there's no organization set, most of these routes won't work. %>
-  <% if user_signed_in? && current_organization.id.present? %>
+  <% if user_signed_in? && current_organization.present? %>
     <%= render partial: "layouts/lte_sidebar" %>
   <% end %>
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -48,7 +48,7 @@ FactoryBot.define do
     end
 
     factory :super_admin_no_org do
-      name { "Administrative User No Org"}
+      name { "Administrative User No Org" }
       super_admin { true }
       organization_id { nil }
     end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -45,6 +45,7 @@ FactoryBot.define do
     factory :super_admin do
       name { "Administrative User" }
       super_admin { true }
+      organization_id { nil }
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -45,6 +45,11 @@ FactoryBot.define do
     factory :super_admin do
       name { "Administrative User" }
       super_admin { true }
+    end
+
+    factory :super_admin_no_org do
+      name { "Administrative User No Org"}
+      super_admin { true }
       organization_id { nil }
     end
   end

--- a/spec/features/admin/admin_namespace_spec.rb
+++ b/spec/features/admin/admin_namespace_spec.rb
@@ -1,7 +1,13 @@
 RSpec.feature "Admin Namespace" do
-  context "While signed in as an admin user" do
+  context "While signed in as an Administrative User (super admin)" do
     before do
       sign_in(@super_admin)
+    end
+  end
+
+  context "While signed in as an Administrative User with no organzation (super admin no org)" do
+    before do
+      sign_in(@super_admin_no_org)
     end
   end
 

--- a/spec/features/admin/canonical_items_spec.rb
+++ b/spec/features/admin/canonical_items_spec.rb
@@ -1,7 +1,72 @@
 RSpec.feature "Canonical Item Admin" do
-  context "While signed in as an organizationl admin" do
+  context "While signed in as an Administrative User (super admin)" do
     before do
       sign_in(@super_admin)
+    end
+
+    let!(:url_prefix) {}
+    context "when creating a new canonical item" do
+      before do
+        visit new_admin_canonical_item_path
+      end
+
+      let(:canonical_item_traits) { attributes_for(:canonical_item) }
+
+      scenario "it succeeds when creating a new canonical item with good data" do
+        fill_in "Name", with: canonical_item_traits[:name]
+        fill_in "Category", with: canonical_item_traits[:category]
+        fill_in "canonical_item_partner_key", with: canonical_item_traits[:partner_key]
+        click_button "Save"
+
+        expect(page.find(".alert")).to have_content "added"
+      end
+
+      scenario "it fails when creating a new canonical item with empty attributes" do
+        click_button "Save"
+        expect(page.find(".alert")).to have_content "ailed"
+      end
+    end
+
+    context "when updating an existing canonical item" do
+      before do
+        visit edit_admin_canonical_item_path(canonical_item)
+      end
+      let(:canonical_item) { CanonicalItem.first }
+
+      scenario "succeeds when changing the name" do
+        fill_in "Name", with: canonical_item.name + " new"
+        click_button "Save"
+        expect(page.find(".alert")).to have_content "pdated"
+      end
+
+      scenario "fails when updating the name to empty" do
+        fill_in "Name", with: ""
+        click_button "Save"
+        expect(page.find(".alert")).to have_content "ailed"
+      end
+    end
+
+    scenario "viewing a listing of all Canonical Items that shows a summary of its sub-items" do
+      canonical_item = CanonicalItem.first
+      create_list(:item, 2, canonical_item: canonical_item)
+      count = canonical_item.item_count
+      visit admin_canonical_items_path
+      expect(page).to have_content(canonical_item.name)
+      within "table tbody tr#canonical-item-row-#{canonical_item.to_param} td:nth-child(3)" do
+        expect(page).to have_content(count)
+      end
+    end
+
+    scenario "viewing a single Canonical Item" do
+      canonical_item = CanonicalItem.first
+      visit admin_canonical_item_path(canonical_item)
+      expect(page).to have_content(canonical_item.name)
+    end
+  end
+
+  context "While signed in as an Administrative User with no organization (super admin no org)" do
+    before do
+      sign_in(@super_admin_no_org)
     end
 
     let!(:url_prefix) {}

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -1,34 +1,70 @@
-RSpec.feature "Organizations Admin" do
-  before :each do
-    sign_in(@super_admin)
-  end
-
-  scenario "creating a new organization" do
-    visit new_admin_organization_path
-    screenshot_and_open_image
-    click_link "Add New Organization"
-    org_params = attributes_for(:organization)
-    fill_in "Name", with: org_params[:name]
-    fill_in "Short name", with: org_params[:short_name]
-    fill_in "Url", with: org_params[:url]
-    fill_in "Email", with: org_params[:email]
-    fill_in "Street", with: "1234 Banana Drive"
-    fill_in "City", with: "Boston"
-    select("MA", from: "State")
-    fill_in "Zipcode", with: "12345"
-
-    click_on "Save"
-
-    expect(page).to have_content("All Diaperbase Organizations")
-
-    within("tr.#{org_params[:short_name]}") do
-      first(:link, "View").click
+RSpec.feature "Admin Organization Management" do
+  context "While signed in as an Administrative User (super admin)" do
+    before :each do
+      sign_in(@super_admin)
     end
 
-    expect(page).to have_content(org_params[:name])
-    expect(page).to have_content("Banana")
-    expect(page).to have_content("Boston")
-    expect(page).to have_content("MA")
-    expect(page).to have_content("12345")
+    scenario "creating a new organization" do
+      visit new_admin_organization_path
+      screenshot_and_open_image
+      click_link "Add New Organization"
+      org_params = attributes_for(:organization)
+      fill_in "Name", with: org_params[:name]
+      fill_in "Short name", with: org_params[:short_name]
+      fill_in "Url", with: org_params[:url]
+      fill_in "Email", with: org_params[:email]
+      fill_in "Street", with: "1234 Banana Drive"
+      fill_in "City", with: "Boston"
+      select("MA", from: "State")
+      fill_in "Zipcode", with: "12345"
+
+      click_on "Save"
+
+      expect(page).to have_content("All Diaperbase Organizations")
+
+      within("tr.#{org_params[:short_name]}") do
+        first(:link, "View").click
+      end
+
+      expect(page).to have_content(org_params[:name])
+      expect(page).to have_content("Banana")
+      expect(page).to have_content("Boston")
+      expect(page).to have_content("MA")
+      expect(page).to have_content("12345")
+    end
+  end
+  context "While signd in as an Administrative User with no organization (super admin no org)" do
+    before :each do
+      sign_in(@super_admin_no_org)
+    end
+
+    scenario "creating a new organization" do
+      visit new_admin_organization_path
+      screenshot_and_open_image
+      click_link "Add New Organization"
+      org_params = attributes_for(:organization)
+      fill_in "Name", with: org_params[:name]
+      fill_in "Short name", with: org_params[:short_name]
+      fill_in "Url", with: org_params[:url]
+      fill_in "Email", with: org_params[:email]
+      fill_in "Street", with: "1234 Potato Drive"
+      fill_in "City", with: "New York"
+      select("NY", from: "State")
+      fill_in "Zipcode", with: "54321"
+
+      click_on "Save"
+
+      expect(page).to have_content("All Diaperbase Organizations")
+
+      within("tr.#{org_params[:short_name]}") do
+        first(:link, "View").click
+      end
+
+      expect(page).to have_content(org_params[:name])
+      expect(page).to have_content("Potato")
+      expect(page).to have_content("New York")
+      expect(page).to have_content("NY")
+      expect(page).to have_content("54321")
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,6 +69,7 @@ def stub_addresses
    "1500 Remount Road, Front Royal, VA 22630",
    "1234 Banana Drive Boston, MA 12345",
    "1234 Banana Drive, Boston, MA 12345",
+   "1234 Potato Drive, New York, NY 54321",
    "123 Donation Site Way",
    "456 Donation Site Way",
    "789 Donation Site Way",
@@ -148,6 +149,7 @@ RSpec.configure do |config|
     @organization_admin = create(:organization_admin, name: "DEFAULT ORG ADMIN", organization: @organization)
     @user = create(:user, organization: @organization, name: "DEFAULT USER")
     @super_admin = create(:super_admin, name: "DEFAULT SUPERADMIN")
+    @super_admin_no_org = create(:super_admin_no_org, name: "DEFAULT SUPERADMIN NO ORG")
 
     # Print the name of the example being run
     Rails.logger.info "\n\n-~=> #{self.class.description} ::::::::::::::::::::::"


### PR DESCRIPTION
Resolves #590 

### Description
Super_admin users are not required to have an organization id. This change makes the `belongs_to` relation optional if the user is a `super_admin?`. It also fixes navigation issues in the `admin` part of the site that was always expecting organization id, and thus would break for any super admin that had non. 

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added feature tests for `super admin with no organization` mirroring feature tests for `super admin with organization`. 
