### PR TITLE
549 display more useful user information part 2

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -25,6 +25,12 @@ class OrganizationsController < ApplicationController
     redirect_to organization_path, notice: "User invited to organization!"
   end
 
+  def resend_user_invitation
+    user = User.find(params[:user_id])
+    user.invite!
+    redirect_to organization_path, notice: "User re-invited to organization!"
+  end
+
   private
 
   def authorize_admin

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,7 @@
+module UsersHelper
+  def reinvite_user_link(user)
+    if user.reinvitable?
+      link_to content_tag(:i, "", class: 'fa fa-envelope', alt: "Re-send invitation", title: "Re-send invitation"), resend_user_invitation_organization_path(user_id: user.id), method: :post
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,4 +56,10 @@ class User < ApplicationRecord
 
     "normal"
   end
+
+  def reinvitable?
+    return true if invitation_status == "invited" && invitation_sent_at <= 7.days.ago
+
+    false
+  end
 end

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -25,16 +25,16 @@
     <div class="col-md-4">
       <h4>Contact Info</h4>
       <p><%= fa_icon "envelope" %> <%= link_to @organization.email, "mailto:#{@organization.email}" %></p>
-      <address><%= fa_icon "map-marker" %> <%= @organization.address %></address>      
+      <address><%= fa_icon "map-marker" %> <%= @organization.address %></address>
     </div>
     <div class="col-md-8">
       <h4>Users</h4>
         <table class="table table-hover">
           <thead>
             <tr>
-              <th>Name</th><th>Email</th><th>Role</th><th>Last Sign in</th><th>Status</th>
-            </tr>  
-          </thead>          
+              <th>Name</th><th>Email</th><th>Role</th><th>Last Sign in</th><th>Status</th><th></th>
+            </tr>
+          </thead>
           <tbody>
             <%= render partial: "/users/organization_user", collection: @organization.users, as: :user %>
           </tbody>

--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -4,4 +4,8 @@
   <td><%= user.kind %></td>
   <td><%= user.most_recent_sign_in %></td>
   <td><%= user.invitation_status %></td>
+  <td><%= reinvite_user_link(user) %></td>
 </tr>
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
     resource :organization, path: :manage, only: %i(edit update) do
       collection do
         post :invite_user
+        post :resend_user_invitation
       end
     end
 

--- a/spec/features/organization_spec.rb
+++ b/spec/features/organization_spec.rb
@@ -29,7 +29,7 @@ RSpec.feature "Organization management", type: :feature do
       end
     end
 
-    scenario "Adding a new user to an organization" do
+    scenario "Can add a new user to an organization" do
       allow(User).to receive(:invite!).and_return(true)
       visit url_prefix + "/organization"
       click_on "Invite User to this Organization"
@@ -38,6 +38,12 @@ RSpec.feature "Organization management", type: :feature do
         click_on "Invite User"
       end
       expect(page).to have_content("invited to organization")
+    end
+
+    scenario "Can re-invite a user to an organization after 7 days" do
+      create(:user, name: "Ye Olde Invited User", invitation_sent_at: Time.current - 7.days)
+      visit url_prefix + "/organization"
+      expect(page).to have_xpath("//i[@alt='Re-send invitation']")
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -62,7 +62,6 @@ RSpec.describe User, type: :model do
       expect(build(:user, invitation_sent_at: Time.current - 7.days).reinvitable?).to be true
       expect(build(:user, invitation_sent_at: Time.current - 6.days).reinvitable?).to be false
       expect(build(:user, invitation_sent_at: Time.current - 7.days, invitation_accepted_at: Time.current - 7.days).reinvitable?).to be false
-
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,5 +57,12 @@ RSpec.describe User, type: :model do
       expect(build(:organization_admin).kind).to eq("admin")
       expect(build(:user).kind).to eq("normal")
     end
+
+    it "#reinvatable?" do
+      expect(build(:user, invitation_sent_at: Time.current - 7.days).reinvitable?).to be true
+      expect(build(:user, invitation_sent_at: Time.current - 6.days).reinvitable?).to be false
+      expect(build(:user, invitation_sent_at: Time.current - 7.days, invitation_accepted_at: Time.current - 7.days).reinvitable?).to be false
+
+    end
   end
 end


### PR DESCRIPTION
Resolves #549 

### Description
This is the bonus round for issue #549. 
The first item was already implemented. The page refreshes when you send an invitation, showing an updated list of users. 
The second item was added. Adds ability to re-send an invitation after 7 or more days. Shows a clickable envelope with a "Re-send invitation" title next to eligible users.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Spec and Feature tests added. 

### Screenshots
![image](https://user-images.githubusercontent.com/200333/47791758-692ed380-dce8-11e8-8f31-14cec9b7fa3a.png)
