### PR TITLE
730 year to date

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -52,11 +52,11 @@ class Partner < ApplicationRecord
   end
 
   def quantity_year_to_date
-    self.distributions
+    distributions
       .includes(items: :line_items)
-      .where("line_items.created_at > ?", Date.today.beginning_of_year)
+      .where("line_items.created_at > ?", Time.zone.today.beginning_of_year)
       .references(items: :line_items).map do |distribution|
-        distribution.items.map(&:line_items)
-      end.flatten.sum(&:quantity)
+      distribution.items.map(&:line_items)
+    end.flatten.sum(&:quantity)
   end
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -50,4 +50,13 @@ class Partner < ApplicationRecord
   def register_on_partnerbase
     UpdateDiaperPartnerJob.perform_async(id)
   end
+
+  def quantity_year_to_date
+    self.distributions
+      .includes(items: :line_items)
+      .where("line_items.created_at > ?", Date.today.beginning_of_year)
+      .references(items: :line_items).map do |distribution|
+        distribution.items.map(&:line_items)
+      end.flatten.sum(&:quantity)
+  end
 end

--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -28,6 +28,10 @@ class DistributionPdf
     text @distribution.distributed_at
     move_down 10
 
+    text "Items Received Year-to-Date", style: :bold
+    text @distribution.partner.quantity_year_to_date.to_s
+    move_down 10
+
     text "Comments:", style: :bold
     text @distribution.comment
 

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -82,4 +82,23 @@ RSpec.describe Partner, type: :model do
       Partner.import_csv(csv, organization.id)
     end
   end
+
+  describe '#quantity_year_to_date' do
+    let(:partner) { create(:partner) }
+    before do
+      create(:distribution, :with_items, partner: partner)
+      create(:distribution, :with_items, partner: partner)
+      create(:distribution, :with_items, partner: partner)
+    end
+
+    it "includes all item quantities for the given year" do
+      expect(partner.quantity_year_to_date).to eq(300)
+    end
+
+    it "does not include quantities from last year" do
+      LineItem.last
+        .update_column(:created_at, Date.today.beginning_of_year - 20)
+      expect(partner.quantity_year_to_date).to eq(200)
+    end
+  end
 end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -96,8 +96,7 @@ RSpec.describe Partner, type: :model do
     end
 
     it "does not include quantities from last year" do
-      LineItem.last
-        .update_column(:created_at, Date.today.beginning_of_year - 20)
+      LineItem.last.update(created_at: Time.zone.today.beginning_of_year - 20)
       expect(partner.quantity_year_to_date).to eq(200)
     end
   end


### PR DESCRIPTION
Resolves #730 

### Description

- Add a method to sum line items quantities (year to date) on a partner instance.
- Display it on a distribution PDF


### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

- automated + manual testing

### Screenshots

![1](https://user-images.githubusercontent.com/1443346/58374373-97813400-7f02-11e9-962d-8b5fc33e58c3.png)

### Other

The tickets indicated the amount should be displayed at the bottom of the PDF document. Too much magic involved to get something looking nice at the bottom so I added it at the top. I hope that's an acceptable adjustment.

