### PR TITLE
Adds migration to fix polymorphic association in Barcodes

### DIFF
--- a/db/migrate/20190407203351_rename_canonical_item_to_base_item_in_barcodeable.rb
+++ b/db/migrate/20190407203351_rename_canonical_item_to_base_item_in_barcodeable.rb
@@ -1,0 +1,12 @@
+class BarcodeItem < ApplicationRecord
+end
+
+class RenameCanonicalItemToBaseItemInBarcodeable < ActiveRecord::Migration[5.2]
+  def up
+    BarcodeItem.where(barcodeable_type: "CanonicalItem").update_all(barcodeable_type: "BaseItem")
+  end
+
+  def down
+    BarcodeItem.where(barcodeable_type: "BaseItem").update_all(barcodeable_type: "CanonicalItem")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_31_231244) do
+ActiveRecord::Schema.define(version: 2019_04_07_203351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We had an issue where the `barcodeable` polymorphic association in `BarcodeItem` was breaking because it wasn't renamed in #762 (I overlooked that, oops!)

This fixes it.

Verify by:
 1. Log in as Site Admin (`superadmin@example.com`)
 2. Go to Admin -> BarcodeItems#index
 3. Pre-migration, it throws an error / post-migration it should behave normally 