### PR TITLE
566 ask for total boops

### DIFF
--- a/app/assets/javascripts/barcode_items.js.erb
+++ b/app/assets/javascripts/barcode_items.js.erb
@@ -53,7 +53,7 @@ $(document).ready(function() {
               if ($(line_item).attr('scanned_more_than_two_times') != undefined) {
                   current_total = parseInt($(line_item).find('input[type=number]').val());
                   current_boops = (current_total / line_item_quantity) + 1;
-                  total_boops = prompt('Enter total packages count for this item', current_boops);
+                  total_boops = prompt('Enter total number of packages for this item', current_boops);
                   if (total_boops != null) {
                       total_boops = parseInt(total_boops);
                       line_item_quantity = total_boops * line_item_quantity;

--- a/app/assets/javascripts/barcode_items.js.erb
+++ b/app/assets/javascripts/barcode_items.js.erb
@@ -51,10 +51,14 @@ $(document).ready(function() {
           if (data['src'] != this && data['value'] == this.value) {
               line_item = this.closest('.nested-fields');
               if ($(line_item).attr('scanned_more_than_two_times') != undefined) {
-                  prompt_value = prompt('Enter total quantity of items', line_item_quantity);
-                  if (prompt_value != null) {
-                      line_item_quantity = parseInt(prompt_value);
+                  current_total = parseInt($(line_item).find('input[type=number]').val());
+                  current_boops = (current_total / line_item_quantity) + 1;
+                  total_boops = prompt('Enter total packages count for this item', current_boops);
+                  if (total_boops != null) {
+                      total_boops = parseInt(total_boops);
+                      line_item_quantity = total_boops * line_item_quantity;
                   } else {
+                      total_boops = 0;
                       line_item_quantity = 0;
                   }
               }


### PR DESCRIPTION
This changes how we calculate the total items in the form from the value in the prompt.
Feature tests not affected and still pass.

Resolves #566 

### Description
Instead of asking total number of items being scanned for a particular item (diaper count in total packages of the same line_item) we now ask for total number of packages. Less mental math and less prone to mistakes. The end result is still the total number of items, but the human interaction is simplified.

### Type of change

* Non-breaking change. 

### How Has This Been Tested?

Feature tests still pass. End result is the same. User interaction is slightly modified.

### Screenshots
![image](https://user-images.githubusercontent.com/200333/47827326-163a3800-dd4b-11e8-8ef8-c6b0aa7d27c9.png)
