### PR TITLE
[WIP] use the fakeredis in dev and test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development, :test do
   gem "terminal-notifier"
   gem "timecop"
   gem "rubocop"
+  gem "fakeredis", require: "fakeredis/rspec"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,8 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
+    fakeredis (0.7.0)
+      redis (>= 3.2, < 5.0)
     ffi (1.9.25)
     flipper (0.16.0)
     flipper-active_record (0.16.0)
@@ -490,6 +492,7 @@ DEPENDENCIES
   devise_invitable
   dotenv-rails
   factory_bot_rails
+  fakeredis
   flipper
   flipper-active_record
   flipper-ui


### PR DESCRIPTION
Resolves #791

### Description
This is an alternate solution to swapping out Sidekiq for Delayed Job where we just the `fakeredis` gem as a stand-in for Sidekiq's Redis dependency. 

Thank you to the person who suggested this as a solution. _tips hat_ 

### Type of change

* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?

- This has been tested by stopping my local redis server and running tests where Sidekiq is required. 
- Tests have also been run on CI

### Screenshots

<img width="1389" alt="Screen Shot 2019-04-11 at 9 11 58 PM" src="https://user-images.githubusercontent.com/7292/56005464-7a6c0b00-5c9e-11e9-9cb6-ddc227d3d26d.png">
