### PR TITLE
Fix logo path

### DIFF
--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,4 +1,3 @@
-<% resource = User.new %>
 <h2><%= t 'devise.invitations.edit.header' %></h2>
 <p>Welcome to Diaperbase! Before we get started, please set a new password for yourself.</p>
 <p>We recommend a password that is:</p>
@@ -9,7 +8,7 @@
 </ul>
 <p>An easy one would be to pick a line from a poem or a favorite quote!</p>
 <%= simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f| %>
-
+  <%= devise_error_messages! %>
   <%= f.hidden_field :invitation_token %>
 
   <%= f.input :password %>

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,3 +1,4 @@
+<% resource = User.new %>
 <h2><%= t 'devise.invitations.edit.header' %></h2>
 <p>Welcome to Diaperbase! Before we get started, please set a new password for yourself.</p>
 <p>We recommend a password that is:</p>
@@ -8,7 +9,7 @@
 </ul>
 <p>An easy one would be to pick a line from a poem or a favorite quote!</p>
 <%= simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f| %>
-  <%= devise_error_messages! %>
+
   <%= f.hidden_field :invitation_token %>
 
   <%= f.input :password %>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -23,7 +23,7 @@
 <div class="login-box">
   <div class="login-logo">
 
-    <img id="MastheadLogo" src="img/diaper-base-logo-full-white-text.svg" style="width: 80%; height: 80%; " alt="Diaperbase" title="Diaperbase" class="serv_icon"/>
+    <img id="MastheadLogo" src="/img/diaper-base-logo-full-white-text.svg" style="width: 80%; height: 80%; " alt="Diaperbase" title="Diaperbase" class="serv_icon"/>
   </div>
   <!-- /.login-logo -->
   <div class="login-box-body">

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -22,7 +22,7 @@
 <body class="hold-transition login-page">
 <div class="login-box">
   <div class="login-logo">
-  <img src="/img/DiaperBase-Logo.png" style="width: 85%; height: 85%" alt="" title="" class="serv_icon">
+  <img src="/img/diaper-base-logo-full-white-text.svg" style="width: 85%; height: 85%" alt="" title="" class="serv_icon">
   </div>
   <!-- /.login-logo -->
   <div class="login-box-body">

--- a/app/views/layouts/navigation/_header.html.erb
+++ b/app/views/layouts/navigation/_header.html.erb
@@ -1,3 +1,4 @@
+<!-- TODO: Remove the layouts/navigation directory probably? None of these files seemed to be rendered anywhere at the moment  -->
 <header class="main-header">
   <a class="logo" href="/">
     <%= image_tag "DiaperBase-Logo.png", alt: "DiaperBase Logo", id: "logo" %>

--- a/app/views/static/index.html.erb
+++ b/app/views/static/index.html.erb
@@ -54,7 +54,7 @@
       <section class="caption">
         <div class="row">
           <h1 class="superbar" style="text-align: center;">
-          <img id="MastheadLogo" src="img/diaper-base-logo-full-white-text.svg" style="width: 70%; height: 70%; " alt="Diaperbase" title="Diaperbase" class="serv_icon"/>
+          <img id="MastheadLogo" src="/img/diaper-base-logo-full-white-text.svg" style="width: 70%; height: 70%; " alt="Diaperbase" title="Diaperbase" class="serv_icon"/>
           </h1>
           <h2 class="superbar">The easiest and most love-filled way to manage your diaper bank.</h2>
         </div>
@@ -79,26 +79,26 @@
       <!--    Start Services List    -->
       <div class="row services_list">
         <div class="small-12 medium-3 large-3 columns">
-          <img src="img/icon2.png" alt="" title="" height="200" width="200" class="serv_icon"/>
+          <img src="/img/icon2.png" alt="" title="" height="200" width="200" class="serv_icon"/>
           <h2 class="title">Report Generation</h2>
           <p>Generate pdfs of partner distribution invoices for easy printing and sending.</p>
         </div>
 
         <div class="small-12 medium-3 large-3 columns">
