### PR TITLE
#789 - Replace literal date format string with DRY solution

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -52,7 +52,7 @@ class Distribution < ApplicationRecord
 
   def distributed_at
     if is_midnight(issued_at)
-      issued_at.strftime("%B %-d %Y")
+      issued_at.to_s(:distribution_date)
     else
       issued_at.to_s(:distribution_date_time)
     end

--- a/app/views/donations/edit.html.erb
+++ b/app/views/donations/edit.html.erb
@@ -9,8 +9,8 @@
       <i class="fa fa-dashboard"></i> Home
     <% end %>
     </li>
-    <li><%= link_to "Donations", (donations_path) %></li>  
-    <li class="active"> Editing <%= @donation.source %> on <%= @donation.created_at.strftime("%B %-d %Y") %></li>
+    <li><%= link_to "Donations", (donations_path) %></li>
+    <li class="active"> Editing <%= @donation.source %> on <%= @donation.created_at.to_s(:distribution_date) %></li>
   </ol>
 </section>
 

--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -10,7 +10,7 @@
     <% end %>
     </li>
     <li><%= link_to "Donations", (donations_path) %></li>
-    <li class="active"> <%= @donation.source %> on <%= @donation.created_at.strftime("%B %-d %Y") %></li>
+    <li class="active"> <%= @donation.source %> on <%= @donation.created_at.to_s(:distribution_date) %></li>
   </ol>
 </section>
 
@@ -19,7 +19,7 @@
   <div class="box">
     <div class="box-header with-border">
       <fieldset>
-        <p>This donation was started on <%= @donation.created_at.strftime("%B %-d %Y") %>:</p>
+        <p>This donation was started on <%= @donation.created_at.to_s(:distribution_date) %>:</p>
         <ul class="list-group">
           <li class="list-group-item">It was collected through: <%= @donation.source %></li>
           <li class="list-group-item">It was dropped off at: <%= @donation.donation_site_view %></li>

--- a/app/views/purchases/edit.html.erb
+++ b/app/views/purchases/edit.html.erb
@@ -10,7 +10,7 @@
     <% end %>
     </li>
     <li><%= link_to "Purchases", (purchases_path) %></li>
-    <li class="active"> Editing <%= @purchase.purchased_from_view %> on <%= @purchase.created_at.strftime("%B %-d %Y") %></li>
+    <li class="active"> Editing <%= @purchase.purchased_from_view %> on <%= @purchase.created_at.to_s(:distribution_date) %></li>
   </ol>
 </section>
 

--- a/app/views/purchases/show.html.erb
+++ b/app/views/purchases/show.html.erb
@@ -10,7 +10,7 @@
     <% end %>
     </li>
     <li><%= link_to "Purchases", (purchases_path) %></li>
-    <li class="active"> <%= @purchase.purchased_from_view %> on <%= @purchase.created_at.strftime("%B %-d %Y") %></li>
+    <li class="active"> <%= @purchase.purchased_from_view %> on <%= @purchase.created_at..to_s(:distribution_date) %></li>
   </ol>
 </section>
 
@@ -19,7 +19,7 @@
   <div class="box">
     <div class="box-header with-border">
       <fieldset>
-        <p>This donation was started on <%= @purchase.created_at.strftime("%B %-d %Y") %>:</p>
+        <p>This donation was started on <%= @purchase.created_at.to_s(:distribution_date) %>:</p>
         <ul class="list-group">
           <li class="list-group-item">It was bought from: <%= @purchase.purchased_from_view %></li>
           <li class="list-group-item">It will be stored at: <%= @purchase.storage_view %></li>
@@ -48,13 +48,13 @@
         -->
         </section>
       </fieldset>
-      
+
     </div>
     <div class="box-footer">
       <%= edit_button_to edit_purchase_path(@purchase), { text: "Make a correction", size: "lg" } %>
     </div>
   </div>
-</section>  
+</section>
 
 
 

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -11,7 +11,7 @@
     <% end %>
     </li>
     <li><%= link_to "Requests", (requests_path) %></li>
-    <li class="active"> Request from <%= @request.partner.name %> at <%= @request.created_at.strftime("%B %-d %Y") %></li>
+    <li class="active"> Request from <%= @request.partner.name %> at <%= @request.created_at.to_s(:distribution_date) %></li>
   </ol>
 </section>
 
@@ -19,7 +19,7 @@
   <div class="box">
     <div class="box-header with-border">
       <fieldset>
-        <p>This request was sent on <%= @request.created_at.strftime("%B %-d %Y") %>:</p>
+        <p>This request was sent on <%= @request.created_at.to_s(:distribution_date) %>:</p>
         <ul class="list-group">
           <li class="list-group-item">It was sent by: <%= @request.partner.name %></li>
           <li class="list-group-item">It has a status of: <%= @request.status %></li>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -5,3 +5,4 @@
 # Usage: @distribution.issued_at.to_s(:distribution_date_time)
 #
 Time::DATE_FORMATS[:distribution_date_time] = "%B %-d %Y %-l:%M%P"
+Time::DATE_FORMATS[:distribution_date] = "%B %-d %Y"

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -74,7 +74,8 @@ RSpec.describe Distribution, type: :model do
     describe "#distributed_at" do
       it "displays explicit issued_at date" do
         two_days_ago = 2.days.ago.midnight
-        expect(create(:distribution, issued_at: two_days_ago).distributed_at).to eq(two_days_ago.strftime("%B %-d %Y"))
+        distribution.issued_at = Time.zone.parse("2014-03-01 14:30:00 UTC")
+        expect(create(:distribution, issued_at: two_days_ago).distributed_at).to eq(two_days_ago.to_s(:distribution_date))
       end
 
       it "shows the hour and minutes if it has been provided" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

OK - I have performed a self-review of my own code,
OK - I have added tests that prove my fix is effective or that my feature works,
OK - New and existing unit tests pass locally with my changes ("bundle exec rake"),

-->

Resolves #789 

### Description
Looking at the code I've seen that already had a format for distribution date and time, so creating a distribution with only date was easy and simple. 