### PR TITLE
Adding pry-byebug to make Byebug cmds available in pry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,7 +49,7 @@ gem "webpacker", "~> 3.5"
 
 group :development, :test do
   gem "awesome_print"
-  gem "byebug", "~> 10.0", platform: :mri
+  gem "pry-byebug"
   gem "guard-rspec"
   gem "pry-rails"
   gem "rspec-rails", "~> 3.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,7 @@ GEM
     bugsnag (6.10.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.3)
-    byebug (10.0.2)
+    byebug (11.0.1)
     capistrano (3.11.0)
       airbrussh (>= 1.0.0)
       i18n
@@ -279,7 +279,10 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    pry-rails (0.3.8)
+    pry-byebug (3.7.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
+    pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (3.0.3)
     puma (3.12.0)
@@ -470,7 +473,6 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass
   bugsnag
-  byebug (~> 10.0)
   capistrano-bundler
   capistrano-rails
   capistrano-rails-console
@@ -508,6 +510,7 @@ DEPENDENCIES
   paperclip
   pg (~> 1.1.3)
   prawn-rails
+  pry-byebug
   pry-rails
   puma
   rails (~> 5.2.2)


### PR DESCRIPTION
Side effect: no need to claim `byebug` individually
