### PR TITLE
Update BarcodeItem Edit to Use New Theme

### DIFF
--- a/app/views/barcode_items/edit.html.erb
+++ b/app/views/barcode_items/edit.html.erb
@@ -1,31 +1,34 @@
-<section class="content-header">
-	<% content_for :title, "Edit - Barcode Items - #{@barcode_item.item.name} - Inventory - #{current_organization.name}" %>
-	<h1>
-	  Editing Barcode
-	  <small>for <%= current_organization.name %></small>
-	</h1>
-	<ol class="breadcrumb">
-	<li><%= link_to(dashboard_path) do %>
-	    <i class="fa fa-dashboard"></i> Home
-	  <% end %>
-	  </li>
-	  <li><%= link_to "All Barcodes", (barcode_items_path) %></li>  
-	  <li class="active">Editing Barcode</li>
-	</ol>
-</section>
+<div class="row wrapper border-bottom white-bg page-heading">
+  <% content_for :title, "Edit - Barcode Items - #{@barcode_item.item.name} - Inventory - #{current_organization.name}" %>
+    <div class="col-lg-8">
+    <h1>
+      Editing Barcode
+      <small>for <%= current_organization.name %></small>
+    </h1>
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item">
+        <%= link_to(dashboard_path) do %>
+        <i class="fa fa-dashboard"></i> Home
+        <% end %>
+      </li>
+      <li class="breadcrumb-item active">
+        <%= link_to "All Barcodes", (barcode_items_path) %>
+      </li>  
+      <li class="breadcrumb-item active">Editing Barcode
+      </li>
+    </ol>
+  </div>
+</div>
 
-<!-- Main content -->
-<section class="content">
-
-<!-- Default box -->
-	<div class="box">
-	  <div class="box-header with-border">
-	    <h3 class="box-title">Barcode for <%= @barcode_item.quantity %> of <%= @barcode_item.item.name %></h3>
-	  </div>
-	  <div class="box-body">
-			<%= render partial: "form", object: @barcode_item %>
-	  </div>
-	</div>
-	<!-- /.box -->
-
-</section>
+<div class="row">
+  <div class="col-lg-12">
+    <div class="wrapper wrapper-content animated fadeInRight">
+      <div class="ibox-content p-xl">
+        <h3 class="box-title">Barcode for <%= @barcode_item.quantity %> of <%= @barcode_item.item.name %></h3>
+        <div class="ibox-content">
+          <%= render partial: "form", object: @barcode_item %>
+        </div>  
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Resolves #895 

### Description

This PR updates the `/app/views/barcode_items/edit.html.erb` page to the new Bootstrap 4 theme.

### Type of change

Update to Bootstrap 4 theme.

### How Has This Been Tested?

`bundle exec rspec` has been executed with 0 failures

### Screenshots

- Before:

![barcodeitemB4](https://user-images.githubusercontent.com/10763483/57478972-b6c96180-7272-11e9-9c12-813fed21abbc.png)


- After: 

![barcodeAFTER](https://user-images.githubusercontent.com/10763483/57478985-bf219c80-7272-11e9-8720-a908c344d82c.png)
