### PR TITLE
Change Behavior status request to Enum, including new status  

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -134,9 +134,9 @@ class DistributionsController < ApplicationController
 
   # If a request id is provided, update the request with the newly created distribution's id
   def update_request(request_atts, distribution_id)
-    if request_atts
-      Request.find(request_atts[:id]).update(distribution_id: distribution_id)
-    end
+    return if request_atts.blank?
+    request = Request.find(request_atts[:id])
+    request.update(distribution_id: distribution_id, status: 'fulfilled')
   end
 
   def send_notification(org, dist, subject: 'Your Distribution')

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -135,6 +135,7 @@ class DistributionsController < ApplicationController
   # If a request id is provided, update the request with the newly created distribution's id
   def update_request(request_atts, distribution_id)
     return if request_atts.blank?
+
     request = Request.find(request_atts[:id])
     request.update(distribution_id: distribution_id, status: 'fulfilled')
   end

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -11,13 +11,13 @@ class RequestsController < ApplicationController
     @request_items = get_items(@request.request_items)
   end
 
-  # Clicking the "Fullfill" button will set the the request to fulfilled
+  # Clicking the "New Distribution" button will set the the request to started
   # and will move the user to the new distribution page with a
   # pre-filled distribution containing all the requested items.
-  def fullfill
+  def start
     request = Request.find(params[:id])
-    request.update(status: "Fulfilled")
-    flash[:notice] = "Request marked as fulfilled"
+    request.status_started!
+    flash[:notice] = "Request started"
     redirect_to new_distribution_path(request_id: request.id)
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -19,9 +19,7 @@ class Request < ApplicationRecord
   belongs_to :distribution, optional: true
   has_many :item_requests, dependent: :destroy
 
