### PR TITLE
Fix rubocop issue in api_v1_family_requests_spec

### DIFF
--- a/spec/requests/api/v1/api_v1_family_requests_spec.rb
+++ b/spec/requests/api/v1/api_v1_family_requests_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
   end
 
   describe "GET /api/v1/family_request/:id" do
-    #let(:organization) { create(:organization) }
+    # let(:organization) { create(:organization) }
 
     context "with a valid API key" do
       context 'with a valid organization id' do
@@ -129,5 +129,3 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
     end
   end
 end
-
-


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->


### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
It just fix:
```
Offenses:
spec/requests/api/v1/api_v1_family_requests_spec.rb:86:5: C: Layout/LeadingCommentSpace: Missing space after #.
    #let(:organization) { create(:organization) }
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
230 files inspected, 1 offense detected
The command "bundle exec rubocop" exited with 1.
```

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

