### PR TITLE
[WIP] 791 replace sidekiq with delayed job

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -24,8 +24,6 @@ require "capistrano/rails/migrations"
 require "capistrano/puma"
 require "capistrano/rails/console"
 require "capistrano/scm/git"
-require 'capistrano/sidekiq'
-require 'capistrano/sidekiq/monit'
 
 install_plugin Capistrano::SCM::Git
 install_plugin Capistrano::Puma # Default puma tasks

--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "bugsnag"
 gem "chartkick"
 gem "cocoon"
 gem "coffee-rails"
-gem 'delayed_job', '~> 4.1.5'
+gem 'delayed_job_active_record', '~> 4.1.3'
 gem "devise"
 gem "devise_invitable"
 gem "dotenv-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem "prawn-rails"
 gem "puma"
 gem "rails", "~> 5.2.2"
 gem "sass-rails"
-gem "sidekiq"
 gem "simple_form"
 gem "skylight"
 gem "sprockets", "~> 3.7.2"
@@ -69,7 +68,6 @@ group :development do
   gem "capistrano-bundler"
   gem "capistrano3-puma"
   gem "capistrano-rails-console", require: false
-  gem 'capistrano-sidekiq'
   gem "listen", "~> 3.1.5"
   gem "rails-erd"
   gem "spring"

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "bugsnag"
 gem "chartkick"
 gem "cocoon"
 gem "coffee-rails"
+gem 'delayed_job', '~> 4.1.5'
 gem "devise"
 gem "devise_invitable"
 gem "dotenv-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,9 @@ GEM
     debug_inspector (0.0.3)
     delayed_job (4.1.5)
       activesupport (>= 3.0, < 5.3)
+    delayed_job_active_record (4.1.3)
+      activerecord (>= 3.0, < 5.3)
+      delayed_job (>= 3.0, < 5)
     devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -488,7 +491,7 @@ DEPENDENCIES
   cocoon
   coffee-rails
   database_cleaner
-  delayed_job (~> 4.1.5)
+  delayed_job_active_record (~> 4.1.3)
   devise
   devise_invitable
   dotenv-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     crass (1.0.4)
     database_cleaner (1.7.0)
     debug_inspector (0.0.3)
+    delayed_job (4.1.5)
+      activesupport (>= 3.0, < 5.3)
     devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -486,6 +488,7 @@ DEPENDENCIES
   cocoon
   coffee-rails
   database_cleaner
+  delayed_job (~> 4.1.5)
   devise
   devise_invitable
   dotenv-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,9 +97,6 @@ GEM
     capistrano-rvm (0.1.2)
       capistrano (~> 3.0)
       sshkit (~> 1.2)
-    capistrano-sidekiq (1.0.2)
-      capistrano (>= 3.9.0)
-      sidekiq (>= 3.4)
     capistrano3-puma (3.1.1)
       capistrano (~> 3.7)
       capistrano-bundler
@@ -133,7 +130,6 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.4)
-    connection_pool (2.2.2)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
@@ -336,7 +332,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    redis (4.1.0)
     ref (2.0.0)
     regexp_parser (1.3.0)
     responders (2.4.0)
@@ -396,11 +391,6 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
     shellany (0.0.1)
-    sidekiq (5.2.5)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (>= 1.5.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
     simple_form (4.1.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -482,7 +472,6 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rails-console
   capistrano-rvm
-  capistrano-sidekiq
   capistrano3-puma
   capybara (~> 3.12)
   capybara-screenshot
@@ -526,7 +515,6 @@ DEPENDENCIES
   rubocop
   sass-rails
   selenium-webdriver
-  sidekiq
   simple_form
   skylight
   spring

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -140,7 +140,7 @@ class DistributionsController < ApplicationController
   end
 
   def send_notification(org, dist, subject: 'Your Distribution')
-    PartnerMailerJob.perform_async(org, dist, subject) if Flipper.enabled?(:email_active)
+    PartnerMailerJob.perform_later(org, dist, subject) if Flipper.enabled?(:email_active)
   end
 
   def distribution_params

--- a/app/jobs/partner_mailer_job.rb
+++ b/app/jobs/partner_mailer_job.rb
@@ -1,5 +1,5 @@
-class PartnerMailerJob
-  include Sidekiq::Worker
+class PartnerMailerJob < ApplicationJob
+  queue_as :default
 
   def perform(org_id, dist_id, subject)
     current_organization = Organization.find(org_id)

--- a/app/jobs/update_diaper_partner_job.rb
+++ b/app/jobs/update_diaper_partner_job.rb
@@ -1,6 +1,6 @@
-class UpdateDiaperPartnerJob
-  include Sidekiq::Worker
+class UpdateDiaperPartnerJob < ApplicationJob
   include DiaperPartnerClient
+  queue_as :default
 
   def perform(partner_id)
     @partner = Partner.find(partner_id)

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -47,6 +47,6 @@ class Partner < ApplicationRecord
   end
 
   def register_on_partnerbase
-    UpdateDiaperPartnerJob.perform_async(id)
+    UpdateDiaperPartnerJob.perform_later(id)
   end
 end

--- a/bin/delayed_job
+++ b/bin/delayed_job
@@ -1,0 +1,5 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'config', 'environment'))
+require 'delayed/command'
+Delayed::Command.new(ARGV).daemonize

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module Diaper
       Devise::RegistrationsController.layout "application"
     end
 
