### PR TITLE
764 add time field to distribution

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -51,10 +51,10 @@ class Distribution < ApplicationRecord
   delegate :name, to: :partner, prefix: true
 
   def distributed_at
-    if is_midnight(self.issued_at)
-      self.issued_at.strftime("%B %-d %Y")
+    if is_midnight(issued_at)
+      issued_at.strftime("%B %-d %Y")
     else
-      self.issued_at.to_s(:distribution_date_time)
+      issued_at.to_s(:distribution_date_time)
     end
   end
 

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -1,3 +1,5 @@
+require 'time_util'
+
 # == Schema Information
 #
 # Table name: distributions
@@ -49,7 +51,11 @@ class Distribution < ApplicationRecord
   delegate :name, to: :partner, prefix: true
 
   def distributed_at
-    issued_at.strftime("%B %-d %Y")
+    if is_midnight(self.issued_at)
+      self.issued_at.strftime("%B %-d %Y")
+    else
+      self.issued_at.to_s(:distribution_date_time)
+    end
   end
 
   def combine_duplicates

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -28,7 +28,7 @@
       label: "Partner",
       error: "Which partner is this distribution going to?" %>
 
-      <%= f.input :issued_at, as: :datetime, minute_step: 15, label: "Distribution date" %>
+      <%= f.input :issued_at, as: :datetime, ampm: true, minute_step: 15, label: "Distribution date" %>
       <%= f.input :agency_rep, label: "Agency representative" %>
 
     <%= render partial: "storage_locations/source", object: f %>

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -24,15 +24,15 @@
   <%= simple_form_for @distribution, html: { class: "storage-location-required" } do |f| %>
 
     <%= f.association :partner,
-      collection: current_organization.partners,    
+      collection: current_organization.partners,
       label: "Partner",
       error: "Which partner is this distribution going to?" %>
 
-      <%= f.input :issued_at, as: :date, label: "Distribution date" %>
+      <%= f.input :issued_at, as: :datetime, minute_step: 15, label: "Distribution date" %>
       <%= f.input :agency_rep, label: "Agency representative" %>
 
     <%= render partial: "storage_locations/source", object: f %>
-    
+
     <%= f.input :comment, label: "Comment" %>
 
 

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -4,4 +4,4 @@
 #
 # Usage: @distribution.issued_at.to_s(:distribution_date_time)
 #
-Time::DATE_FORMATS[:distribution_date_time] = "%b %-d, %Y %-l:%M%P"
+Time::DATE_FORMATS[:distribution_date_time] = "%B %-d %Y %-l:%M%P"

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,7 @@
+# Custom time format key to display Distribution issued_at time where
+# we're storing date & time but ignoring the timezone. So use this
+# format to NOT show the time zone.
+#
+# Usage: @distribution.issued_at.to_s(:distribution_date_time)
+#
+Time::DATE_FORMATS[:distribution_date_time] = "%b %-d, %Y %-l:%M%P"

--- a/lib/time_util.rb
+++ b/lib/time_util.rb
@@ -1,0 +1,3 @@
+def is_midnight(time)
+  time == time.beginning_of_day
+end

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -72,10 +72,14 @@ RSpec.describe Distribution, type: :model do
     let(:donation) { create(:donation) }
 
     describe "#distributed_at" do
-      it "displays either the explicit distributed_at date, or falls-through to issued_at" do
-        two_days_ago = 2.days.ago
+      it "displays explicit issued_at date" do
+        two_days_ago = 2.days.ago.midnight
         expect(create(:distribution, issued_at: two_days_ago).distributed_at).to eq(two_days_ago.strftime("%B %-d %Y"))
-        expect(create(:distribution).distributed_at).to eq(Time.zone.now.strftime("%B %-d %Y"))
+      end
+
+      it "shows the hour and minutes if it has been provided" do
+        distribution.issued_at = Time.parse("2014-03-01 14:30:00 UTC")
+        expect(distribution.distributed_at).to eq("March 1 2014 2:30pm")
       end
     end
 

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Distribution, type: :model do
       end
 
       it "shows the hour and minutes if it has been provided" do
-        distribution.issued_at = Time.parse("2014-03-01 14:30:00 UTC")
+        distribution.issued_at = Time.zone.parse("2014-03-01 14:30:00 UTC")
         expect(distribution.distributed_at).to eq("March 1 2014 2:30pm")
       end
     end


### PR DESCRIPTION
Resolves #764

### Description
- Designed a new time format
- Added an hours and minutes field for issued_at, with minutes snapped to the quarter hour
- Added logic for old issued_at datetimes that did not include a time to display without the time.
- New entries that include a time will display the time along with the date"

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- I ran rspec tests on the method, the model, and the entire application. All passed.
