### PR TITLE
Convert admin/feedback Feature spec to System spec

### DIFF
--- a/spec/system/admin/feedback_system_spec.rb
+++ b/spec/system/admin/feedback_system_spec.rb
@@ -1,10 +1,10 @@
-RSpec.feature "Admin Feedback Message Management" do
+RSpec.describe "Admin Feedback Message Management", type: :system do
   context "While signed in as an Administrative User (super admin)" do
     before :each do
       sign_in(@super_admin)
     end
 
-    scenario "viewing and marking feedback as resolved", js: true do
+    it "viewing and marking feedback as resolved", js: true do
       feedback_message = FactoryBot.create(:feedback_message)
       visit admin_feedback_messages_path
 


### PR DESCRIPTION
Resolves #899

### Description
Converts `spec/features/admin/feedback_spec.rb` to a Rails System spec.