### PR TITLE
Fixed typo on Diaper Drive Participants page

### DIFF
--- a/app/views/diaper_drive_participants/index.html.erb
+++ b/app/views/diaper_drive_participants/index.html.erb
@@ -31,7 +31,7 @@
           <table class="table table-hover">
             <thead>
               <tr>
-                <th>Buisness Name</th>
+                <th>Business Name</th>
                 <th>Contact Name</th>
                 <th>Phone</th>
                 <th>Email</th>

--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -31,7 +31,7 @@
           <table class="table table-hover">
             <thead>
               <tr>
-                <th>Buisness Name</th>
+                <th>Business Name</th>
                 <th>Contact Name</th>
                 <th>Phone</th>
                 <th>Email</th>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #957 

### Description
Fixes typo "Buisness Name" to "Business Name" in two places (see screenshots below)
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually tested in the views.
<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
- `diaper_drive_participants/index.html.erb`
<img width="597" alt="diaper_drive_participants" src="https://user-images.githubusercontent.com/20273892/57181424-1bdb1c80-6e59-11e9-8a34-2d3bfa174f61.png">

- `vendors/index.html.erb`
<img width="547" alt="vendors" src="https://user-images.githubusercontent.com/20273892/57181427-21386700-6e59-11e9-93d2-0fc9b5db0eaf.png">
