### PR TITLE
Add endpoint for processing family requests

### DIFF
--- a/app/controllers/api/v1/family_requests_controller.rb
+++ b/app/controllers/api/v1/family_requests_controller.rb
@@ -1,0 +1,31 @@
+class API::V1::FamilyRequestsController < ApplicationController
+  skip_before_action :verify_authenticity_token
+  skip_before_action :authenticate_user!
+  skip_before_action :authorize_user
+  respond_to :json
+
+  def create
+    return head :forbidden unless api_key_valid?
+
+    partner_request = parse_request
+    if partner_request.save
+      render json: partner_request.family_request_reply, status: :created
+    else
+      render json: partner_request.errors, status: :bad_request
+    end
+  end
+
+  private
+
+  def api_key_valid?
+    request.headers["X-Api-Key"] == ENV["PARTNER_KEY"]
+  end
+
+  def parse_request
+    Request.parse_family_request(request_params)
+  end
+
+  def request_params
+    JSON.parse(request.body.read)
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -103,4 +103,8 @@ class Item < ApplicationRecord
       canonical_item.name
     ]
   end
+
+  def default_quantity
+    50
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -105,6 +105,7 @@ class Item < ApplicationRecord
   end
 
   def default_quantity
+    # TODO: actual logic for calculating and letting users configure this calculation
     50
   end
 end

--- a/app/models/item_request.rb
+++ b/app/models/item_request.rb
@@ -1,0 +1,4 @@
+class ItemRequest < ApplicationRecord
+  belongs_to :request
+  belongs_to :item
+end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -17,6 +17,7 @@ class Request < ApplicationRecord
   belongs_to :partner
   belongs_to :organization
   belongs_to :distribution, optional: true
+  has_many :item_requests, dependent: :destroy
 
   scope :active, -> { where(status: "Active") }
 
@@ -26,5 +27,33 @@ class Request < ApplicationRecord
     @items_hash ||= request_items.collect do |key, _|
       [key, Item.order("created_at ASC").find_by(partner_key: key)]
     end.to_h
+  end
+
+  def family_request_reply
+    {
+      "organization_id": organization_id,
+      "partner_id": partner_id,
+      "requested_items": item_requests.map do |ir|
+        {
+          "item_id": ir.item_id,
+          "count": ir.quantity
+        }
+      end
+    }
+  end
+
+  def self.parse_family_request(family_request)
+    request = Request.new(organization_id: family_request['organization_id'], partner_id: family_request['partner_id'])
+    request.item_requests = []
+
+    family_request['requested_items'].each do |item|
+      item_request = ItemRequest.new
+      item_request.item = Item.find(item['item_id'])
+
+      item_request.quantity = item_request.item.default_quantity * item['count']
+      request.item_requests << item_request
+    end
+
+    request
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -50,7 +50,7 @@ class Request < ApplicationRecord
       item_request = ItemRequest.new
       item_request.item = Item.find(item['item_id'])
 
-      item_request.quantity = item_request.item.default_quantity * item['count']
+      item_request.quantity = item_request.item.default_quantity * item['person_count']
       request.item_requests << item_request
     end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -36,7 +36,8 @@ class Request < ApplicationRecord
       "requested_items": item_requests.map do |ir|
         {
           "item_id": ir.item_id,
-          "count": ir.quantity
+          "count": ir.quantity,
+          "item_name": ir.item.name
         }
       end
     }
@@ -49,7 +50,6 @@ class Request < ApplicationRecord
     family_request['requested_items'].each do |item|
       item_request = ItemRequest.new
       item_request.item = Item.find(item['item_id'])
-
       item_request.quantity = item_request.item.default_quantity * item['person_count']
       request.item_requests << item_request
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :partner_requests, only: %i(create show)
       resources :partner_approvals, only: :create
+      resources :family_requests, only: %i(create show)
     end
   end
 

