### PR TITLE
973 items value to integer in cents

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -76,7 +76,7 @@ class PurchasesController < ApplicationController
 
   def purchase_params
     params = compact_line_items
-    params.require(:purchase).permit(:comment, :amount_spent, :purchased_from, :storage_location_id, :issued_at, :vendor_id, line_items_attributes: %i(id item_id quantity _destroy)).merge(organization: current_organization)
+    params.require(:purchase).permit(:comment, :amount_spent_in_cents, :purchased_from, :storage_location_id, :issued_at, :vendor_id, line_items_attributes: %i(id item_id quantity _destroy)).merge(organization: current_organization)
   end
 
   def filter_params

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -4,7 +4,11 @@ module ItemsHelper
     if value.zero?
       ''
     else
-      addition + ActionController::Base.helpers.number_to_currency(value, precision: value.round == value ? 0 : 2)
+      addition + ActionController::Base.helpers.number_to_currency(cents_to_dollar(value), precision: cents_to_dollar(value).round == value ? 0 : 2)
     end
+  end
+
+  def cents_to_dollar(value_in_cents)
+    value_in_cents.to_f / 100
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,7 +11,7 @@
 #  organization_id :integer
 #  active          :boolean          default(TRUE)
 #  partner_key     :string
-#  value           :decimal(5, 2)    default(0.0)
+#  value_in_cents  :integer   default(0)
 #
 
 class Item < ApplicationRecord
@@ -20,7 +20,7 @@ class Item < ApplicationRecord
   validates :name, uniqueness: { scope: :organization }
   validates :name, presence: true
   validates :organization, presence: true
-  validates :value, numericality: { greater_than_or_equal_to: 0 }
+  validates :value_in_cents, numericality: { greater_than_or_equal_to: 0 }
 
   has_many :line_items, dependent: :destroy
   has_many :inventory_items, dependent: :destroy

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -20,6 +20,6 @@ class LineItem < ApplicationRecord
   scope :active, -> { joins(:item).where(items: { active: true }) }
 
   def value_per_line_item
-    item.value * quantity
+    item.value_in_cents * quantity
   end
 end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -7,7 +7,7 @@
 #  comment             :text
 #  organization_id     :integer
 #  storage_location_id :integer
-#  amount_spent        :integer
+#  amount_spent_in_cents        :integer
 #  issued_at           :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
@@ -41,7 +41,7 @@ class Purchase < ApplicationRecord
   before_create :combine_duplicates
   before_destroy :remove_inventory
 
-  validates :amount_spent, numericality: { greater_than: 0 }
+  validates :amount_spent_in_cents, numericality: { greater_than: 0 }
 
   def storage_view
     storage_location.nil? ? "N/A" : storage_location.name
@@ -89,7 +89,7 @@ class Purchase < ApplicationRecord
   end
 
   def self.csv_export_headers
-    ["Purchases from", "Storage Location", "Quantity of Items", "Variety of Items", "Amount spent"]
+    ["Purchases from", "Storage Location", "Quantity of Items", "Variety of Items", "Amount spent in Cents"]
   end
 
   def csv_export_attributes
@@ -98,7 +98,7 @@ class Purchase < ApplicationRecord
       storage_location.name,
       line_items.total,
       line_items.size,
-      amount_spent,
+      amount_spent_in_cents,
     ]
   end
 

--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -13,7 +13,7 @@ class DistributionPdf
     end
     data = [["Items Received", "Value/item", "Total value", "Quantity"]]
     data += @distribution.line_items.sorted.map do |c|
-      [c.item.name, item_value(c.item.value), item_value(c.value_per_line_item), c.quantity]
+      [c.item.name, item_value(c.item.value_in_cents), item_value(c.value_per_line_item), c.quantity]
     end
     data += [["", "", "", ""], ["Total Items Received", "", item_value(@distribution.value_per_itemizable), @distribution.line_items.total]]
 

--- a/app/queries/items_by_storage_collection_and_quantity_query.rb
+++ b/app/queries/items_by_storage_collection_and_quantity_query.rb
@@ -16,7 +16,7 @@ class ItemsByStorageCollectionAndQuantityQuery
       unless @items_by_storage_collection_and_quantity.key?(row.id)
         @items_by_storage_collection_and_quantity[row.id] = {
           item_name: row.name,
-          item_value: row.value,
+          item_value: row.value_in_cents,
           item_barcode_count: row.barcode_count
         }
       end

