### PR TITLE
Theme update for "Distributions New"

### DIFF
--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -18,12 +18,10 @@
   </div>
 </div>
 
-<!-- Main content -->
-<section class="content">
-
-<!-- Default box -->
-<div class="box">
-  <div class="box-body">
+<div class="row">
+  <div class="col-lg-12">
+    <div class="wrapper wrapper-content animated fadeInRight">
+      <div class="ibox-content p-xl">
 
   <%= simple_form_for @distribution, html: { class: "storage-location-required" } do |f| %>
     <%= f.simple_fields_for :request do |r| %>
@@ -50,23 +48,21 @@
           <%= render 'line_items/line_item_fields', f: item %>
         </div>
       <% end %>
-      <div class="row links">
+      <div class="links">
         <div class="col-xs-12">
           <%= add_line_item_button f, "#distribution_line_items" %>
         </div>
       </div>
 
     </fieldset>
-      <div class="row">
-        <div class="col-xs-12">
-          <%= submit_button %>
-      </div>
+    <div class="col-xs-12 text-right">
+      <%= submit_button(align: nil) %>
     </div>
   <% end %>
   </div>
 </div>
-<!-- /.box -->
+</div>
 
 <%= render partial: "donations/barcode_modal" %>
 
-</section>
+</div>

--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -22,47 +22,46 @@
   <div class="col-lg-12">
     <div class="wrapper wrapper-content animated fadeInRight">
       <div class="ibox-content p-xl">
+        <%= simple_form_for @distribution, html: { class: "storage-location-required" } do |f| %>
+          <%= f.simple_fields_for :request do |r| %>
+            <%= r.input :id, as: :hidden %>
+          <% end %>
 
-  <%= simple_form_for @distribution, html: { class: "storage-location-required" } do |f| %>
-    <%= f.simple_fields_for :request do |r| %>
-      <%= r.input :id, as: :hidden %>
-    <% end %>
+          <%= f.association :partner,
+            collection: current_organization.partners,
+            label: "Partner",
+            error: "Which partner is this distribution going to?" %>
 
-    <%= f.association :partner,
-      collection: current_organization.partners,    
-      label: "Partner",
-      error: "Which partner is this distribution going to?" %>
+            <%= f.input :issued_at, as: :date, label: "Distribution pick-up date" %>
+            <%= f.input :agency_rep, label: "Agency representative" %>
 
-      <%= f.input :issued_at, as: :date, label: "Distribution pick-up date" %>
-      <%= f.input :agency_rep, label: "Agency representative" %>
+          <%= render partial: "storage_locations/source", object: f %>
 
-    <%= render partial: "storage_locations/source", object: f %>
-    
-    <%= f.input :comment, label: "Comment" %>
+          <%= f.input :comment, label: "Comment" %>
 
 
-    <fieldset style="margin-bottom: 2rem;" class="form-inline">
-      <legend>Items in this distribution</legend>
-      <%= f.simple_fields_for :line_items do |item| %>
-        <div id="distribution_line_items" class="line-item-fields" data-capture-barcode="true">
-          <%= render 'line_items/line_item_fields', f: item %>
-        </div>
-      <% end %>
-      <div class="links">
-        <div class="col-xs-12">
-          <%= add_line_item_button f, "#distribution_line_items" %>
-        </div>
+          <fieldset style="margin-bottom: 2rem;" class="form-inline">
+            <legend>Items in this distribution</legend>
+            <%= f.simple_fields_for :line_items do |item| %>
+              <div id="distribution_line_items" class="line-item-fields" data-capture-barcode="true">
+                <%= render 'line_items/line_item_fields', f: item %>
+              </div>
+            <% end %>
+            <div class="links">
+              <div class="col-xs-12">
+                <%= add_line_item_button f, "#distribution_line_items" %>
+              </div>
+            </div>
+
+          </fieldset>
+          <div class="col-xs-12 text-right">
+            <%= submit_button(align: nil) %>
+          </div>
+        <% end %>
       </div>
-
-    </fieldset>
-    <div class="col-xs-12 text-right">
-      <%= submit_button(align: nil) %>
     </div>
-  <% end %>
   </div>
-</div>
-</div>
 
-<%= render partial: "donations/barcode_modal" %>
+  <%= render partial: "donations/barcode_modal" %>
 
 </div>

--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -1,18 +1,22 @@
-<section class="content-header">
+<div class="row wrapper border-bottom white-bg page-heading">
   <% content_for :title, "New - Distributions - #{current_organization.name}" %>
-  <h1>
-    New Distribution
-    <small>for <%= current_organization.name %></small>
-  </h1>
-  <ol class="breadcrumb">
-  <li><%= link_to(dashboard_path) do %>
-      <i class="fa fa-dashboard"></i> Home
-    <% end %>
-    </li>
-    <li><%= link_to "Distributions", (distributions_path) %></li>
-    <li class="active"> New Distribution</li>
-  </ol>
-</section>
+  <div class="col-lg-8">
+    <h2>New Distribution for <%= current_organization.name %></h2>
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item">
+        <%= link_to(dashboard_path) do %>
+          <i class="fa fa-dashboard"></i> Home
+        <% end %>
+      </li>
+      <li class="breadcrumb-item">
+        <%= link_to "Distributions", (distributions_path) %>
+      </li>
+      <li class="breadcrumb-item active">
+        New Distribution
+      </li>
+    </ol>
+  </div>
+</div>
 
 <!-- Main content -->
 <section class="content">

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,6 +1,6 @@
 <div class="nested-fields">
   <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
-  <label>OR</label>
+  <span>OR</span>
   <%= f.input_field :item_id, collection: @items, prompt: "Choose an item", class: 'form-control' %>
   <%= f.input_field :quantity, placeholder: "Quantity", class: 'form-control' %>
   <%= delete_line_item_button f %>


### PR DESCRIPTION
Resolves #861 

### Description
This PR updates the "Distributions New" page to the new Bootstrap 4 theme.
It includes a bunch of indentation changes, so would recommend reviewing commit-by-commit, or with `?w=1`

### Type of change

Theme update

### How Has This Been Tested?

Manually click around the http://localhost:3000/diaper_bank/distributions/new page


### Screenshot (before)
<img width="1257" alt="Image 2019-05-02 at 12 34 30 PM" src="https://user-images.githubusercontent.com/84566/57094640-a5161600-6cd6-11e9-855a-84abb1fa43df.png">

### Screenshot (after)
<img width="1263" alt="Image 2019-05-02 at 12 34 02 PM" src="https://user-images.githubusercontent.com/84566/57094616-96c7fa00-6cd6-11e9-9198-8a3eb1769424.png">

