### PR TITLE
issue 908 - update storage-location edit view for new theme

### DIFF
--- a/app/views/storage_locations/edit.html.erb
+++ b/app/views/storage_locations/edit.html.erb
@@ -1,33 +1,38 @@
-<section class="content-header">
+<div class="content-header">
 	<% content_for :title, "Edit - Storage Locations - #{@storage_location.name} - Inventory - #{current_organization.name}" %>
-<h1>
-  Editing Storage Location
-  <small>for <%= current_organization.name %></small>
-</h1>
-<ol class="breadcrumb">
-<li><%= link_to(dashboard_path) do %>
-    <i class="fa fa-dashboard"></i> Home
-  <% end %>
-  </li>
-  <li><%= link_to "Storeage Locations", (storage_locations_path) %></li>  
-  <li class="active">Editing <%= @storage_location.name %></li>
-</ol>
-</section>
-
-<!-- Main content -->
-<section class="content">
-
-<!-- Default box -->
-<div class="box">
-  <div class="box-header with-border">
-    <h3 class="box-title">Update record for <%= @storage_location.name %></h3>
-  </div>
-  <div class="box-body">
-		<%= render partial: "form", object: @storage_location %>
+  <div class="col-lg-8">
+    <h2>Editing Storage Location for <%= current_organization.name %></h2>
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item">
+        <%= link_to(dashboard_path) do %>
+          <i class="fa fa-dashboard"></i> Home
+        <% end %>
+      </li>
+      <li class="breadcrumb-item">
+        <%= link_to "Storeage Locations", (storage_locations_path) %>
+      </li>
+      <li class="breadcrumb-item active">
+        Editing <%= @storage_location.name %>
+      </li>
+    </ol>
   </div>
 </div>
-<!-- /.box -->
 
-</section>
-
-
+<div class="row">
+  <div class="col-lg-12">
+    <div class="wrapper wrapper-content animated fadeInRight">
+      <div class="ibox-content p-xl">
+        <div class="row">
+          <div class="box">
+            <div class="box-header with-border">
+              <h3 class="box-title">Update record for <%= @storage_location.name %></h3>
+            </div>
+            <div class="box-body">
+              <%= render partial: "form", object: @storage_location %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Resolves #908 

Updated storage-location edit view to match other examples of the bootstrap 4 new_theme update.
- followed conventions in other examples
- did not run any tests, since my tests were not running locally
- part of the open source workshop at RailsConf 2019

![storage-location-edit](https://user-images.githubusercontent.com/1998791/57094087-3c7a6980-6cd5-11e9-8891-b149d0b6c07f.PNG)