--- a/app/queries/items_by_storage_collection_query.rb
+++ b/app/queries/items_by_storage_collection_query.rb
@@ -21,7 +21,7 @@ class ItemsByStorageCollectionQuery
                         items.name,
                         items.barcode_count,
                         items.partner_key,
-                        items.value,
+                        items.value_in_cents,
                         storage_locations.name as storage_name,
                         storage_locations.id as storage_id,
                         sum(inventory_items.quantity) as quantity

--- a/app/views/distributions/_distribution_item_row.html.erb
+++ b/app/views/distributions/_distribution_item_row.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td><%= distribution_item_row.quantity %></td>
-  <td><%= item_value(distribution_item_row.item.value) %></td>
+  <td><%= item_value(distribution_item_row.item.value_in_cents) %></td>
   <td><%= item_value(distribution_item_row.value_per_line_item) %></td>
   <td><%= distribution_item_row.item.name %></td>
 </tr>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -7,7 +7,7 @@
     <% end %>
     <%= f.input :name, label: "Value per item", wrapper: :vertical_input_group do %>
       <span class="input-group-addon"><i class="fa fa-money"></i></span>
-      <%= f.input_field :value, class: "form-control" %>
+      <%= f.input_field :value_in_cents, class: "form-control" %>
     <% end %>
 
     <%= submit_button %>

--- a/app/views/items/_item_row.html.erb
+++ b/app/views/items/_item_row.html.erb
@@ -2,7 +2,7 @@
   <td><%= item_row.name %></td>
   <td><%= item_row.barcode_count %></td>
   <td><%= item_row.base_item.name %></td>
-  <td><%= item_value(item_row.value) %></td>
+  <td><%= item_value(item_row.value_in_cents) %></td>
   <td class="text-right">
     <%= view_button_to item_path(item_row) %>
     <%= edit_button_to edit_item_path(item_row) %>

--- a/app/views/items/_item_row_quantity.html.erb
+++ b/app/views/items/_item_row_quantity.html.erb
@@ -2,5 +2,5 @@
   <td><%= item_row.name %></td>
   <td><%= item_row.barcode_count %></td>
   <td><%= item_row.quantity %></td>
-  <td><%= item_value(item_row.value) %></td>
+  <td><%= item_value(item_row.value_in_cents) %></td>
 </tr>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -20,7 +20,7 @@
 <!-- Default box -->
 <div class="box">
   <div class="box-header with-border">
-    <h3 class="box-title"><%= @item.name %>  <%= item_value(@item.value, ', value per Item: ') %></h3>
+    <h3 class="box-title"><%= @item.name %>  <%= item_value(@item.value_in_cents, ', value per Item (in cents): ') %></h3>
   </div>
   <div class="box-body">
 

--- a/app/views/purchases/_purchase_form.html.erb
+++ b/app/views/purchases/_purchase_form.html.erb
@@ -26,7 +26,7 @@
 
     <div class="row">
       <div class="col-xs-8 col-md-6">
-        <%= f.input :amount_spent,
+        <%= f.input :amount_spent_in_cents,
                     wrapper: :vertical_input_group %>
       </div>
     </div>

--- a/app/views/purchases/_purchase_row.html.erb
+++ b/app/views/purchases/_purchase_row.html.erb
@@ -3,7 +3,7 @@
   <td><%= purchase_row.storage_location.name %></td>
   <td><%= purchase_row.line_items.total %></td>
   <td><%= purchase_row.line_items.size %></td>
-  <td><%= purchase_row.amount_spent %></td>
+  <td><%= purchase_row.amount_spent_in_cents %></td>
   <td class="text-right">
     <%= view_button_to purchase_path(purchase_row) %>
   </td>

--- a/db/migrate/20190516195732_change_item_value_to_integer.rb
+++ b/db/migrate/20190516195732_change_item_value_to_integer.rb
@@ -1,0 +1,9 @@
+class ChangeItemValueToInteger < ActiveRecord::Migration[5.2]
+  def self.up
+    change_column :items, :value, :integer, default: 0
+  end
+
+  def self.down
+    change_column :items, :value, :decimal, precision: 5, scale: 2, default: 0
+  end
+end