--- a/db/migrate/20190331205131_create_item_requests.rb
+++ b/db/migrate/20190331205131_create_item_requests.rb
@@ -1,0 +1,11 @@
+class CreateItemRequests < ActiveRecord::Migration[5.2]
+  def change
+    create_table :item_requests do |t|
+      t.references :request, foreign_key: true
+      t.references :item, foreign_key: true
+      t.integer :quantity
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_31_220545) do
+ActiveRecord::Schema.define(version: 2019_04_07_203351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 2019_03_31_220545) do
     t.index ["organization_id"], name: "index_barcode_items_on_organization_id"
   end
 
-  create_table "canonical_items", force: :cascade do |t|
+  create_table "base_items", force: :cascade do |t|
     t.string "name"
     t.string "category"
     t.integer "barcode_count"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_19_080442) do
+ActiveRecord::Schema.define(version: 2019_03_31_205131) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -184,6 +184,16 @@ ActiveRecord::Schema.define(version: 2019_02_19_080442) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "item_requests", force: :cascade do |t|
+    t.bigint "request_id"
+    t.bigint "item_id"
+    t.integer "quantity"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_item_requests_on_item_id"
+    t.index ["request_id"], name: "index_item_requests_on_request_id"
+  end
+
   create_table "items", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "category"
@@ -339,6 +349,8 @@ ActiveRecord::Schema.define(version: 2019_02_19_080442) do
   add_foreign_key "distributions", "partners"
   add_foreign_key "distributions", "storage_locations"
   add_foreign_key "donations", "storage_locations"
+  add_foreign_key "item_requests", "items"
+  add_foreign_key "item_requests", "requests"
   add_foreign_key "requests", "organizations"
   add_foreign_key "requests", "partners"
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -110,6 +110,7 @@ RSpec.feature "Dashboard", type: :feature do
 
   scenario "getting started guide works as expected", js: true do
     # When dashboard loads, ensure that we are on step 1 (Partner Agencies)
+    Partner.delete_all
     visit @url_prefix + "/dashboard"
     expect(page).to have_selector("#getting-started-guide", count: 1)
     expect(page).to have_selector("#org-stats-call-to-action-partners", count: 1)
@@ -118,7 +119,7 @@ RSpec.feature "Dashboard", type: :feature do
     expect(page).to have_selector("#org-stats-call-to-action-inventory", count: 0)
 
     # After we create a partner, ensure that we are on step 2 (Storage Locations)
-    create(:partner)
+    @partner = create(:partner, organization: @organization)
     visit @url_prefix + "/dashboard"
     expect(page).to have_selector("#getting-started-guide", count: 1)
     expect(page).to have_selector("#org-stats-call-to-action-partners", count: 0)

--- a/spec/features/partner_spec.rb
+++ b/spec/features/partner_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Partner management", type: :feature do
       visit url_prefix + "/partners"
     end
     scenario "the partner agency names are in alphabetical order" do
-      expect(page).to have_css("table tr", count: 4)
+      expect(page).to have_css("table tr", count: 5)
       expect(page.find(:xpath, "//table/tbody/tr[1]/td[1]")).to have_content(@first.name)
       expect(page.find(:xpath, "//table/tbody/tr[3]/td[1]")).to have_content(@third.name)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -141,8 +141,9 @@ RSpec.configure do |config|
     __start_db_cleaning_with_log
 
     # prepare a default @organization and @user to always be available for testing
-    Rails.logger.info "\n\n-~=> Creating DEFAULT organization"
+    Rails.logger.info "\n\n-~=> Creating DEFAULT organization & partner"
     @organization = create(:organization, name: "DEFAULT")
+    @partner = create(:partner, organization: @organization)
     Rails.logger.info "\n\n-~=> Creating DEFAULT admins & user"
     @organization_admin = create(:organization_admin, name: "DEFAULT ORG ADMIN", organization: @organization)
     @user = create(:user, organization: @organization, name: "DEFAULT USER")

