### PR TITLE
update partner invitation form button with more context

### DIFF
--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -9,6 +9,6 @@
           <%= f.input_field :email, class: "form-control" %>
         <% end %>
 
-        <%= submit_button({text: "Send Invitation"}) %>
+        <%= submit_button({text: "Send Invitation", icon: "envelope"}) %>
   <% end %>
 </div>

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -9,7 +9,6 @@
           <%= f.input_field :email, class: "form-control" %>
         <% end %>
 
-        <%= submit_button %>
-  <% end %>    
-
+        <%= submit_button({text: "Send Invitation"}) %>
+  <% end %>
 </div>

--- a/spec/features/partner_spec.rb
+++ b/spec/features/partner_spec.rb
@@ -22,14 +22,14 @@ RSpec.feature "Partner management", type: :feature do
     visit url_prefix + "/partners/new"
     fill_in "Name", with: "Frank"
     fill_in "E-mail", with: "frank@frank.com"
-    click_button "Save"
+    click_button "Send Invitation"
 
     expect(page.find(".alert")).to have_content "added"
   end
 
   scenario "User creates a new partner with empty name" do
     visit url_prefix + "/partners/new"
-    click_button "Save"
+    click_button "Send Invitation"
 
     expect(page.find(".alert")).to have_content "didn't work"
   end
@@ -38,7 +38,7 @@ RSpec.feature "Partner management", type: :feature do
     partner = create(:partner, name: "Frank")
     visit url_prefix + "/partners/#{partner.id}/edit"
     fill_in "Name", with: "Franklin"
-    click_button "Save"
+    click_button "Save Invitation"
 
     expect(page.find(".alert")).to have_content "updated"
     partner.reload
@@ -49,7 +49,7 @@ RSpec.feature "Partner management", type: :feature do
     partner = create(:partner, name: "Frank")
     visit url_prefix + "/partners/#{partner.id}/edit"
     fill_in "Name", with: ""
-    click_button "Save"
+    click_button "Send Invitation"
 
     expect(page.find(".alert")).to have_content "didn't work"
   end

--- a/spec/features/partner_spec.rb
+++ b/spec/features/partner_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Partner management", type: :feature do
     partner = create(:partner, name: "Frank")
     visit url_prefix + "/partners/#{partner.id}/edit"
     fill_in "Name", with: "Franklin"
-    click_button "Save Invitation"
+    click_button "Send Invitation"
 
     expect(page.find(".alert")).to have_content "updated"
     partner.reload


### PR DESCRIPTION
Resolves #713 

### Description
If applied, this pull request will change the button on the new partner agency form from "save" to "send invitation". 

This should provide greater context for the user as to what will happen. 

### Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
- Tested in browser. See attached screenshot. 
- Updated feature specs.

### Screenshots
![screen shot 2019-02-17 at 6 06 42 pm](https://user-images.githubusercontent.com/7292/52920898-8f03d680-32df-11e9-9760-07e9b7209b8a.png)
