### PR TITLE
adds links to partner proof files

### DIFF
--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -1,2 +1,8 @@
 module PartnersHelper
+  def documentation_url(path)
+    # NOTE(chaserx): add to .env with http://localhost:3001 or https://partnerbase.org
+    uri = URI(ENV['PARTNER_BASE_URL'])
+    uri.path = path
+    uri.to_s
+  end
 end

--- a/app/views/partners/approve_partner.html.erb
+++ b/app/views/partners/approve_partner.html.erb
@@ -36,7 +36,7 @@
           <p>Name: <%= @agency[:name] %></p>
           <p>Distributor Type <%= @agency[:distributor_type] %></p>
           <p>Agency Type: <% @agency[:agency_type] %></p>
-          <p>Proof of Agency Status (Link) <%= @agency[:proof_of_agency_status] %></p>
+          <p>Proof of Agency Status (Link): <%= link_to File.basename(@agency[:proof_of_agency_status]), documentation_url(@agency[:proof_of_agency_status]) %></p>
           <p>Agency Mission: <%= @agency[:agency_mission] %></p>
           <p>Address <%= @agency[:address1] %></p>
           <p>Address <%= @agency[:address2] %></p>
@@ -52,7 +52,7 @@
           <h2>Agency Stability</h2>
           <p>Founded <%= @agency[:stability][:founded] %></p>
           <p>Form 990: <%= @agency[:stability][:form_990] ? 'Yes' : 'No' %></p>
-          <p>Form 990 Link <%= @agency[:stability][:form_990_link] %></p>
+          <p>Form 990 Link: <%= link_to File.basename(@agency[:stability][:form_990_link]), documentation_url(@agency[:stability][:form_990_link]) %></p>
           <p>Program Name <%= @agency[:stability][:program_name] %></p>
           <p>Program Description <%= @agency[:stability][:program_description] %></p>
           <p>Program Age <%= @agency[:stability][:program_age] %></p>
@@ -138,7 +138,12 @@
           <p>Sources of Diapers: <%= @agency[:funding][:diapers] %> </p>
           <p>Diaper Budget:<%= @agency[:funding][:budget] %></p>
           <p>Diaper Funding Source: <%= @agency[:funding][:diaper_funding_source] %></p>
-
+          <h2>Other Documents</h2>
+          <ul>
+            <% @agency[:documents].each do |document| %>
+              <li><%= link_to File.basename(document[:document_link]), documentation_url(document[:document_link]) %></li>
+            <% end %>
+          </ul>
         </div>
         <!-- /.box -->
       </div>


### PR DESCRIPTION
This PR corresponds to the bonus section for https://github.com/rubyforgood/partner/issues/57 where we include path information in the JSON body as seen in https://github.com/rubyforgood/partner/pulls/58

It requires an additional env variable `PARTNER_BASE_URL`.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested the UI for the `/:organization_id/partners/:partner_id/approve_partner` locally in browser. See screenshot below.

### Screenshots

![screencapture-localhost-3000-1-partners-3-approve_partner-2018-11-23-18_55_45](https://user-images.githubusercontent.com/7292/48962789-5314db80-ef53-11e8-8a8f-0f5e5555f710.png)
