### PR TITLE
#955 Add barcode "boop" test helper.

### DIFF
--- a/spec/features/distribution_spec.rb
+++ b/spec/features/distribution_spec.rb
@@ -201,7 +201,7 @@ RSpec.feature "Distributions", type: :feature do
     end
 
     scenario "a user can add items via scanning them in by barcode", js: true do
-      Barcode.boop_barcode(@existing_barcode.value)
+      Barcode.boop(@existing_barcode.value)
       # the form should update
       qty = page.find(:xpath, '//input[@id="distribution_line_items_attributes_0_quantity"]').value
 

--- a/spec/features/distribution_spec.rb
+++ b/spec/features/distribution_spec.rb
@@ -201,12 +201,7 @@ RSpec.feature "Distributions", type: :feature do
     end
 
     scenario "a user can add items via scanning them in by barcode", js: true do
-      pending "The JS doesn't appear to be executing in this correctly"
-      # I tried (3 Feb) to get this working and it still doesn't execute.
-      # The data gets put into the field correctly, tho it doesn't show up on
-      # the browser snapshot -- but the Ajax doesn't execute. Not sure why this is broken.
-      # enter the barcode into the barcode field
-      page.fill_in "_barcode-lookup-0", with: @existing_barcode.value + 13.chr
+      Barcode.boop_barcode(@existing_barcode.value)
       # the form should update
       qty = page.find(:xpath, '//input[@id="distribution_line_items_attributes_0_quantity"]').value
 

--- a/spec/support/barcode_helper.rb
+++ b/spec/support/barcode_helper.rb
@@ -1,5 +1,5 @@
 module Barcode
-  def self.boop_barcode(value, barcode_field = nil)
+  def self.boop(value, barcode_field = nil)
     barcode_field ||= get_last_empty_barcode_field
     Capybara.fill_in "_barcode-lookup-" + barcode_field.to_s, with: value + 10.chr
   end

--- a/spec/support/barcode_helper.rb
+++ b/spec/support/barcode_helper.rb
@@ -1,3 +1,22 @@
+module Barcode
+  def self.boop_barcode(value, barcode_field = nil)
+    barcode_field ||= get_last_empty_barcode_field
+    Capybara.fill_in "_barcode-lookup-" + barcode_field.to_s, with: value + 10.chr
+  end
+
+  def self.get_last_empty_barcode_field
+    last_empty_field = 0
+    last_empty_field += 1 until is_empty?(last_empty_field)
+    last_empty_field
+  end
+
+  def self.is_empty?(field)
+    Capybara.find("#_barcode-lookup-" + field.to_s).value == ""
+  rescue Capybara::ElementNotFound
+    false
+  end
+end
+
 def initialize_barcodes
   # create one pre-existing barcode associated with an item
   @existing_barcode = create(:barcode_item)

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe "Donations", type: :system, js: true do
 
         within "#donation_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-          Barcode.boop_barcode(@existing_barcode.value)
+          Barcode.boop(@existing_barcode.value)
         end
         # the form should update
         expect(page).to have_xpath('//input[@id="donation_line_items_attributes_0_quantity"]')
@@ -269,14 +269,14 @@ RSpec.describe "Donations", type: :system, js: true do
       it "Updates the line item when the same barcode is scanned twice", :js do
         within "#donation_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-          Barcode.boop_barcode(@existing_barcode.value)
+          Barcode.boop(@existing_barcode.value)
         end
 
         expect(page).to have_field "donation_line_items_attributes_0_quantity", with: @existing_barcode.quantity.to_s
 
         within "#donation_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-1']")
-          Barcode.boop_barcode(@existing_barcode.value)
+          Barcode.boop(@existing_barcode.value)
         end
 
         expect(page).to have_field "donation_line_items_attributes_0_quantity", with: (@existing_barcode.quantity * 2).to_s
@@ -287,7 +287,7 @@ RSpec.describe "Donations", type: :system, js: true do
         # enter a new barcode
         within "#donation_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-          Barcode.boop_barcode(new_barcode)
+          Barcode.boop(new_barcode)
         end
 
         # form finds no barcode and responds by prompting user to choose an item and quantity
@@ -327,7 +327,7 @@ RSpec.describe "Donations", type: :system, js: true do
           visit @url_prefix + "/donations/new"
           within "#donation_line_items" do
             expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-            Barcode.boop_barcode(@global_barcode.value)
+            Barcode.boop(@global_barcode.value)
           end
           expect(page).to have_xpath('//input[@id="donation_line_items_attributes_0_quantity"]')
           expect(page.has_select?("donation_line_items_attributes_0_item_id", selected: @item.name)).to eq(true)

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -256,7 +256,7 @@ RSpec.describe "Donations", type: :system, js: true do
 
         within "#donation_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-          fill_in "_barcode-lookup-0", with: @existing_barcode.value + 10.chr
+          Barcode.boop_barcode(@existing_barcode.value)
         end
         # the form should update
         expect(page).to have_xpath('//input[@id="donation_line_items_attributes_0_quantity"]')
