### PR TITLE
Update partner edit to new theme

### DIFF
--- a/app/views/partners/edit.html.erb
+++ b/app/views/partners/edit.html.erb
@@ -1,32 +1,33 @@
-<section class="content-header">
-<% content_for :title, "Edit - Partners - #{@partner.name} - Agencies - #{current_organization.name}" %>
-<h1>
-  Editing Partner Information
-  <small>for <%= current_organization.name %></small>
-</h1>
-<ol class="breadcrumb">
-  <li>
-    <%= link_to(dashboard_path) do %>
-      <i class="fa fa-dashboard"></i> Home
-    <% end %>
-  </li>
-  <li><%= link_to "Partners", (partners_path) %></li>
-  <li class="active">Editing <%= @partner.name %></li>
-</ol>
-</section>
-
-<!-- Main content -->
-<section class="content">
-
-<!-- Default box -->
-<div class="box">
-  <div class="box-header with-border">
-    <h3 class="box-title">Update record for <%= @partner.name %></h3>
-  </div>
-  <div class="box-body">
-    <%= render partial: "form", object: @partner, locals: { submit_btn_options: { text: "Update Partner" } } %>
+<div class="row wrapper border-bottom white-bg page-heading">
+  <% content_for :title, "Edit - Partners - #{@partner.name} - Agencies - #{current_organization.name}" %>
+  <div class="col-lg-8">
+    <h2> Editing Partner for <%= current_organization.name %></h2>
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item">
+        <%= link_to(dashboard_path) do %>
+          <i class="fa fa-dashboard"></i> Home
+        <% end %>
+      </li>
+      <li class="breadcrumb-item">
+        <%= link_to "Partners", (partners_path) %>
+      </li>
+      <li class="breadcrumb-item active">
+        Editing <%= @partner.name %>
+      </li>
+    </ol>
   </div>
 </div>
-<!-- /.box -->
-
-</section>
+<div class="row">
+  <div class="col-lg-12">
+    <div class="wrapper wrapper-content animated fadeInRight">
+      <div class="ibox-content p-xl">
+        <div class="ibox-title">
+          <h3 class="box-title">Update record for <%= @partner.name %></h3>
+        </div>
+        <div class="ibox-content">
+          <%= render partial: "form", object: @partner, locals: { submit_btn_options: { text: "Update Partner" } } %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/diaper/issues/905

### Description

Updates the /app/views/partners/edit.html.erb  page to the New Bootstrap 4 theme

### Type of change

* Layout

### How Has This Been Tested?

Manually and rspec

### Screenshots
before:

![Screenshot 2019-05-15 19 48 32](https://user-images.githubusercontent.com/392677/57814614-9dc92080-774a-11e9-9ac6-5046b7e5ae3d.png)


after:

![Screenshot 2019-05-15 19 48 12](https://user-images.githubusercontent.com/392677/57814617-a3bf0180-774a-11e9-9eb1-3c363b57eace.png)

