### PR TITLE
Update README: corrected link to Application Overview wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 This application is an inventory management system that is built to address the needs of [Diaper Banks](http://nationaldiaperbanknetwork.org/what-is-diaper-need/diaper-facts/) as directly and explicitly as possible. Diaper Banks maintain inventory, receive donations and other means of intaking diapers (and related supplies), and issue Distributions to community partner organizations. Like any non-profit, they also need to perform reports on this data, and have day-to-day operational information they need as well. This application aims to serve all those needs, as well as facilitate, wherever possible the general operations of the Diaper Bank themselves (eg. through using barcode readers, scale weighing, inventory audits).
 
-For a general overview of the application, please see the [Application Overview](/rubyforgood/diaper/wiki/Application-Overview) wiki article.
+For a general overview of the application, please see the [Application Overview](https://github.com/rubyforgood/diaper/wiki/Application-Overview) wiki article.
 
 ### Closed Beta
 


### PR DESCRIPTION
Seems the use of relative links in this case adds extra fluff to the URL.
The link should direct your browser to:
https://github.com/rubyforgood/diaper/wiki/Application-Overview
Instead, it directs the browser to:
https://github.com/rubyforgood/diaper/blob/master/rubyforgood/diaper/wiki/Application-Overview
