### PR TITLE
Add yarn install to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ This project took what we built for the [Portland Diaper Bank in 2016](https://g
 ### Ruby Version
 This app uses Ruby version 2.6.2, indicated in `/.ruby-version` and `Gemfile`, which will be auto-selected if you use a Ruby versioning manager like `rvm` or `rbenv`.
 
+### Yarn Installation
+If you don't have Yarn installed, you can install with Homebrew on macOS `brew install yarn` or visit [https://yarnpkg.com/en/docs/install](https://yarnpkg.com/en/docs/install). 
+
 ### Database Configuration
 This app uses PostgreSQL for all environments. You'll also need to create the `dev` and `test` databases, the app is expecting them to be named `diaper_development` and `diaper_test`, respectively. This should all be handled with `rails db:setup`.
 


### PR DESCRIPTION
Relates to #751. 

### Description

* Adds instructions on how to install yarn to the README. Perhaps it needs to also include information on installing npm?

### Type of change

* Documentation update

### How Has This Been Tested?

* Verified the url goes to the correct page.