-    config.active_job.queue_adapter = :sidekiq
+    config.active_job.queue_adapter = :delayed_job
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,7 +23,6 @@ set :ssh_options,     forward_agent: true, user: fetch(:user), keys: %w(~/.ssh/i
 set :puma_preload_app, true
 set :puma_worker_timeout, nil
 set :puma_init_active_record, true # Change to false when not using ActiveRecord
-set :sidekiq_processes, 2
 
 ## Defaults:
 # set :scm,           :git
@@ -64,6 +63,7 @@ namespace :deploy do
   task :restart do
     on roles(:app), in: :sequence, wait: 5 do
       invoke "puma:restart"
+      invoke 'delayed_job:restart'
     end
   end
 

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -1,0 +1,1 @@
+Delayed::Worker.delay_jobs = !Rails.env.test?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,16 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
 
-  require 'sidekiq/web'
-  if Rails.env.production?
-    Sidekiq::Web.use Rack::Auth::Basic do |username, password|
-      ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(username), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_USERNAME"])) &
-        ActiveSupport::SecurityUtils.secure_compare(::Digest::SHA256.hexdigest(password), ::Digest::SHA256.hexdigest(ENV["SIDEKIQ_PASSWORD"]))
-    end
-  end
-  mount Sidekiq::Web => '/sidekiq'
-  Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
-
   flipper_app = Flipper::UI.app(Flipper.instance) do |builder|
     builder.use Rack::Auth::Basic do |username, password|
       username == ENV["FLIPPER_USERNAME"] && password == ENV["FLIPPER_PASSWORD"]

--- a/db/migrate/20190409022648_create_delayed_jobs.rb
+++ b/db/migrate/20190409022648_create_delayed_jobs.rb
@@ -1,0 +1,22 @@
+class CreateDelayedJobs < ActiveRecord::Migration[5.2]
+  def self.up
+    create_table :delayed_jobs, force: true do |table|
+      table.integer :priority, default: 0, null: false # Allows some jobs to jump to the front of the queue
+      table.integer :attempts, default: 0, null: false # Provides for retries, but still fail eventually.
+      table.text :handler,                 null: false # YAML-encoded string of the object that will do work
+      table.text :last_error                           # reason for last failure (See Note below)
+      table.datetime :run_at                           # When to run. Could be Time.zone.now for immediately, or sometime in the future.
+      table.datetime :locked_at                        # Set when a client is working on this object
+      table.datetime :failed_at                        # Set when all retries have failed (actually, by default, the record is deleted instead)
+      table.string :locked_by                          # Who is working on this object (if locked)
+      table.string :queue                              # The name of the queue this job is in
+      table.timestamps null: true
+    end
+
+    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+  end
+
+  def self.down
+    drop_table :delayed_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_07_203351) do
+ActiveRecord::Schema.define(version: 2019_04_09_022648) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,6 +92,21 @@ ActiveRecord::Schema.define(version: 2019_04_07_203351) do
     t.string "size"
     t.integer "item_count"
     t.string "partner_key"
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "diaper_drive_participants", id: :serial, force: :cascade do |t|

--- a/lib/capistrano/tasks/delayed_job.rake
+++ b/lib/capistrano/tasks/delayed_job.rake
@@ -1,0 +1,46 @@
+# https://github.com/collectiveidea/delayed_job/wiki/Delayed-Job-tasks-for-Capistrano-3
+
+namespace :delayed_job do
+
+  def args
+    fetch(:delayed_job_args, "")
+  end
+
+  def delayed_job_roles
+    fetch(:delayed_job_server_role, :app)
+  end
+
+  desc 'Stop the delayed_job process'
+  task :stop do
+    on roles(delayed_job_roles) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :bundle, :exec, :'bin/delayed_job', :stop
+        end
+      end
+    end
+  end
+
+  desc 'Start the delayed_job process'
+  task :start do
+    on roles(delayed_job_roles) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :bundle, :exec, :'bin/delayed_job', args, :start
+        end
+      end
+    end
+  end
+
+  desc 'Restart the delayed_job process'
+  task :restart do
+    on roles(delayed_job_roles) do
+      within release_path do
+        with rails_env: fetch(:rails_env) do
+          execute :bundle, :exec, :'bin/delayed_job', args, :restart
+        end
+      end
+    end
+  end
+
+end

