### PR TITLE
609 Prevent `request_storage_location_and_populate_item` from executing incorrectly

### DIFF
--- a/app/assets/javascripts/distributions_and_transfers.coffee
+++ b/app/assets/javascripts/distributions_and_transfers.coffee
@@ -21,11 +21,12 @@ populate_dropdowns = (objects, inventory) ->
 
 request_storage_location_and_populate_item = (item_to_populate) ->
   control = $("select.storage-location-source")
-  $.ajax
-    url: control.data("storage-location-inventory-path").replace(":id", control.val())
-    dataType: "json"
-    success: (data) ->
-      populate_dropdowns item_to_populate, data
+  if(control.length > 0 && control.val() != "")
+    $.ajax
+      url: control.data("storage-location-inventory-path").replace(":id", control.val())
+      dataType: "json"
+      success: (data) ->
+        populate_dropdowns item_to_populate, data
 
 $ ->
   control = $("select.storage-location-source")


### PR DESCRIPTION
Resolves #609

### Description
JS function `request_storage_location_and_populate_item` fires on every page, but should not continue execution until it finds the element it depends on, and it has a value. 

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

No longer seeing console errors

### Screenshots
Continuing on even though element was not found:
![image](https://user-images.githubusercontent.com/200333/47829805-42f44c80-dd57-11e8-9034-6ffbfce904ba.png)

Continuing on even though element has no value selected.
![image](https://user-images.githubusercontent.com/200333/47829830-60291b00-dd57-11e8-88b7-316a57a0235b.png)
