### PR TITLE
Fix dashboard totals

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -73,14 +73,14 @@ module DashboardHelper
   private
 
   def total_received_donations_unformatted(range = selected_range)
-    LineItem.where(itemizable: current_organization.donations.during(range)).sum(:quantity)
+    LineItem.active.where(itemizable: current_organization.donations.during(range)).sum(:quantity)
   end
 
   def total_purchased_unformatted(range = selected_range)
-    LineItem.where(itemizable: current_organization.purchases.during(range)).sum(:quantity)
+    LineItem.active.where(itemizable: current_organization.purchases.during(range)).sum(:quantity)
   end
 
   def total_distributed_unformatted(range = selected_range)
-    LineItem.where(itemizable: current_organization.distributions.during(range)).sum(:quantity)
+    LineItem.active.where(itemizable: current_organization.distributions.during(range)).sum(:quantity)
   end
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -17,6 +17,7 @@ class LineItem < ApplicationRecord
 
   validates :item_id, presence: true
   validates :quantity, numericality: { other_than: 0, only_integer: true }
+  scope :active, -> { joins(:item).where(items: { active: true }) }
 
   def value_per_line_item
     item.value * quantity

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -19,5 +19,13 @@ FactoryBot.define do
     sequence(:name) { |n| "#{n}T Diapers" }
     organization { Organization.try(:first) || create(:organization) }
     partner_key { BaseItem.first&.partner_key || create(:base_item).partner_key }
+
+    trait :active do
+      active { true }
+    end
+
+    trait :inactive do
+      active { false }
+    end
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -52,60 +52,112 @@ RSpec.feature "Dashboard", type: :feature do
     end
   end
 
-  scenario "inventory totals on dashboard are updated immediately after donations and distributions are made", js: true do
-    create(:partner)
-    create(:item, organization: @organization)
-    create(:storage_location, organization: @organization)
-    create(:donation_site, organization: @organization)
-    create(:diaper_drive_participant, organization: @organization)
-    @organization.reload
+  context "inventory" do
+    let(:donation) { create(:donation, :with_items, organization: @organization) }
+    let(:purchase) { create(:purchase, :with_items, organization: @organization) }
+    let(:distribution) { create(:distribution, :with_items, organization: @organization) }
 
-    # Verify the initial totals on dashboard
-    visit @url_prefix + "/dashboard"
-    expect(page).to have_content("0 items received")
-    expect(page).to have_content("0 items on-hand")
+    before do
+      create(:partner)
+      create(:item, organization: @organization)
+      create(:storage_location, organization: @organization)
+      create(:donation_site, organization: @organization)
+      create(:diaper_drive_participant, organization: @organization)
+      @organization.reload
+    end
 
-    # Make a donation
-    visit @url_prefix + "/donations/new"
-    select "Misc. Donation", from: "donation_source"
-    expect(page).not_to have_xpath("//select[@id='donation_donation_site_id']")
-    expect(page).not_to have_xpath("//select[@id='donation_diaper_drive_participant_id']")
-    select StorageLocation.first.name, from: "donation_storage_location_id"
-    select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
-    fill_in "donation_line_items_attributes_0_quantity", with: "100"
-    click_button "Save"
+    context "inactive item cannot count in totals" do
 
-    # Make a diaper drive donation
-    visit @url_prefix + "/donations/new"
-    select "Diaper Drive", from: "donation_source"
-    select DiaperDriveParticipant.first.business_name, from: "donation_diaper_drive_participant_id"
-    select StorageLocation.first.name, from: "donation_storage_location_id"
-    select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
-    fill_in "donation_line_items_attributes_0_quantity", with: "100"
-    click_button "Save"
+      scenario 'for donations' do
+        item = donation.storage_location.items.first
+        visit @url_prefix + "/dashboard"
+        expect(page).to have_content("100 items received year to date")
 
-    # Check the dashboard now
-    visit @url_prefix + "/dashboard"
-    expect(page).to have_content("200 items received")
-    expect(page).to have_content("200 items on-hand")
+        inactive_item = item.update(active: false)
+        visit @url_prefix + "/dashboard"
+        expect(page).to_not have_content("100 items received year to date")
+      end
 
-    # Check distributions
-    visit @url_prefix + "/distributions/new"
-    select Partner.last.name, from: "distribution_partner_id"
-    select @organization.storage_locations.first.name, from: "distribution_storage_location_id"
-    select Item.last.name, from: "distribution_line_items_attributes_0_item_id"
-    fill_in "distribution_line_items_attributes_0_quantity", with: "50"
-    click_button "Save"
-    click_on "View", match: :first
-    expect(page).to have_content "Distribution Manifest for"
-    expect(page).to have_xpath("//table/tbody/tr/td", text: "50")
+      scenario 'for purchases' do
+        item = purchase.storage_location.items.first
+        visit @url_prefix + "/dashboard"
+        expect(page).to have_content("100 items received year to date")
 
