### PR TITLE
[#860] updated diaper drive participant new theme + feature specs

### DIFF
--- a/app/views/diaper_drive_participants/new.html.erb
+++ b/app/views/diaper_drive_participants/new.html.erb
@@ -1,33 +1,37 @@
-<section class="content-header">
+<div class="row wrapper border-bottom white-bg page-heading">
 	<% content_for :title, "New - Diaper Drive Participants - Agencies - #{current_organization.name}" %>
-  <h1>
-    Diaper Drive Participant
-    <small>for <%= current_organization.name %></small>
-  </h1>
-	<ol class="breadcrumb">
-	<li><%= link_to(dashboard_path) do %>
-	    <i class="fa fa-dashboard"></i> Home
-	  <% end %>
-	  </li>
-	  <li><%= link_to "Diaper Drive Participants", (diaper_drive_participants_path) %></li>  
-	  <li class="active"> New Diaper Drive Participant</li>
-	</ol>
-</section>
+	<div class="col-lg-8">
+	  <h2>
+	    Diaper Drive Participant
+	    <small>for <%= current_organization.name %></small>
+	  </h2>
+		<ol class="breadcrumb">
+			<li class="breadcrumb-item">
+	      <%= link_to(dashboard_path) do %>
+	        <i class="fa fa-dashboard"></i> Home
+	      <% end %>
+	    </li>
+		  <li class="breadcrumb-item">
+		  	<%= link_to "Diaper Drive Participants", (diaper_drive_participants_path) %>
+		  </li>  
+		  <li class="breadcrumb-item active">
+	    	New Diaper Drive Participant
+	    </li>
+		</ol>
+	</div>
+</div>
 
-<!-- Main content -->
-<section class="content">
-
-<!-- Default box -->
-<div class="box">
-  <div class="box-header with-border">
-    <h3 class="box-title">New Diaper Drive Participant</h3>
-  </div>
-  <div class="box-body">
-		<%= render partial: "form", object: @diaper_drive_participant %>
+<div class="row">
+  <div class="col-lg-12">
+    <div class="wrapper wrapper-content animated fadeInRight">
+      <div class="ibox-content p-xl">
+        <div class="ibox-title">
+          <h3>New Diaper Drive Participant</h3>
+        </div>
+        <div class="ibox-content">
+          <%= render partial: "form", object: @diaper_drive_participant %>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
-<!-- /.box -->
-
-</section>
-
-

--- a/spec/features/diaper_drive_participant_spec.rb
+++ b/spec/features/diaper_drive_participant_spec.rb
@@ -29,14 +29,14 @@ RSpec.feature "Diaper Drive Participant", type: :feature do
       click_button "Save"
     end.to change { DiaperDriveParticipant.count }.by(1)
 
-    expect(page.find(".alert")).to have_content "added"
+    expect(page).to have_content(diaper_drive_participant_traits[:contact_name])
   end
 
   scenario "User add a new diaper drive instance with empty attributes" do
     visit url_prefix + "/diaper_drive_participants/new"
     click_button "Save"
 
-    expect(page.find(".alert")).to have_content "didn't work"
+    expect(page).to have_content("Must provide a ")
   end
 
   scenario "User can update the contact info for a diaper drive participant" do


### PR DESCRIPTION
Resolves #860 

### Screenshots
<img width="1680" alt="Screen Shot 2019-05-02 at 10 39 26 AM" src="https://user-images.githubusercontent.com/8730201/57094979-9d4e7580-6cc6-11e9-80bf-33706a5554ae.png">
<img width="1462" alt="Screen Shot 2019-05-02 at 10 39 09 AM" src="https://user-images.githubusercontent.com/8730201/57094988-a0496600-6cc6-11e9-87a2-874d8df89dc2.png">

### Description
Updated bootstrap for the diaper drive participant new page. Also updated the feature specs since it did not appear that we were alerting on the page previously.

### Testing
Tested locally with feature tests