-  scope :active, -> { where(status: "Active") }
-
-  STATUSES = %w[Active Fulfilled].freeze
+  enum status: { pending: 0, started: 1, fulfilled: 2 }, _prefix: true
 
   def family_request_reply
     {

--- a/app/views/layouts/_lte_navbar.html.erb
+++ b/app/views/layouts/_lte_navbar.html.erb
@@ -73,8 +73,8 @@
     <li class="dropdown notifications-menu">
       <a href="#" class="dropdown-toggle" data-toggle="dropdown">
         <i class="fa fa-bell-o"></i>
-        <% if current_organization && (current_organization.requests.active.size > 0 || current_organization.partners.awaiting_review.size > 0) %>
-          <span class="label label-warning"><%= (current_organization.requests.active.size + current_organization.partners.awaiting_review.size) %></span>
+        <% if current_organization && (current_organization.requests.status_pending.size > 0 || current_organization.partners.awaiting_review.size > 0) %>
+          <span class="label label-warning"><%= (current_organization.requests.status_pending.size + current_organization.partners.awaiting_review.size) %></span>
         <% end %>
       </a>
       <ul class="dropdown-menu">
@@ -83,7 +83,7 @@
           <ul class="menu">
             <li>
               <%= link_to(requests_path) do %>
-                <i class="fa fa-file-text text-aqua"></i> <%= current_organization&.requests.active.size rescue "0" %>
+                <i class="fa fa-file-text text-aqua"></i> <%= current_organization&.requests.status_pending.size rescue "0" %>
                 Diaper Requests
               <% end %>
             </li>

--- a/app/views/requests/_request_row.html.erb
+++ b/app/views/requests/_request_row.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td><%= request_row.created_at.strftime("%m/%d/%Y") %></td>
   <td><%= request_row.partner.name %> </td>
-  <td><%= request_row.status %></td>
+  <td><%= request_row.status.try(:humanize) %></td>
   <td class="text-right">
     <%= view_button_to request_path(request_row) %>
   </td>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -57,7 +57,7 @@
 
     </div>
     <div class="box-footer">
-      <%= submit_button_to fullfill_request_path(@request), { text: "Fulfill request" } unless @request.distribution %>
+      <%= submit_button_to start_request_path(@request), { text: "New Distribution" } unless @request.distribution %>
       <%= view_button_to(distribution_path(@request.distribution), { text: "View Associated Distribution", size: "lg" }) if @request.distribution %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,7 +119,7 @@ Rails.application.routes.draw do
     resources :purchases
     resources :requests, only: %i(index new show) do
       member do
-        post :fullfill
+        post :start
       end
     end
 

--- a/db/migrate/20190422130439_change_status_to_enum_in_requests.rb
+++ b/db/migrate/20190422130439_change_status_to_enum_in_requests.rb
@@ -1,3 +1,4 @@
+class Request < ApplicationRecord; end
 class ChangeStatusToEnumInRequests < ActiveRecord::Migration[5.2]
   def up
     add_column :requests, :status_new, :integer, default: 0

--- a/db/migrate/20190422130439_change_status_to_enum_in_requests.rb
+++ b/db/migrate/20190422130439_change_status_to_enum_in_requests.rb
@@ -1,0 +1,27 @@
+class ChangeStatusToEnumInRequests < ActiveRecord::Migration[5.2]
+  def up
+    add_column :requests, :status_new, :integer, default: 0
+
+    Request.where(status: 'Active').update_all status_new: 0
+    Request.where(status: 'Fulfilled').update_all status_new: 2
+
+    remove_column :requests, :status
+
+    rename_column :requests, :status_new, :status
+
+    add_index :requests, :status
+  end
+
+  def down
+    add_column :requests, :status_new, :string, default: 'Active'
+
+    Request.where(status: 0).update_all status_new: 'Active'
+    Request.where(status: 2).update_all status_new: 'Fulfilled'
+
+    remove_column :requests, :status
+
+    rename_column :requests, :status_new, :status
+
+    add_index :requests, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_07_203351) do
+ActiveRecord::Schema.define(version: 2019_04_22_130439) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -267,14 +267,15 @@ ActiveRecord::Schema.define(version: 2019_04_07_203351) do
   create_table "requests", force: :cascade do |t|
     t.bigint "partner_id"
     t.bigint "organization_id"
-    t.string "status", default: "Active"
     t.jsonb "request_items", default: {}
     t.text "comments"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "distribution_id"
+    t.integer "status", default: 0
     t.index ["organization_id"], name: "index_requests_on_organization_id"
     t.index ["partner_id"], name: "index_requests_on_partner_id"
+    t.index ["status"], name: "index_requests_on_status"
   end
 
   create_table "storage_locations", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -217,7 +217,7 @@ end
 end
 
 20.times.each do |count|
