### PR TITLE
Update readme to "rails db:migrate" instead of "rake db: migrate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ PG_PASSWORD=password
 If you're getting the error `PG::ConnectionBad: fe_sendauth: no password supplied`, it's because you have probably not done this.
 
 ## Seed the database
-From the root of the app, run `bundle exec rake db:seed`. This will create some initial data to use while testing the app and developing new features, including setting up the default user.
+From the root of the app, run `bundle exec rails db:seed`. This will create some initial data to use while testing the app and developing new features, including setting up the default user.
 
 ## Login
 To login, use these default credentials:


### PR DESCRIPTION
I have not opened an issue for this minor change, which I noticed as I was installing the repo for the first time. 

This PR updates the argument structure for the latest Rails version. I understand that prior to Rails 5 we would use "rake db:migrate". The updated pattern in Rails 5+ is to use "rails db:migrate". 