### PR TITLE
move partner update from after create to background job

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -8,6 +8,7 @@ class PartnersController < ApplicationController
   def create
     @partner = current_organization.partners.new(partner_params)
     if @partner.save
+      UpdateDiaperPartnerJob.perform_async(@partner.id)
       redirect_to partners_path, notice: "Partner added!"
     else
       flash[:error] = "Something didn't work quite right -- try again?"

--- a/app/jobs/update_diaper_partner_job.rb
+++ b/app/jobs/update_diaper_partner_job.rb
@@ -1,0 +1,11 @@
+class UpdateDiaperPartnerJob
+  include SuckerPunch::Job
+  include DiaperPartnerClient
+  workers 2
+
+  def perform(partner_id)
+    @partner = Partner.find(partner_id)
+    DiaperPartnerClient.post(@partner.attributes) if Flipper.enabled?(:email_active)
+    @partner.update(status: "Pending")
+  end
+end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -26,8 +26,6 @@ class Partner < ApplicationRecord
       .order(:name)
   }
 
-  include DiaperPartnerClient
-  after_create :update_diaper_partner
   # better to extract this outside of the model
   def self.import_csv(data, organization_id)
     CSV.parse(data, headers: true) do |row|
@@ -44,12 +42,5 @@ class Partner < ApplicationRecord
 
   def csv_export_attributes
     [name, email]
-  end
-
-  private
-
-  def update_diaper_partner
-    update(status: "Pending")
-    DiaperPartnerClient.post(attributes) if Flipper.enabled?(:email_active)
   end
 end

--- a/spec/controllers/partners_controller_spec.rb
+++ b/spec/controllers/partners_controller_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe PartnersController, type: :controller do
       subject { post :create, params: default_params.merge(partner_params) }
 
       it "creates a new partner" do
-        expect{ subject }.to change(Partner, :count).by(1)
+        expect { subject }.to change(Partner, :count).by(1)
       end
 
       it "enqueues a UpdateDiaperPartnerJob job" do
@@ -68,7 +68,6 @@ RSpec.describe PartnersController, type: :controller do
       end
     end
   end
-
 
   describe "DELETE #destroy" do
     subject { delete :destroy, params: default_params.merge(id: create(:partner, organization: @organization)) }

--- a/spec/controllers/partners_controller_spec.rb
+++ b/spec/controllers/partners_controller_spec.rb
@@ -40,6 +40,36 @@ RSpec.describe PartnersController, type: :controller do
     it_behaves_like "csv import"
   end
 
+  describe "POST #create" do
+    context "successful save" do
+      partner_params = { partner: { name: "A Partner", email: "partner@example.com" } }
+      subject { post :create, params: default_params.merge(partner_params) }
+
+      it "creates a new partner" do
+        expect{ subject }.to change(Partner, :count).by(1)
+      end
+
+      it "enqueues a UpdateDiaperPartnerJob job" do
+        expect(UpdateDiaperPartnerJob).to receive(:perform_async)
+        subject
+      end
+
+      it "redirects to #index" do
+        expect(subject).to redirect_to(partners_path)
+      end
+    end
+
+    context "unsuccessful save due to empty params" do
+      partner_params = { partner: { name: "", email: "" } }
+      subject { post :create, params: default_params.merge(partner_params) }
+
+      it "renders :new" do
+        expect(subject).to render_template(:new)
+      end
+    end
+  end
+
+
   describe "DELETE #destroy" do
     subject { delete :destroy, params: default_params.merge(id: create(:partner, organization: @organization)) }
     it "redirects to #index" do

--- a/spec/jobs/update_diaper_partner_job_spec.rb
+++ b/spec/jobs/update_diaper_partner_job_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe UpdateDiaperPartnerJob, job: true do
+  describe ".perform_async" do
+    it "updates partner status to Pending" do
+      partner = create(:partner)
+
+      UpdateDiaperPartnerJob.perform_async(partner.id)
+
+      expect(partner.reload.status).to eq("Pending")
+    end
+
+    it "posts via DiaperPartnerClient" do
+      partner = create(:partner)
+      allow(Flipper).to receive(:enabled?) { true }
+
+      expect(DiaperPartnerClient).to receive(:post)
+
+      UpdateDiaperPartnerJob.perform_async(partner.id)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require "capybara/rails"
 require "capybara/rspec"
 require "capybara-screenshot/rspec"
 require "pry"
+require "sucker_punch/testing/inline"
 
 # Add additional requires below this line. Rails is not loaded until this point!
 


### PR DESCRIPTION
Resolves #637 

### Description

As outlined in #637, this PR moves the `update_diaper_partner` into a background job. 

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

This behavior change was tested by adding new tests to the automated test suite.
