### PR TITLE
Making partner information viewable (clickable) all the time, not jus…

### DIFF
--- a/app/views/partners/_partner_row.html.erb
+++ b/app/views/partners/_partner_row.html.erb
@@ -4,11 +4,11 @@
   <td><%= link_to partner_row.email, "mailto:#{partner_row.email}" %></td>
   <td>  <% case status
     when "Pending" %>
-      <span class="btn btn-xs bg-maroon"><%= status %></span>
+      <%= link_to approve_partner_partner_path(partner_row), class: "btn btn-xs bg-maroon" do %><%= status %><% end %>
     <% when "Awaiting Review" %>
       <%= link_to approve_partner_partner_path(partner_row), class: "btn btn-xs bg-orange" do %><%= status %><% end %>
     <% when "Approved" %>
-      <span class="btn btn-xs bg-olive"><%= status %></span>
+      <%= link_to approve_partner_partner_path(partner_row), class: "btn btn-xs bg-olive" do %><%= status %><% end %>
   <% end %>
   </td>
   <!-- <td><%== (rand < 0.7) ? '<span class="label label-success">Approved</span>' :

--- a/app/views/partners/approve_partner.html.erb
+++ b/app/views/partners/approve_partner.html.erb
@@ -148,7 +148,7 @@
         <!-- /.box -->
       </div>
       <div class="box-footer">
-        <%= print_button_to approve_application_partner_path(@partner), { text: "Approve Partner", icon: "thumbs-o-up", type: "success", size: "lg" } %>
+        <%= print_button_to approve_application_partner_path(@partner), { text: "Approve Partner", icon: "thumbs-o-up", type: "success", size: "lg" } if @partner.status == "Awaiting Review" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This is a request from one of the diaper banks. They want to be able to view all the partner details in the partner app at any time, not just when they are waiting for review. This is a cosmetic change.