-  status = count > 15 ? 'Fulfilled' : 'Active'
+  status = count > 15 ? 'fulfilled' : 'pending'
   Request.create(
     partner: random_record(Partner),
     organization: random_record(Organization),

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -30,17 +30,21 @@ RSpec.describe DistributionsController, type: :controller do
     end
 
     describe "POST #create" do
-      it "redirects to #index on success" do
-        i = create(:storage_location)
-        p = create(:partner)
+      let!(:storage_location) { create(:storage_location) }
+      let!(:partner) { create(:partner) }
+      let(:distribution) do
+        { distribution: { storage_location_id: storage_location.id, partner_id: partner.id } }
+      end
 
-        expect(i).to be_valid
-        expect(p).to be_valid
+      it "redirects to #index on success" do
+        params = default_params.merge(distribution)
+        expect(storage_location).to be_valid
+        expect(partner).to be_valid
         expect(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
 
         jobs_count = PartnerMailerJob.jobs.count
 
-        post :create, params: default_params.merge(distribution: { storage_location_id: i.id, partner_id: p.id })
+        post :create, params: params
         expect(response).to have_http_status(:redirect)
 
         expect(response).to redirect_to(distributions_path)

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -21,6 +21,21 @@ RSpec.describe RequestsController, type: :controller do
         expect(subject).to be_successful
       end
     end
+
+    context "start a request" do
+      let!(:request) { create(:request) }
+      let(:request_id) { request.id }
+      let(:params) { default_params.merge( { id: request_id } ) }
+
+      before { post :start, params: params }
+
+      it "change request status to started" do
+        expect(request.reload).to be_status_started
+      end
+      it "redirect to new distribution path" do
+        expect(response).to redirect_to(new_distribution_path(request_id: request_id))
+      end
+    end
   end
 
   context "While not signed in" do

--- a/spec/controllers/requests_controller_spec.rb
+++ b/spec/controllers/requests_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe RequestsController, type: :controller do
     context "start a request" do
       let!(:request) { create(:request) }
       let(:request_id) { request.id }
-      let(:params) { default_params.merge( { id: request_id } ) }
+      let(:params) { default_params.merge(id: request_id) }
 
       before { post :start, params: params }
 

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
   factory :request do
     partner { Partner.try(:first) || create(:partner) }
     organization { Organization.try(:first) || create(:organization) }
-    request_items { random_keys(3).collect { |k| [k, rand(3..10)] }.to_h }
+    request_items { random_request_items }
     comments { "Urgent" }
   end
 

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -22,8 +22,15 @@ FactoryBot.define do
   factory :request do
     partner { Partner.try(:first) || create(:partner) }
     organization { Organization.try(:first) || create(:organization) }
-    request_items { random_request_items }
-    status { "Active" }
+    request_items { random_keys(3).collect { |k| [k, rand(3..10)] }.to_h }
     comments { "Urgent" }
+  end
+
+  trait :started do
+    status { 'started' }
+  end
+
+  trait :fulfilled do
+    status { 'fulfilled' }
   end
 end

--- a/spec/features/distribution_spec.rb
+++ b/spec/features/distribution_spec.rb
@@ -176,7 +176,7 @@ RSpec.feature "Distributions", type: :feature do
       @request = create :request, organization: @organization, request_items: request_items
 
       visit @url_prefix + "/requests/#{@request.id}"
-      click_on "Fulfill request"
+      click_on "New Distribution"
       within "#new_distribution" do
         select @storage_location.name, from: "From storage location"
         click_on "Save"
@@ -185,8 +185,9 @@ RSpec.feature "Distributions", type: :feature do
       @distribution = Distribution.last
     end
 
-    scenario "it sets the distribution id on the request" do
+    scenario "it sets the distribution id and fulfilled status on the request" do
       expect(@request.reload.distribution_id).to eq @distribution.id
+      expect(@request.reload).to be_status_fulfilled
     end
   end
 

--- a/spec/features/request_spec.rb
+++ b/spec/features/request_spec.rb
@@ -36,16 +36,30 @@ RSpec.feature "Requests", type: :feature do
       expect(page).to have_content("334")
     end
 
-    scenario "the request is fullfillable", js: true do
-      visit url_prefix + "/requests/#{@request.id}"
-      click_on "Fulfill request"
-      expect(page).to have_content "fulfilled"
-      select @storage_location.name, from: "From storage location"
-      fill_in "Comment", with: "Take my wipes... please"
-      click_on "Save"
-      expect(page).to have_content "Distributions"
-      expect(page).to have_content "Distribution created"
-      expect(@request.reload.distribution_id).to eq Distribution.last.id
+    context "change status request" do
+      before do
+        visit url_prefix + "/requests/#{@request.id}"
+        click_on "New Distribution"
+      end
+
+      scenario 'to started',js: true do
+        visit url_prefix + "/requests"
+        expect(page).to have_content "started"
+        expect(@request.reload).to be_status_started
+      end
+
+      context 'when save the distribution ' do
+        scenario "is fullfillable", js: true do
+          expect(page).to have_content "started"
+          select @storage_location.name, from: "From storage location"
+          fill_in "Comment", with: "Take my wipes... please"
+          click_on "Save"
+          expect(page).to have_content "Distributions"
+          expect(page).to have_content "Distribution created"
+          expect(@request.reload.distribution_id).to eq Distribution.last.id
+          expect(@request.reload).to be_status_fulfilled
+        end
+      end
     end
   end
 end

--- a/spec/features/request_spec.rb
+++ b/spec/features/request_spec.rb
@@ -42,14 +42,14 @@ RSpec.feature "Requests", type: :feature do
         click_on "New Distribution"
       end
 
-      scenario 'to started',js: true do
+      scenario "to started", js: true do
         visit url_prefix + "/requests"
         expect(page).to have_content "started"
         expect(@request.reload).to be_status_started
       end
 
-      context 'when save the distribution ' do
-        scenario "is fullfillable", js: true do
+      context "when save the distribution" do
+        scenario "change request to fulfilled", js: true do
           expect(page).to have_content "started"
           select @storage_location.name, from: "From storage location"
           fill_in "Comment", with: "Take my wipes... please"

--- a/spec/features/request_spec.rb
+++ b/spec/features/request_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature "Requests", type: :feature do
 
       scenario "to started", js: true do
         visit url_prefix + "/requests"
-        expect(page).to have_content "started"
+        expect(page).to have_content "Started"
         expect(@request.reload).to be_status_started
       end
 
@@ -52,7 +52,7 @@ RSpec.feature "Requests", type: :feature do
         scenario "change request to fulfilled", js: true do
           expect(page).to have_content "started"
           select @storage_location.name, from: "From storage location"
-          fill_in "Comment", with: "Take my wipes... please"
+          fill_in "Comment", with: "Tak4e my wipes... please"
           click_on "Save"
           expect(page).to have_content "Distributions"
           expect(page).to have_content "Distribution created"

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Organization, type: :model do
   describe "#ordered_requests" do
     let!(:new_active_request)  { create(:request, comments: "first active") }
     let!(:old_active_request) { create(:request, comments: "second active") }
-    let!(:fulfilled_request) { create(:request, status: 'Fulfilled', comments: "first fulfilled") }
+    let!(:fulfilled_request) { create(:request, :fulfilled, comments: "first fulfilled") }
     let!(:organization) { create(:organization, requests: [old_active_request, fulfilled_request, new_active_request]) }
 
     it "puts active requests before fulfilled requests" do

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -14,13 +14,16 @@
 #
 
 RSpec.describe Request, type: :model do
-  describe "Scopes >" do
-    describe "->active" do
-      it "retrieves only those with active status" do
-        Request.delete_all
-        create(:request, status: "Fulfilled")
-        create(:request, status: "Active")
-        expect(Request.active.size).to eq(1)
+  describe "Enums >" do
+    describe "#status" do
+      let!(:request_pending) { create(:request, :pending) }
+      let!(:request_started) { create(:request, :started) }
+      let!(:request_fulfilled) { create(:request, :fulfilled) }
+
+      it "scopes" do
+        expect(Request.status_pending).to eq([request_pending])
+        expect(Request.status_started).to eq([request_started])
+        expect(Request.status_fulfilled).to eq([request_fulfilled])
       end
     end
   end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -16,7 +16,7 @@
 RSpec.describe Request, type: :model do
   describe "Enums >" do
     describe "#status" do
-      let!(:request_pending) { create(:request, :pending) }
+      let!(:request_pending) { create(:request) }
       let!(:request_started) { create(:request, :started) }
       let!(:request_fulfilled) { create(:request, :fulfilled) }
 


### PR DESCRIPTION
Resolves #736 
Closes pr #793 

I changed the method 'fulfill' in request controller to 'start' and used the same code, instead of change method 'new' in 'distribution' controller. Makes more sense to me.
I created a migration to change existing data.