--- a/spec/requests/api/v1/api_v1_family_requests_spec.rb
+++ b/spec/requests/api/v1/api_v1_family_requests_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
         headers = {
           "ACCEPT" => "application/json",
           "Content-Type" => "application/json",
-          "X-Api-Key" => "some-fake-key",
+          "X-Api-Key" => "some-fake-key"
         }
 
         params = {

--- a/spec/requests/api/v1/api_v1_family_requests_spec.rb
+++ b/spec/requests/api/v1/api_v1_family_requests_spec.rb
@@ -6,9 +6,12 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
     @partner = create(:partner, organization: @organization)
   end
 
+  after :all do
+    @partner.destroy!
+    @organization.destroy!
+  end
+
   describe "POST /api/v1/family_requests" do
-    # let!(:organization) { @organization }
-    # let!(:partner) { @organization }
     let(:items) { Item.all.sample(3) }
     let(:request_items) do
       items.collect do |item|
@@ -125,7 +128,7 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
     context "without a valid API key" do
       headers = {
         "ACCEPT" => "application/json",
-        "X-Api-Key" => "blarg"
+        "X-Api-Key" => "some-invalid-key"
       }
 
       before { get api_v1_partner_request_path(organization.id), headers: headers }

--- a/spec/requests/api/v1/api_v1_family_requests_spec.rb
+++ b/spec/requests/api/v1/api_v1_family_requests_spec.rb
@@ -1,16 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe "API::V1::FamilyRequests", type: :request do
-  before :all do
-    @organization = create(:organization)
-    @partner = create(:partner, organization: @organization)
-  end
-
-  after :all do
-    @partner.destroy!
-    @organization.destroy!
-  end
-
   describe "POST /api/v1/family_requests" do
     let(:items) { Item.all.sample(3) }
     let(:request_items) do
@@ -93,7 +83,7 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
   end
 
   describe "GET /api/v1/family_request/:id" do
-    let(:organization) { create(:organization) }
+    #let(:organization) { create(:organization) }
 
     context "with a valid API key" do
       context 'with a valid organization id' do
@@ -101,14 +91,14 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
           "ACCEPT" => "application/json",
           "X-Api-Key" => ENV["PARTNER_KEY"]
         }
-        before { get api_v1_partner_request_path(organization.id), headers: headers }
+        before { get api_v1_partner_request_path(@organization.id), headers: headers }
 
         it "returns HTTP success" do
           expect(response).to be_successful
         end
 
         it "returns a body with valid items" do
-          expect(JSON.parse(response.body)).to match_array(organization.valid_items)
+          expect(JSON.parse(response.body)).to match_array(@organization.valid_items)
         end
       end
 
@@ -131,7 +121,7 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
         "X-Api-Key" => "some-invalid-key"
       }
 
-      before { get api_v1_partner_request_path(organization.id), headers: headers }
+      before { get api_v1_partner_request_path(@organization.id), headers: headers }
 
       it "returns HTTP forbidden" do
         expect(response).to have_http_status(:forbidden)

--- a/spec/requests/api/v1/api_v1_family_requests_spec.rb
+++ b/spec/requests/api/v1/api_v1_family_requests_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
       Item.all.pluck(:id).sample(3).collect do |k|
         {
           "item_id" => k,
-          "count" => rand(3..10)
+          "person_count" => rand(3..10)
         }
       end
     end

--- a/spec/requests/api/v1/api_v1_family_requests_spec.rb
+++ b/spec/requests/api/v1/api_v1_family_requests_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
         expected_items = request_items.map do |item|
           {
             'item_id' => item['item_id'],
-            'count' => item['count'] * 50
+            'count' => item['person_count'] * 50
           }
         end
         expect(returned_body['requested_items']).to eq(expected_items)