-          <img src="img/icon1.png" alt="" title="" height="200" width="200" class="serv_icon"/>
+          <img src="/img/icon1.png" alt="" title="" height="200" width="200" class="serv_icon"/>
           <h2 class="title">Barcode Scanning</h2>
           <p>Quickly add or remove inventory with the scan of a barcode. The adjusting and transfering of
           inventory is also supported as well as creating your own barcodes.</p>
         </div>
 
         <div class="small-12 medium-3 large-3 columns">
-          <img src="img/icon3.png" alt="" title="" height="200" width="200" class="serv_icon"/>
+          <img src="/img/icon3.png" alt="" title="" height="200" width="200" class="serv_icon"/>
           <h2 class="title">Inventory Management</h2>
           <p>Easily keep track of the items in your inventory regardless of their storage location.</p>
         </div>
 
         <div class="small-12 medium-3 large-3 columns">
-          <img src="img/icon4.png" alt="" title="" height="200" width="200" class="serv_icon"/>
+          <img src="/img/icon4.png" alt="" title="" height="200" width="200" class="serv_icon"/>
           <h2 class="title">Dashboard Visualization</h2>
           <p>Quickly view your inventory, donations, purchases and distributions on a single page.</p>
         </div>
@@ -136,14 +136,14 @@
           <div id="carousel">
             
             <div class="tesimonial">
-              <img src="img/diaper-base-logo-icon.svg" title="Diaperbase Logo" alt="Diaperbase Logo">
+              <img src="/img/diaper-base-logo-icon.svg" title="Diaperbase Logo" alt="Diaperbase Logo">
               <!-- <span class="name">Mashable</span> -->
               <p>Finally, an inventory management system designed specifically for the unique needs of diaper banks!</p>
               <span class="author">Rachel Alston, PDX Diaper Bank</span>
             </div>
 
             <div class="tesimonial">
-              <img src="img/diaper-base-logo-icon.svg" title="Diaperbase Logo" alt="Diaperbase Logo">
+              <img src="/img/diaper-base-logo-icon.svg" title="Diaperbase Logo" alt="Diaperbase Logo">
               <!-- <span class="name">Mashable_2</span> -->
               <p>DiaperBase has taken our diaper distribution to the next level. We no longer have to worry about how to track our incoming and outgoing inventory, and having all our products and data tracked in different ways in different documents and systems. DiaperBase has saved us time, money, energy and many, many headaches. The system is extremely intuitive and user-friendly and we are so grateful to have it.</p>
               <span class="author">Megan, Sweet Cheeks Diaper Bank</span>

--- a/app/views/static/register.html.erb
+++ b/app/views/static/register.html.erb
@@ -39,7 +39,7 @@
   <section class="caption">
     <div class="row">
       <h1 class="superbar" style="text-align: center;">
-      <img id="MastheadLogo" src="img/diaper-base-logo-full-white-text.svg" style="width: 70%; height: 70%; " alt="Diaperbase" title="Diaperbase" class="serv_icon"/></h1>
+      <img id="MastheadLogo" src="/img/diaper-base-logo-full-white-text.svg" style="width: 70%; height: 70%; " alt="Diaperbase" title="Diaperbase" class="serv_icon"/></h1>
       <h2 class="superbar" style="text-align: center;">Register to receive an invitation to become a DiaperBase user.</h2>
     </div>
   </section>


### PR DESCRIPTION
<!--Read comments, before commiting pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

### Description
This PR fixes the logo path so that the Diaper Base logo is rendered rather than a broken image link.
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually tested since this is a view change.

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

<img width="507" alt="screen shot 2018-11-03 at 11 15 28 pm" src="https://user-images.githubusercontent.com/13142719/47959692-c795d380-dfc0-11e8-9175-7ab20530f781.png">
<img width="446" alt="screen shot 2018-11-03 at 11 23 38 pm" src="https://user-images.githubusercontent.com/13142719/47959693-c95f9700-dfc0-11e8-87fd-1f356f97cfc3.png">