@@ -269,14 +269,14 @@ RSpec.describe "Donations", type: :system, js: true do
       it "Updates the line item when the same barcode is scanned twice", :js do
         within "#donation_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-          fill_in "_barcode-lookup-0", with: @existing_barcode.value + 10.chr
+          Barcode.boop_barcode(@existing_barcode.value)
         end
 
         expect(page).to have_field "donation_line_items_attributes_0_quantity", with: @existing_barcode.quantity.to_s
 
         within "#donation_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-1']")
-          fill_in "_barcode-lookup-1", with: @existing_barcode.value + 10.chr
+          Barcode.boop_barcode(@existing_barcode.value)
         end
 
         expect(page).to have_field "donation_line_items_attributes_0_quantity", with: (@existing_barcode.quantity * 2).to_s
@@ -287,7 +287,7 @@ RSpec.describe "Donations", type: :system, js: true do
         # enter a new barcode
         within "#donation_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-          fill_in "_barcode-lookup-0", with: new_barcode + 10.chr
+          Barcode.boop_barcode(new_barcode)
         end
 
         # form finds no barcode and responds by prompting user to choose an item and quantity
@@ -327,7 +327,7 @@ RSpec.describe "Donations", type: :system, js: true do
           visit @url_prefix + "/donations/new"
           within "#donation_line_items" do
             expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-            fill_in "_barcode-lookup-0", with: @global_barcode.value + 10.chr
+            Barcode.boop_barcode(@global_barcode.value)
           end
           expect(page).to have_xpath('//input[@id="donation_line_items_attributes_0_quantity"]')
           expect(page.has_select?("donation_line_items_attributes_0_item_id", selected: @item.name)).to eq(true)

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -140,11 +140,10 @@ RSpec.describe "Purchases", type: :system, js: true do
       end
 
       it "a user can add items via scanning them in by barcode" do
-        pending "The JS doesn't appear to be executing in this correctly"
         # enter the barcode into the barcode field
         within "#purchase_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-          fill_in "_barcode-lookup-0", with: @existing_barcode.value + 13.chr
+          Barcode.boop_barcode(@existing_barcode.value)
         end
         # the form should update
         expect(page).to have_xpath('//input[@id="purchase_line_items_attributes_0_quantity"]')
@@ -157,7 +156,7 @@ RSpec.describe "Purchases", type: :system, js: true do
         pending "The JS doesn't appear to be executing in this correctly"
         within "#purchase_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-          fill_in "_barcode-lookup-0", with: @existing_barcode.value + 13.chr
+          Barcode.boop_barcode(@existing_barcode.value)
         end
 
         expect(page).to have_field "purchase_line_items_attributes_0_quantity", with: @existing_barcode.quantity.to_s
@@ -166,7 +165,7 @@ RSpec.describe "Purchases", type: :system, js: true do
 
         within "#purchase_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-1']")
-          fill_in "_barcode-lookup-1", with: @existing_barcode.value + 13.chr
+          Barcode.boop_barcode(@existing_barcode.value)
         end
 
         expect(page).to have_field "purchase_line_items_attributes_0_quantity", with: (@existing_barcode.quantity * 2).to_s

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe "Purchases", type: :system, js: true do
         # enter the barcode into the barcode field
         within "#purchase_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-          Barcode.boop_barcode(@existing_barcode.value)
+          Barcode.boop(@existing_barcode.value)
         end
         # the form should update
         expect(page).to have_xpath('//input[@id="purchase_line_items_attributes_0_quantity"]')
@@ -156,7 +156,7 @@ RSpec.describe "Purchases", type: :system, js: true do
         pending "The JS doesn't appear to be executing in this correctly"
         within "#purchase_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
-          Barcode.boop_barcode(@existing_barcode.value)
+          Barcode.boop(@existing_barcode.value)
         end
 
         expect(page).to have_field "purchase_line_items_attributes_0_quantity", with: @existing_barcode.quantity.to_s
@@ -165,7 +165,7 @@ RSpec.describe "Purchases", type: :system, js: true do
 
         within "#purchase_line_items" do
           expect(page).to have_xpath("//input[@id='_barcode-lookup-1']")
-          Barcode.boop_barcode(@existing_barcode.value)
+          Barcode.boop(@existing_barcode.value)
         end
 
         expect(page).to have_field "purchase_line_items_attributes_0_quantity", with: (@existing_barcode.quantity * 2).to_s


### PR DESCRIPTION
Resolves #955 

### Description
This PR introduces the `Barcode` test helper module, which includes the `boop_barcode` method. This method extracts the "boop" logic; it also defaults to finding the last empty barcode field. The field can be supplied as the second argument, but leaving it blank will use `Barcode.get_last_empty_barcode_field` to find the empty field.

(Added bonus: this fixed two tests that was using `13.chr` instead of `10.chr`, so this PR also removes the `pending` tag for that test as well.)

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

There's no testing on the helper itself, but all current tests are green, including one that utilizes the default `get_last_empty_barcode_field` to fill in multiple fields.