### PR TITLE
Resolve #844 - Update Organizations Index to Use New Theme

### DIFF
--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -1,49 +1,49 @@
-<section class="content-header">
+<div class="row wrapper border-bottom white-bg page-heading">
   <% content_for :title, "Admin - Organizations" %>
-  <h1>
-    All Diaperbase Organizations
-    <small></small>
-  </h1>
-  <ol class="breadcrumb">
-    <li>
-      <%= link_to(admin_dashboard_path) do %>
-        <i class="fa fa-dashboard"></i> Home
-      <% end %>
-    </li>
-    <li><a href="#">All Diaperbase organizations</a></li>
-  </ol>
-</section>
+  <div class="col-lg-8">
+    <h2>
+      All Diaperbase Organizations
+    </h2>
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item">
+        <%= link_to(admin_dashboard_path) do %>
+          <i class="fa fa-dashboard"></i> Home
+        <% end %>
+      </li>
+      <li class="breadcrumb-item active">
+        All Diaperbase Organizations
+      </li>
+    </ol>
+  </div>
+  <div class="col-lg-4">
+    <div class="title-action">
+      <%= new_button_to new_admin_organization_path, { text: "Add New Organization" } %>
+    </div>
+  </div>
+</div>
 
-<!-- Main content -->
-<section class="content">
-  <!-- Default box -->
-  <div class="box">
-    <div class="box-body">
-      <div class="text-right">
-        <%= new_button_to new_admin_organization_path, { text: "Add New Organization" } %>
-      </div>
-      <div class="row">
-        <div class="col-xs-12">
-          <!-- /.box-header -->
-          <div class="box-body table-responsive no-padding">
+<div class="row">
+  <div class="col-lg-12">
+    <div class="wrapper wrapper-content animated fadeInRight">
+      <div class="ibox-content p-xl">
+        <div class="row">
+          <div class="table-responsive">
             <table class="table table-hover">
               <thead>
-              <tr>
-                <th>Organization</th>
-                <th>Contact E-mail</th>
-                <th>Added On</th>
-                <th class="text-right">Actions</th>
-              </tr>
+                <tr>
+                  <th>Organization</th>
+                  <th>Contact E-mail</th>
+                  <th>Added On</th>
+                  <th class="text-right">Actions</th>
+                </tr>
               </thead>
               <tbody>
-              <%= render partial: "organization_row", collection: @organizations %>
+                <%= render partial: "organization_row", collection: @organizations %>
               </tbody>
             </table>
-            <!-- /.box-body -->
           </div>
-          <!-- /.box -->
         </div>
       </div>
     </div>
   </div>
-</section>
+</div>

--- a/app/views/purchases/show.html.erb
+++ b/app/views/purchases/show.html.erb
@@ -10,7 +10,7 @@
     <% end %>
     </li>
     <li><%= link_to "Purchases", (purchases_path) %></li>
-    <li class="active"> <%= @purchase.purchased_from_view %> on <%= @purchase.created_at..to_s(:distribution_date) %></li>
+    <li class="active"> <%= @purchase.purchased_from_view %> on <%= @purchase.created_at.to_s(:distribution_date) %></li>
   </ol>
 </section>
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -101,11 +101,12 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
   config.include Devise::Test::IntegrationHelpers, type: :feature
+  config.include Devise::Test::IntegrationHelpers, type: :system
 
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.
-  config.use_transactional_fixtures = false
+  config.use_transactional_fixtures = true
 
   # Location for fixtures (logo, etc)
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -115,6 +116,12 @@ RSpec.configure do |config|
 
   # Make FactoryBot easier.
   config.include FactoryBot::Syntax::Methods
+
+  # set driver for system tests
+  config.before(:each, type: :system) do
+    driven_by :selenium_chrome_headless
+    Capybara.server = :puma, { Silent: true }
+  end
 
   # Preparatifyication
   config.before(:suite) do

--- a/spec/system/account_system_spec.rb
+++ b/spec/system/account_system_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe "User account management", type: :system do
+  before do
+    sign_in(@user)
+    visit "/users/edit"
+  end
+
+  it "should change a user name" do
+    name = @user.name + "aaa"
+    fill_in "Name", with: name
+    fill_in "user_current_password", with: @user.password
+    click_button "Save"
+
+    expect(page).to have_content(name)
+  end
+end

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe "Adjustment management", type: :system do
+  before do
+    sign_in(@user)
+  end
+  let!(:url_prefix) { "/#{@organization.to_param}" }
+
+  it "can add an inventory adjustment at a storage location", js: true do
+    add_quantity = 10
+    storage_location = create(:storage_location, :with_items, organization: @organization)
+    visit url_prefix + "/adjustments"
+    click_link "New Adjustment"
+    select storage_location.name, from: "From storage location"
+    fill_in "Comment", with: "something"
+    select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
+    fill_in "adjustment_line_items_attributes_0_quantity", with: add_quantity.to_s
+
+    expect do
+      click_button "Save"
+    end.to change { storage_location.size }.by(add_quantity)
+    expect(page).to have_content("Adjustment was successfully created")
+  end
+
+  it "can subtract an inventory adjustment at a storage location", js: true do
+    sub_quantity = -10
+    storage_location = create(:storage_location, :with_items, organization: @organization)
+    visit url_prefix + "/adjustments"
+    click_link "New Adjustment"
+    select storage_location.name, from: "From storage location"
+    fill_in "Comment", with: "something"
+    select Item.last.name, from: "adjustment_line_items_attributes_0_item_id"
+    fill_in "adjustment_line_items_attributes_0_quantity", with: sub_quantity.to_s
+
+    expect do
+      click_button "Save"
+    end.to change { storage_location.size }.by(sub_quantity)
+    expect(page).to have_content("Adjustment was successfully created")
+  end
+
+  it "can filter the #index by storage location" do
+    storage_location = create(:storage_location, name: "here", organization: @organization)
+    storage_location2 = create(:storage_location, name: "there", organization: @organization)
+    create(:adjustment, organization: @organization, storage_location: storage_location)
+    create(:adjustment, organization: @organization, storage_location: storage_location2)
+
+    visit url_prefix + "/adjustments"
+    select storage_location.name, from: "filters_at_location"
+    click_button "Filter"
+
+    expect(page).to have_css("table tr", count: 2)
+  end
+end


### PR DESCRIPTION
Resolves #844

### Description
We're upgrading our bootstrap theme to use a bootstrap 4 template and need to upgrade the various pages in our site. This PR applies the new theme to the organizations index page.

### Screenshots

Old:

![image](https://user-images.githubusercontent.com/1656401/57094389-10131d00-6cd6-11e9-84e0-6d7389719e67.png)

New:

![image](https://user-images.githubusercontent.com/1656401/57094410-16a19480-6cd6-11e9-9840-096b6784fc8a.png)