--- a/db/migrate/20190516200530_change_items_values_field_name.rb
+++ b/db/migrate/20190516200530_change_items_values_field_name.rb
@@ -1,0 +1,9 @@
+class ChangeItemsValuesFieldName < ActiveRecord::Migration[5.2]
+  def self.up
+    rename_column :items, :value, :value_in_cents
+  end
+
+  def self.down
+    rename_column :items, :value_in_cents, :value
+  end
+end

--- a/db/migrate/20190517141740_purchase_amount_spent_to_amount_spent_in_cents.rb
+++ b/db/migrate/20190517141740_purchase_amount_spent_to_amount_spent_in_cents.rb
@@ -1,0 +1,9 @@
+class PurchaseAmountSpentToAmountSpentInCents < ActiveRecord::Migration[5.2]
+  def self.up
+    rename_column :purchases, :amount_spent, :amount_spent_in_cents
+  end
+
+  def self.down
+    rename_column :items, :amount_spent_in_cents, :amount_spent
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_22_130439) do
+ActiveRecord::Schema.define(version: 2019_05_17_141740) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -204,7 +204,7 @@ ActiveRecord::Schema.define(version: 2019_04_22_130439) do
     t.integer "organization_id"
     t.boolean "active", default: true
     t.string "partner_key"
-    t.decimal "value", precision: 5, scale: 2, default: "0.0"
+    t.integer "value_in_cents", default: 0
     t.index ["organization_id"], name: "index_items_on_organization_id"
     t.index ["partner_key"], name: "index_items_on_partner_key"
   end
@@ -255,7 +255,7 @@ ActiveRecord::Schema.define(version: 2019_04_22_130439) do
     t.text "comment"
     t.integer "organization_id"
     t.integer "storage_location_id"
-    t.integer "amount_spent"
+    t.integer "amount_spent_in_cents"
     t.datetime "issued_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -34,14 +34,14 @@ RSpec.describe PurchasesController, type: :controller do
           purchase: { storage_location_id: storage_location.id,
                       purchased_from: "Google",
                       vendor_id: vendor.id,
-                      amount_spent: 10,
+                      amount_spent_in_cents: 10,
                       line_items: line_items }
         )
         expect(response).to redirect_to(purchases_path)
       end
 
       it "renders GET#new with error on failure" do
-        post :create, params: default_params.merge(purchase: { storage_location_id: nil, amount_spent: nil })
+        post :create, params: default_params.merge(purchase: { storage_location_id: nil, amount_spent_in_cents: nil })
         expect(response).to be_successful # Will render :new
         expect(flash[:error]).to match(/error/i)
       end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -11,7 +11,7 @@
 #  organization_id :integer
 #  active          :boolean          default(TRUE)
 #  partner_key     :string
-#  value           :decimal(5, 2)    default(0.0)
+#  value           :integer    default(0)
 #
 
 FactoryBot.define do

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -7,7 +7,7 @@
 #  comment             :text
 #  organization_id     :integer
 #  storage_location_id :integer
-#  amount_spent        :integer
+#  amount_spent_in_cents        :integer
 #  issued_at           :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
@@ -21,7 +21,7 @@ FactoryBot.define do
     storage_location
     organization { Organization.try(:first) || create(:organization) }
     issued_at { nil }
-    amount_spent { 10 }
+    amount_spent_in_cents { 1000 }
     vendor { Vendor.try(:first) || create(:vendor) }
 
     transient do

--- a/spec/features/distribution_spec.rb
+++ b/spec/features/distribution_spec.rb
@@ -75,9 +75,9 @@ RSpec.feature "Distributions", type: :feature do
 
   context "When creating a distribution and items have value" do
     before do
-      item1 = create(:item, value: 10.5)
+      item1 = create(:item, value_in_cents: 1050)
       item2 = create(:item)