--- a/spec/requests/api/v1/api_v1_family_requests_spec.rb
+++ b/spec/requests/api/v1/api_v1_family_requests_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+RSpec.describe "API::V1::FamilyRequests", type: :request do
+  describe "POST /api/v1/family_requests" do
+    let!(:organization) { create(:organization) }
+    let!(:partner) { create(:partner, organization: organization) }
+    let(:request_items) do
+      Item.all.pluck(:id).sample(3).collect do |k|
+        {
+          "item_id" => k,
+          "count" => rand(3..10)
+        }
+      end
+    end
+
+    context "with a valid API key" do
+      subject do
+        headers = {
+          "ACCEPT" => "application/json",
+          "Content-Type" => "application/json",
+          "X-Api-Key" => ENV["PARTNER_KEY"]
+        }
+
+        params = {
+          organization_id: organization.id,
+          partner_id: partner.id,
+          comments: "please and thank you",
+          requested_items: request_items
+        }.to_json
+
+        post api_v1_family_requests_path, params: params, headers: headers
+      end
+
+      it "returns HTTP created" do
+        subject
+        expect(response).to have_http_status(:created)
+      end
+
+      it "creates a new Request" do
+        expect { subject }.to change { Request.count }.by(1)
+      end
+
+      it "returns the request actually created" do
+        subject
+        returned_body = JSON.parse(response.body)
+        expected_items = request_items.map do |item|
+          {
+            'item_id' => item['item_id'],
+            'count' => item['count'] * 50
+          }
+        end
+        expect(returned_body['requested_items']).to eq(expected_items)
+      end
+    end
+
+    context "without a valid API key" do
+      before do
+        headers = {
+          "ACCEPT" => "application/json",
+          "X-Api-Key" => "blarg"
+        }
+
+        params = {
+          request: {
+            organization_id: organization.id,
+            partner_id: partner.id,
+            comments: "please and thank you",
+            request_items: random_keys(3).collect { |k| [k, rand(3..10)] }.to_h
+          }
+        }
+
+        post api_v1_partner_requests_path, params: params, headers: headers
+      end
+
+      it "returns HTTP forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "GET /api/v1/family_request/:id" do
+    let(:organization) { create(:organization) }
+
+    context "with a valid API key" do
+      context 'with a valid organization id' do
+        headers = {
+          "ACCEPT" => "application/json",
+          "X-Api-Key" => ENV["PARTNER_KEY"]
+        }
+        before { get api_v1_partner_request_path(organization.id), headers: headers }
+
+        it "returns HTTP success" do
+          expect(response).to be_successful
+        end
+
+        it "returns a body with valid items" do
+          expect(JSON.parse(response.body)).to match_array(organization.valid_items)
+        end
+      end
+
+      context "without a valid organization id" do
+        headers = {
+          "ACCEPT" => "application/json",
+          "X-Api-Key" => ENV["PARTNER_KEY"]
+        }
+        before { get api_v1_partner_request_path('foo'), headers: headers }
+
+        it "returns HTTP bad request" do
+          expect(response).to have_http_status(:bad_request)
+        end
+      end
+    end
+
+    context "without a valid API key" do
+      headers = {
+        "ACCEPT" => "application/json",
+        "X-Api-Key" => "blarg"
+      }
+
+      before { get api_v1_partner_request_path(organization.id), headers: headers }
+
+      it "returns HTTP forbidden" do
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION


<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Address #777 <!--fill issue number-->

### Description

The partner app would like to be able to send requests that are expressed in terms of item ID and persons needing that item. This adds the API endpoint for receiving such requests.

*TODO*: Add actual logic for calculating quantity per person. Currently method just returns `50`.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

* rspec specs
* manually calling API routes with cURL

Manual testing steps:

1. Make `sample_data.json` - see cat of file below.

``` bash
$ PARTNER_KEY=foo bundle exec rails s
# in a different shell:
$ cat sample_data.json
{
    "organization_id": 1,
    "partner_id": 1,
    "requested_items": [
        {
            "item_id": 75,
            "person_count": 3
        },
        {
            "item_id": 34,
            "person_count": 3
        }
    ]
}
$ curl -H "X-Api-Key: foo" -H "Accept: application/json" -H "Content-Type: application/json" -d@sample_request.json localhost:3030/api/v1/family_requests -v
```

It should return a 201: Created with a body like this (note that person count has been replaced with actual counts:

``` json
{
    "organization_id": 1,
    "partner_id": 1,
    "requested_items": [
        {
            "item_id": 75,
            "count": 150
        },
        {
            "item_id": 34,
            "count": 150
        }
    ]
}
```
