### PR TITLE
Fixes #614 - New Organizations should include an Admin User.

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -19,12 +19,14 @@ class Admin::OrganizationsController < AdminController
 
   def new
     @organization = Organization.new
+    @organization.users.build(organization_admin: true)
   end
 
   def create
     @organization = Organization.create(organization_params)
     if @organization.save
       Organization.seed_items(@organization)
+      @organization.users.try(:last).try(:invite!)
       redirect_to admin_organizations_path, notice: "Organization added!"
     else
       flash[:error] = "Failed to create Organization."
@@ -48,6 +50,8 @@ class Admin::OrganizationsController < AdminController
   private
 
   def organization_params
-    params.require(:organization).permit(:name, :short_name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location)
+    params.require(:organization)
+          .permit(:name, :short_name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location,
+                  users_attributes: %i(name email password password_confirmation organization_admin))
   end
 end

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -5,12 +5,15 @@ class StaticController < ApplicationController
   layout false
 
   def index
-    redirect_to dashboard_url(current_user.organization) if current_user
+    if current_user
+      redirect_to admin_dashboard_url && return if current_user.super_admin?
+      redirect_to dashboard_url(current_user.organization)
+    end
   end
 
   def register; end
 
-  def page
+  def pages
     # This allows for a flexible addition of static content
     # Anything under the url /pages/:name will render the file /app/views/static/[name].html.erb
     # Example: /pages/contact renders /app/views/static/contact.html.erb

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -6,8 +6,11 @@ class StaticController < ApplicationController
 
   def index
     if current_user
-      redirect_to admin_dashboard_url && return if current_user.super_admin?
-      redirect_to dashboard_url(current_user.organization)
+      if current_user.organization.present?
+        redirect_to dashboard_url(current_user.organization)
+      elsif current_user.super_admin?
+        redirect_to admin_dashboard_url if current_user.super_admin?
+      end
     end
   end
 

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -16,7 +16,7 @@ class StaticController < ApplicationController
 
   def register; end
 
-  def pages
+  def page
     # This allows for a flexible addition of static content
     # Anything under the url /pages/:name will render the file /app/views/static/[name].html.erb
     # Example: /pages/contact renders /app/views/static/contact.html.erb

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -48,6 +48,8 @@ class Organization < ApplicationRecord
 
   has_one_attached :logo
 
+  accepts_nested_attributes_for :users
+
   geocoded_by :address
   after_validation :geocode, if: ->(obj) { obj.address.present? && obj.address_changed? }
 

--- a/app/views/admin/organizations/new.html.erb
+++ b/app/views/admin/organizations/new.html.erb
@@ -39,7 +39,15 @@ New Organization
   <p class="help-block">Logo should be a 4:1 ratio of width / height (default image is 763 x 188 pixels).
     Only jpeg/png format is supported.
   </p>
-    <%= submit_button %>
+  <h1>Add a user</h1>
+  <%= f.simple_fields_for :users do |user| %>
+    <%= render 'admin/users/user_form_fields', f: user %>
+    <%= user.input :organization_admin, label: "Organization Admin?", wrapper: :vertical_input_group do %>
+      <%= user.check_box :organization_admin %>
+    <% end %>
+  <% end %>
+
+  <%= submit_button %>
 </div>
 
 </div>

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -23,20 +23,23 @@
     <h3 class="box-title"><%= @organization.name %></h3>
   </div>
   <div class="box-body">
-		<div class="col-md-6">
-		  <h4>Contact Info</h4>
-			<p><%= fa_icon "envelope" %> <%= link_to @organization.email, "mailto:#{@organization.email}" %></p>
-			<address><%= fa_icon "map-marker" %> <%= @organization.address %></address>
+    <div class="col-md-4">
+      <h4>Contact Info</h4>
+      <p><%= fa_icon "envelope" %> <%= link_to @organization.email, "mailto:#{@organization.email}" %></p>
+      <address><%= fa_icon "map-marker" %> <%= @organization.address %></address>
     </div>