--- a/spec/features/distribution_spec.rb
+++ b/spec/features/distribution_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature "Distributions", type: :feature do
 
       expect do
         click_button "Save", match: :first
-      end.to change { PartnerMailerJob.jobs.size }.by(1)
+      end.to change { Delayed::Job.count }.by(1)
 
       expect(page).to have_content "Distributions"
       expect(page.find(".alert-info")).to have_content "reated"

--- a/spec/jobs/update_diaper_partner_job_spec.rb
+++ b/spec/jobs/update_diaper_partner_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
       it "sets the partner status to pending" do
         with_features email_active: true do
           expect do
-            UpdateDiaperPartnerJob.perform_now(@partner.id)
+            UpdateDiaperPartnerJob.perform_later(@partner.id)
             @partner.reload
           end.to change { @partner.status }.to("Pending")
         end

--- a/spec/jobs/update_diaper_partner_job_spec.rb
+++ b/spec/jobs/update_diaper_partner_job_spec.rb
@@ -9,12 +9,10 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
 
       it "sets the partner status to pending" do
         with_features email_active: true do
-          Sidekiq::Testing.inline! do
-            expect do
-              UpdateDiaperPartnerJob.perform_async(@partner.id)
-              @partner.reload
-            end.to change { @partner.status }.to("Pending")
-          end
+          expect do
+            UpdateDiaperPartnerJob.perform_now(@partner.id)
+            @partner.reload
+          end.to change { @partner.status }.to("Pending")
         end
       end
     end
@@ -28,24 +26,20 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
 
       it "sets the partner status to error" do
         with_features email_active: true do
-          Sidekiq::Testing.inline! do
-            expect do
-              UpdateDiaperPartnerJob.perform_async(@partner.id)
-              @partner.reload
-            end.to change { @partner.status }.to("Error")
-          end
+          expect do
+            UpdateDiaperPartnerJob.perform_now(@partner.id)
+            @partner.reload
+          end.to change { @partner.status }.to("Error")
         end
       end
       it "posts via DiaperPartnerClient" do
         with_features email_active: true do
-          Sidekiq::Testing.inline! do
-            partner = create(:partner)
-            allow(Flipper).to receive(:enabled?) { true }
+          partner = create(:partner)
+          allow(Flipper).to receive(:enabled?) { true }
 
-            expect(DiaperPartnerClient).to receive(:post)
+          expect(DiaperPartnerClient).to receive(:post)
 
-            UpdateDiaperPartnerJob.perform_async(partner.id)
-          end
+          UpdateDiaperPartnerJob.perform_now(partner.id)
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,7 +9,6 @@ require "capybara/rails"
 require "capybara/rspec"
 require "capybara-screenshot/rspec"
 require "pry"
-Sidekiq::Testing.fake! # fake is the default mode
 
 # Add additional requires below this line. Rails is not loaded until this point!
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,7 +9,6 @@ require "capybara/rails"
 require "capybara/rspec"
 require "capybara-screenshot/rspec"
 require "pry"
-require 'sidekiq/testing'
 Sidekiq::Testing.fake! # fake is the default mode
 
 # Add additional requires below this line. Rails is not loaded until this point!
@@ -99,6 +98,7 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :feature
+  config.include ActiveJob::TestHelper
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false

--- a/spec/support/delayed_job_adapter.rb
+++ b/spec/support/delayed_job_adapter.rb
@@ -1,0 +1,23 @@
+# https://til.hashrocket.com/posts/chdlp2pbwb-delayed-job-queue-adapter-in-rspec-with-rails-51
+
+class ActiveJob::QueueAdapters::DelayedJobAdapter
+  class EnqueuedJobs
+    def clear
+      Delayed::Job.where(failed_at:nil).map &:destroy
+    end
+  end
+
+  class PerformedJobs
+    def clear
+      Delayed::Job.where.not(failed_at:nil).map &:destroy
+    end
+  end
+
+  def enqueued_jobs
+    EnqueuedJobs.new
+  end
+
+  def performed_jobs
+    PerformedJobs.new
+  end
+end


### PR DESCRIPTION
Resolves #791 

### Description
Here, we are replacing Sidekiq with Delayed Job for background processing. 
This change should reduce the dependency footprint and allow for a more straightforward setup.
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

- Removing Sidekiq gem
- Adding delayed_job_active_record gem

Include anything else we should know about. -->

### Type of change

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

- Testing by automated testing. 
- I have yet to validate it locally. 
