### PR TITLE
replaced preheader text with first line of email body

### DIFF
--- a/app/views/distribution_mailer/partner_mailer.html.erb
+++ b/app/views/distribution_mailer/partner_mailer.html.erb
@@ -332,7 +332,7 @@
       <div class="content">
 
         <!-- START CENTERED WHITE CONTAINER -->
-        <span class="preheader">This is preheader text. Some clients will show this text as a preview.</span>
+        <span class="preheader">Your diaper request has been approved.</span>
         <table role="presentation" class="main">
 
           <!-- START MAIN CONTENT AREA -->


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/partner/issues/77

### Description

Our community partner PDX Diaperbank reported a minor bug where placeholder text was visible to email recipients. This small change uses their suggestion to replace that placeholder text in the preheaders with the first line from the regular body. 

This only replaces text, no logic changes. 
   
### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested in the rails console with a factory for distribution and the following 
` DistributionMailer.partner_mailer(d.organization, d).deliver_now` 

