### PR TITLE
Remove quantity items on audit #990

### DIFF
--- a/app/assets/javascripts/distributions_and_transfers.coffee
+++ b/app/assets/javascripts/distributions_and_transfers.coffee
@@ -6,7 +6,9 @@ new_option = (item, selected = false) ->
   content = "<option value=\"" + item.item_id + "\""
   content += " selected" if selected
   content += ">"
-  content += item.item_name + " (#{item.quantity})"
+  content += item.item_name
+  if( $('select.storage-location-source').attr('id') != 'audit_storage_location_id')
+    content += " (#{item.quantity})"
   content += "</option>\n"
   content
 

--- a/spec/features/audit_spec.rb
+++ b/spec/features/audit_spec.rb
@@ -214,5 +214,15 @@ RSpec.feature "Audit management", type: :feature do
       expect(page).not_to have_content("Delete Audit")
       # Actual Deletion(`delete :destroy`) Check is done in audits_controller_spec
     end
+
+    scenario "When creating an audit users can not see items quantity", js: true do
+      item = create(:item)
+      create(:storage_location, :with_items, item: item, item_quantity: 10)
+      visit url_prefix + "/audits/new"
+      first('.storage-location-source', minimum: 1).select_option
+      first('#audit_line_items_attributes_0_item_id', minimum: 1).select_option
+      first_item = find('#audit_line_items_attributes_0_item_id  > option:nth-child(2)').text
+      expect(first_item).to eq(item.name)
+    end
   end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a bug fix

-->

Resolves #990  <!--fill issue number-->

### Description
I remove line_items quantities from dropdown as request on issue #990 

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

I run all previous tests and add one to verify if the items quantity was not exhibit on page

### Screenshots

![image](https://user-images.githubusercontent.com/31314523/58025254-7081c700-7aea-11e9-80ee-e824a70f836b.png)