-      item3 = create(:item, value: 1)
+      item3 = create(:item, value_in_cents: 100)
       @distribution1 = create(:distribution, :with_items, item: item1, agency_rep: "A Person", organization: @user.organization)
       create(:distribution, :with_items, item: item2, agency_rep: "A Person", organization: @user.organization)
       @distribution3 = create(:distribution, :with_items, item: item3, agency_rep: "A Person", organization: @user.organization)

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -7,7 +7,7 @@
 #  comment             :text
 #  organization_id     :integer
 #  storage_location_id :integer
-#  amount_spent        :integer
+#  amount_spent_in_cents        :integer
 #  issued_at           :datetime
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null

--- a/spec/models/vendor_spec.rb
+++ b/spec/models/vendor_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Vendor, type: :model do
     describe "volume" do
       it "retrieves the amount of product that has been bought from this vendor" do
         vendor = create(:vendor)
-        create(:purchase, :with_items, item_quantity: 10, amount_spent: 1, vendor: vendor)
+        create(:purchase, :with_items, item_quantity: 10, amount_spent_in_cents: 1, vendor: vendor)
         expect(vendor.volume).to eq(10)
       end
     end

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -341,9 +341,9 @@ RSpec.describe "Donations", type: :system do
 
   context "When donation items have value" do
     before do
-      item1 = create(:item, value: 1.25)
+      item1 = create(:item, value_in_cents: 125)
       item2 = create(:item)
-      item3 = create(:item, value: 2)
+      item3 = create(:item, value_in_cents: 200)
       @donation1 = create(:donation, :with_items, item: item1, source: Donation::SOURCES[:misc])
       create(:donation, :with_items, item: item2, source: Donation::SOURCES[:misc])
       create(:donation, :with_items, item: item3, source: Donation::SOURCES[:misc])

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Purchases", type: :system, js: true do
         select Vendor.first.business_name, from: "purchase_vendor_id"
         fill_in "purchase_line_items_attributes_0_quantity", with: "5"
         fill_in "purchase_issued_at", with: "01/01/2001"
-        fill_in "purchase_amount_spent", with: "10"
+        fill_in "purchase_amount_spent_in_cents", with: "10"
 
         expect do
           click_button "Save"
@@ -92,7 +92,7 @@ RSpec.describe "Purchases", type: :system, js: true do
         select Item.alphabetized.first.name, from: select_id
         text_id = page.find(:xpath, '//*[@id="purchase_line_items"]/div[2]/input[2]')[:id]
         fill_in text_id, with: "10"
-        fill_in "purchase_amount_spent", with: "10"
+        fill_in "purchase_amount_spent_in_cents", with: "10"
 
         expect do
           click_button "Save"

--- a/spec/system/vendor_system_spec.rb
+++ b/spec/system/vendor_system_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe "Vendor", type: :system do
   context "When vendor have purchases associated with them already" do
     before(:each) do
       @vendor = create(:vendor)
-      create(:purchase, :with_items, created_at: 1.day.ago, item_quantity: 10, amount_spent: 1, vendor: @vendor)
-      create(:purchase, :with_items, created_at: 1.week.ago, item_quantity: 15, amount_spent: 1, vendor: @vendor)
+      create(:purchase, :with_items, created_at: 1.day.ago, item_quantity: 10, amount_spent_in_cents: 1, vendor: @vendor)
+      create(:purchase, :with_items, created_at: 1.week.ago, item_quantity: 15, amount_spent_in_cents: 1, vendor: @vendor)
     end
 
     it "can have existing vendors show in the #index with some summary stats" do


### PR DESCRIPTION
Resolves #973 

### Description

Changing Item.value to be an integer, in cents. Also, changing Purchase.amount_spent to Purchase.amout_spent_in_cents. Some other changes were needed, please check all codes.

### Type of change

* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* This change requires a documentation update

First, I changed the `Item.value` to `Item.value_in_cents` and  I turned the column type from Decimal to Integer. Some changes were needed on the controllers, models, views, queries, and helpers to deal with those changes. I also changed some tests because they are using values in Decimals, so I multiply all the Item values per 100 to combine with Integer and `in_cents`.
To finish, I changed the `Purchase.amount_spent` to `Purchase.amount_spent_in_cents` and I make some updates on the controllers, models, and views to combine with the change.

### How Has This Been Tested?  

All the tests passed.  