### PR TITLE
#894 - Moves admin dashboard feature spec to system specs

### DIFF
--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -112,7 +112,8 @@
           <ul class="users-list clearfix">
             <% @recent_organizations.each do |org| %>
             <li>
-              <%= image_tag(org&.logo_path) %>
+              <%= image_tag(org&.logo) 
+              %>
               <%= link_to org.name, admin_organization_path(org), class: "users-list-name" %>
               <span class="users-list-date"><%= time_ago_in_words(org.created_at) %></span>
             </li>

--- a/spec/system/admin/dashboard_system_spec.rb
+++ b/spec/system/admin/dashboard_system_spec.rb
@@ -1,13 +1,15 @@
-RSpec.feature "Dashboard" do
+RSpec.describe "Dashboard", type: :system, js: true do
+  subject { admin_dashboard_path }
+  
   context "When the super admin user also has an organization assigned" do
     before do
       @super_admin.organization = @organization
       @super_admin.save
       sign_in(@super_admin)
+      visit subject
     end
 
-    scenario "the side and top nav both have a link to return to their organization dashboard" do
-      visit admin_dashboard_path
+    it "displays a link to return to their organization dashboard on both the side and top nav" do
       within "section.sidebar" do
         expect(page).to have_xpath("//li/a[@href='#{dashboard_path(@organization.short_name)}']")
       end
@@ -22,10 +24,10 @@ RSpec.feature "Dashboard" do
       @super_admin.organization = nil
       @super_admin.save
       sign_in(@super_admin)
+      visit subject
     end
 
-    scenario "the side and top navs DO NOT have a link to the organization dashboard" do
-      visit admin_dashboard_path
+    it "DOES NOT have a link to the organization dashboard in the side and top navs" do
       within "section.sidebar" do
         expect(page).not_to have_xpath("//li/a[@href='#{dashboard_path(@organization.short_name)}']")
       end

--- a/spec/system/admin/dashboard_system_spec.rb
+++ b/spec/system/admin/dashboard_system_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Dashboard", type: :system, js: true do
   subject { admin_dashboard_path }
-  
+
   context "When the super admin user also has an organization assigned" do
     before do
       @super_admin.organization = @organization


### PR DESCRIPTION
Closes #894

This also discovered a bug in the site admin dashboard, where the org logos were being referenced incorrectly. It fixes that bug.

Otherwise it's just a trivial spec conversion.