-    # Check the dashboard now
-    visit @url_prefix + "/dashboard"
-    expect(page).to have_content("200 items received")
-    expect(page).to have_content("50 items distributed")
-    expect(page).to have_content("150 items on-hand")
-    expect(page).to have_content("1 Diaper Drives")
+        inactive_item = item.update(active: false)
+        visit @url_prefix + "/dashboard"
+        expect(page).to_not have_content("100 items received year to date")
+      end
+
+      scenario 'for distributions' do
+        item = distribution.storage_location.items.first
+        visit @url_prefix + "/dashboard"
+        expect(page).to have_content("100 items distributed year to date")
+
+        inactive_item = item.update(active: false)
+        visit @url_prefix + "/dashboard"
+        expect(page).to_not have_content("100 items distributed year to date")
+      end
+    end
+
+
+    scenario 'when have a donation. and inactive an item then cannot count in totals on the dashboard' do
+      item = donation.storage_location.items.first
+      visit @url_prefix + "/dashboard"
+
+      expect(page).to have_content("100 items received year to date")
+      inactive_item = item.update(active: false)
+      visit @url_prefix + "/dashboard"
+      expect(page).to_not have_content("100 items received year to date")
+    end
+
+    scenario "totals on dashboard are updated immediately after donations and distributions are made", js: true do
+      # Verify the initial totals on dashboard
+      visit @url_prefix + "/dashboard"
+      expect(page).to have_content("0 items received")
+      expect(page).to have_content("0 items on-hand")
+
+      # Make a donation
+      visit @url_prefix + "/donations/new"
+      select "Misc. Donation", from: "donation_source"
+      expect(page).not_to have_xpath("//select[@id='donation_donation_site_id']")
+      expect(page).not_to have_xpath("//select[@id='donation_diaper_drive_participant_id']")
+      select StorageLocation.first.name, from: "donation_storage_location_id"
+      select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
+      fill_in "donation_line_items_attributes_0_quantity", with: "100"
+      click_button "Save"
+
+      # Make a diaper drive donation
+      visit @url_prefix + "/donations/new"
+      select "Diaper Drive", from: "donation_source"
+      select DiaperDriveParticipant.first.business_name, from: "donation_diaper_drive_participant_id"
+      select StorageLocation.first.name, from: "donation_storage_location_id"
+      select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
+      fill_in "donation_line_items_attributes_0_quantity", with: "100"
+      click_button "Save"
+
+      # Check the dashboard now
+      visit @url_prefix + "/dashboard"
+      expect(page).to have_content("200 items received")
+      expect(page).to have_content("200 items on-hand")
+
+      # Check distributions
+      visit @url_prefix + "/distributions/new"
+      select Partner.last.name, from: "distribution_partner_id"
+      select @organization.storage_locations.first.name, from: "distribution_storage_location_id"
+      select Item.last.name, from: "distribution_line_items_attributes_0_item_id"
+      fill_in "distribution_line_items_attributes_0_quantity", with: "50"
+      click_button "Save"
+      click_on "View", match: :first
+      expect(page).to have_content "Distribution Manifest for"
+      expect(page).to have_xpath("//table/tbody/tr/td", text: "50")
+
+      # Check the dashboard now
+      visit @url_prefix + "/dashboard"
+      expect(page).to have_content("200 items received")
+      expect(page).to have_content("50 items distributed")
+      expect(page).to have_content("150 items on-hand")
+      expect(page).to have_content("1 Diaper Drives")
+    end
   end
 
   scenario "getting started guide works as expected", js: true do

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -67,13 +67,12 @@ RSpec.feature "Dashboard", type: :feature do
     end
 
     context "inactive item cannot count in totals" do
-
       scenario 'for donations' do
         item = donation.storage_location.items.first
         visit @url_prefix + "/dashboard"
         expect(page).to have_content("100 items received year to date")
 
-        inactive_item = item.update(active: false)
+        item.update(active: false)
         visit @url_prefix + "/dashboard"
         expect(page).to_not have_content("100 items received year to date")
       end
@@ -83,7 +82,7 @@ RSpec.feature "Dashboard", type: :feature do
         visit @url_prefix + "/dashboard"
         expect(page).to have_content("100 items received year to date")
 
-        inactive_item = item.update(active: false)
+        item.update(active: false)
         visit @url_prefix + "/dashboard"
         expect(page).to_not have_content("100 items received year to date")
       end
@@ -93,21 +92,10 @@ RSpec.feature "Dashboard", type: :feature do
         visit @url_prefix + "/dashboard"
         expect(page).to have_content("100 items distributed year to date")
 
-        inactive_item = item.update(active: false)
+        item.update(active: false)
         visit @url_prefix + "/dashboard"
         expect(page).to_not have_content("100 items distributed year to date")
       end
-    end
-
-
-    scenario 'when have a donation. and inactive an item then cannot count in totals on the dashboard' do
-      item = donation.storage_location.items.first
-      visit @url_prefix + "/dashboard"
-
-      expect(page).to have_content("100 items received year to date")
-      inactive_item = item.update(active: false)
-      visit @url_prefix + "/dashboard"
-      expect(page).to_not have_content("100 items received year to date")
     end
 
     scenario "totals on dashboard are updated immediately after donations and distributions are made", js: true do

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -29,4 +29,20 @@ RSpec.describe LineItem, type: :model do
       expect(build(:line_item, quantity: 1)).to be_valid
     end
   end
+
+  describe "Scopes >" do
+    describe "->active" do
+      let!(:active_item) { create(:item, :active) }
+      let!(:inactive_item) { create(:item, :inactive) }
+
+      before do
+        create(:line_item, item: active_item)
+        create(:line_item, item: inactive_item)
+      end
+
+      it "retrieves only those with active status" do
+        expect(described_class.active.size).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #809

### Description
I found this issue only in dashboard counts. The problem was the queries getting inactive items. When a user deletes an item then that set to active false. 
If someone knows about other places where this can happing, please tell me.
   
### Type of change
* Bug fix 
