### PR TITLE
Fixes #630 - added xs adults briefs category to canonical items list

### DIFF
--- a/db/canonical_items.json
+++ b/db/canonical_items.json
@@ -3,7 +3,8 @@
     { "name": "Adult Briefs (Large/X-Large)", "qty": [0,0,3741], "key": "adult_lxl" },
     { "name": "Adult Briefs (Medium/Large)", "qty": [0,0,108], "key": "adult_ml" },
     { "name": "Adult Briefs (Small/Medium)", "qty": [0,0,2742], "key": "adult_sm" },
-    { "name": "Adult Briefs (XXL)", "qty": [0,0,24], "key": "adult_xxl" }
+    { "name": "Adult Briefs (XXL)", "qty": [0,0,24], "key": "adult_xxl" },
+    { "name": "Adult Briefs (XS/Small)", "qty": [0,0,0], "key": "adult_xs" }
   ],
   "Diapers - Childrens": [
     { "name": "Cloth Diapers (Plastic Cover Pants)", "qty": [0,0,75], "key": "cloth" },


### PR DESCRIPTION
Resolves #630 

### Description
I have added the new category. Please advise if you know what should be included in the array and I can add this.

There are two additional actions stipulated on issue #630 to be completed once this PR has been approved. The first requires a site admin and the third requires an addition to PartnerBase, which @chaserx will do.
   
### Type of change
* New feature (non-breaking change which adds functionality)
