### PR TITLE
Update ruby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This project took what we built for the [Portland Diaper Bank in 2016](https://g
 ## Development
 
 ### Ruby Version
-This app uses Ruby version 2.5.3, indicated in `/.ruby-version` and `Gemfile`, which will be auto-selected if you use a Ruby versioning manager like `rvm` or `rbenv`.
+This app uses Ruby version 2.6.1, indicated in `/.ruby-version` and `Gemfile`, which will be auto-selected if you use a Ruby versioning manager like `rvm` or `rbenv`.
 
 ### Database Configuration
 This app uses PostgreSQL for all environments. You'll also need to create the `dev` and `test` databases, the app is expecting them to be named `diaper_development` and `diaper_test`, respectively. This should all be handled with `rails db:setup`.


### PR DESCRIPTION
### Description
The README is out of sync with the current `.ruby-version` and `Gemfile`, this is a simple text change to make it current.

### Type of change
* Documentation update

### How Has This Been Tested?
N/A
