### PR TITLE
Change to webdrivers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,12 +83,10 @@ group :test do
   gem "database_cleaner"
   gem "factory_bot_rails"
   gem "launchy"
-  gem "chromedriver-helper"
-  gem "selenium-webdriver"
+  gem 'webdrivers', '~> 3.0'
   gem "rails-controller-testing"
   gem "webmock", "~> 3.5"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", "~> 1.2", platforms: %i(mingw mswin x64_mingw jruby)
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,8 +59,6 @@ GEM
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 13.0)
     api-auth (2.3.1)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.4.3)
@@ -119,9 +117,6 @@ GEM
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     choice (0.2.0)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     climate_control (0.2.0)
     cocoon (1.2.12)
     coderay (1.1.2)
@@ -207,7 +202,6 @@ GEM
     image_processing (1.7.1)
       mini_magick (~> 4.0)
       ruby-vips (>= 2.0.13, < 3)
-    io-like (0.3.0)
     jaro_winkler (1.5.1)
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
@@ -249,6 +243,7 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (5.0.2)
+    net_http_ssl_fix (0.0.10)
     newrelic_rpm (5.6.0.349)
     nio4r (2.3.1)
     nokogiri (1.10.1)
@@ -448,6 +443,11 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (3.7.2)
+      net_http_ssl_fix
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     webmock (3.5.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -484,7 +484,6 @@ DEPENDENCIES
   capybara (~> 3.12)
   capybara-screenshot
   chartkick
-  chromedriver-helper
   cocoon
   coffee-rails
   database_cleaner
@@ -522,7 +521,6 @@ DEPENDENCIES
   rspec-rails (~> 3.8)
   rubocop
   sass-rails
-  selenium-webdriver
   sidekiq
   simple_form
   skylight
@@ -537,6 +535,7 @@ DEPENDENCIES
   tzinfo-data (~> 1.2)
   uglifier (>= 1.3.0)
   web-console
+  webdrivers (~> 3.0)
   webmock (~> 3.5)
   webpacker (~> 3.5)
   yajl-ruby

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,8 @@ require "capybara/rspec"
 require "capybara-screenshot/rspec"
 require "pry"
 require 'sidekiq/testing'
+require 'webdrivers'
+
 Sidekiq::Testing.fake! # fake is the default mode
 
 # Add additional requires below this line. Rails is not loaded until this point!

--- a/spec/support/webmock.rb
+++ b/spec/support/webmock.rb
@@ -1,2 +1,7 @@
 require "webmock/rspec"
-WebMock.disable_net_connect! allow_localhost: true
+allowed_sites = [
+  "https://chromedriver.storage.googleapis.com",
+  "https://github.com/mozilla/geckodriver/releases",
+  "https://selenium-release.storage.googleapis.com"
+]
+WebMock.disable_net_connect!(allow_localhost: true, allow: allowed_sites)


### PR DESCRIPTION
Resolves #759 

### Description
  The gem chromedriver-helper is out of support, so this pr change to gem [webdrivers](https://github.com/titusfortner/webdrivers)

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

RSpec test