-		<div class="col-md-6">
-			<h4>Users</h4>
-			  <ul class="list-group">
-					<li class="list-group-item">
-			<%= @organization.display_users.split(",").join("</li><li class=\"list-group-item\">").html_safe %>
-			    </li>
-				</ul>
+    <div class="col-md-8">
+      <h4>Users</h4>
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th>Name</th><th>Email</th><th>Role</th><th>Last Sign in</th><th>Status</th><th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <%= render partial: "/users/organization_user", collection: @organization.users, as: :user %>
+        </tbody>
+      </table>
     </div>
-	</div>
-
 </div>
 </section>

--- a/app/views/admin/users/_user_form_fields.html.erb
+++ b/app/views/admin/users/_user_form_fields.html.erb
@@ -1,0 +1,16 @@
+<%= f.input :name, label: "Name", wrapper: :vertical_input_group, required: true, autofocus: true do %>
+  <span class="input-group-addon"><%= fa_icon "user" %></span>
+  <%= f.input_field :name, class: "form-control" %>
+<% end %>
+<%= f.input :email, label: "E-mail", wrapper: :vertical_input_group, required: true do %>
+  <span class="input-group-addon"><%= fa_icon "envelope" %></span>
+  <%= f.input_field :email, class: "form-control" %>
+<% end %>
+<%= f.input :password, label: "Password", wrapper: :vertical_input_group, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) do %>
+  <span class="input-group-addon"><%= fa_icon "lock" %></span>
+  <%= f.input_field :password, class: "form-control" %>
+<% end %>
+<%= f.input :password_confirmation, label: "Confirm Password", wrapper: :vertical_input_group, required: true do %>
+  <span class="input-group-addon"><%= fa_icon "check" %></span>
+  <%= f.input_field :password_confirmation, class: "form-control" %>
+<% end %>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -13,30 +13,11 @@
         <span class="input-group-addon"><%= fa_icon "building" %></span>
         <%= f.input_field :organization_id, collection: @organizations, class: "form-control" %>
       <% end %>
-      <%= f.input :name, label: "Name", wrapper: :vertical_input_group, required: true, autofocus: true do %>
-        <span class="input-group-addon"><%= fa_icon "user" %></span>
-        <%= f.input_field :name, class: "form-control" %>
-      <% end %>
-      <%= f.input :email, label: "E-mail", wrapper: :vertical_input_group, required: true do %>
-        <span class="input-group-addon"><%= fa_icon "envelope" %></span>
-        <%= f.input_field :email, class: "form-control" %>
-      <% end %>
-      <%= f.input :password, label: "Password", wrapper: :vertical_input_group, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) do %>
-        <span class="input-group-addon"><%= fa_icon "lock" %></span>
-        <%= f.input_field :password, class: "form-control" %>
-      <% end %>
-      <%= f.input :password_confirmation, label: "Confirm Password", wrapper: :vertical_input_group, required: true do %>
-        <span class="input-group-addon"><%= fa_icon "check" %></span>
-        <%= f.input_field :password_confirmation, class: "form-control" %>
-      <% end %>
+      <%= render 'admin/users/user_form_fields', f: f %>
     </div>
-
     <div class="form-actions">
       <%= submit_button %>
     </div>
-
   <% end %>
-
-
-</div>
+  </div>
 </div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -41,8 +41,7 @@
         </table>
 
       <%= modal_button_to("#addUserModal", { text: "Invite User to this Organization" }) if can_administrate? %>
-
-  </div>
+    </div>
   </div>
   <div class="box-footer">
     <%= edit_button_to(edit_organization_path, { size: "lg" }) if can_administrate? %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,6 +12,8 @@ Rails.application.configure do
   # preloads Rails for running tests, you may have to set it to true.
   config.eager_load = false
 
+  config.action_mailer.default_url_options = { host: "localhost" }
+
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {

--- a/spec/features/admin/organizations_spec.rb
+++ b/spec/features/admin/organizations_spec.rb
@@ -5,18 +5,26 @@ RSpec.feature "Admin Organization Management" do
     end
 
     scenario "creating a new organization" do
+      allow(User).to receive(:invite!).and_return(true)
       visit new_admin_organization_path
       screenshot_and_open_image
       click_link "Add New Organization"
       org_params = attributes_for(:organization)
-      fill_in "Name", with: org_params[:name]
-      fill_in "Short name", with: org_params[:short_name]
-      fill_in "Url", with: org_params[:url]
-      fill_in "Email", with: org_params[:email]
-      fill_in "Street", with: "1234 Banana Drive"
-      fill_in "City", with: "Boston"
-      select("MA", from: "State")
-      fill_in "Zipcode", with: "12345"
+      fill_in "organization_name", with: org_params[:name]
+      fill_in "organization_short_name", with: org_params[:short_name]
+      fill_in "organization_url", with: org_params[:url]
+      fill_in "organization_email", with: org_params[:email]
+      fill_in "organization_street", with: "1234 Banana Drive"
+      fill_in "organization_city", with: "Boston"
+      select("MA", from: "organization_state")
+      fill_in "organization_zipcode", with: "12345"
+
+      admin_user_params = attributes_for(:organization_admin)
+      fill_in "organization_users_attributes_0_name", with: admin_user_params[:name]
+      fill_in "organization_users_attributes_0_email", with: admin_user_params[:email]
+      fill_in "organization_users_attributes_0_password", with: "123password"
+      fill_in "organization_users_attributes_0_password_confirmation", with: "123password"
+      check "organization_users_attributes_0_organization_admin"
 
       click_on "Save"
 
@@ -31,6 +39,10 @@ RSpec.feature "Admin Organization Management" do
       expect(page).to have_content("Boston")
       expect(page).to have_content("MA")
       expect(page).to have_content("12345")
+
+      expect(page).to have_content(admin_user_params[:name])
+      expect(page).to have_content(admin_user_params[:email])
+      expect(page).to have_content("invited")
     end
   end
   context "While signd in as an Administrative User with no organization (super admin no org)" do
@@ -39,18 +51,26 @@ RSpec.feature "Admin Organization Management" do
     end
 
     scenario "creating a new organization" do
+      allow(User).to receive(:invite!).and_return(true)
       visit new_admin_organization_path
       screenshot_and_open_image
       click_link "Add New Organization"
       org_params = attributes_for(:organization)
-      fill_in "Name", with: org_params[:name]
-      fill_in "Short name", with: org_params[:short_name]
-      fill_in "Url", with: org_params[:url]
-      fill_in "Email", with: org_params[:email]
-      fill_in "Street", with: "1234 Potato Drive"
-      fill_in "City", with: "New York"
-      select("NY", from: "State")
-      fill_in "Zipcode", with: "54321"
+      fill_in "organization_name", with: org_params[:name]
+      fill_in "organization_short_name", with: org_params[:short_name]
+      fill_in "organization_url", with: org_params[:url]
+      fill_in "organization_email", with: org_params[:email]
+      fill_in "organization_street", with: "1234 Potato Drive"
+      fill_in "organization_city", with: "New York"
+      select("NY", from: "organization_state")
+      fill_in "organization_zipcode", with: "54321"
+
+      admin_user_params = attributes_for(:organization_admin)
+      fill_in "organization_users_attributes_0_name", with: admin_user_params[:name]
+      fill_in "organization_users_attributes_0_email", with: admin_user_params[:email]
+      fill_in "organization_users_attributes_0_password", with: "543password"
+      fill_in "organization_users_attributes_0_password_confirmation", with: "543password"
+      check "organization_users_attributes_0_organization_admin"
 
       click_on "Save"
 
@@ -65,6 +85,10 @@ RSpec.feature "Admin Organization Management" do
       expect(page).to have_content("New York")
       expect(page).to have_content("NY")
       expect(page).to have_content("54321")
+
+      expect(page).to have_content(admin_user_params[:name])
+      expect(page).to have_content(admin_user_params[:email])
+      expect(page).to have_content("invited")
     end
   end
 end


### PR DESCRIPTION
Resolves #614

### Description
Streamlines the creation of a new admin user at the same time a new organization is created. Adds a User form below the Organization form when creating a new organization. 

Also updates the "Users" section to match the regular orgs detail page when viewing an organization within the admin namespace. This includes more user information such as role, status, etc. 

Fixes an issue with the static_controller redirecting super_admins incorrectly when no org is present. All users with an org id should default to regular org dashboard. Any super-user with no org should default to admin dashboard.

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Admin organization feature tests have been expanding to create and test for the user. 

### Screenshots
