### PR TITLE
Add pry remote gem for test and develop env to easily test while runn…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ group :development, :test do
   gem "fakeredis", require: "fakeredis/rspec"
   gem "guard-rspec"
   gem "pry-rails"
+  gem "pry-remote"
   gem "pry-nav"
   gem 'rb-readline', '~> 0.5.3'
   gem "rspec-rails", "~> 3.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,9 @@ GEM
       pry (>= 0.9.10, < 0.13.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    pry-remote (0.1.8)
+      pry (~> 0.9)
+      slop (~> 3.0)
     public_suffix (3.0.3)
     puma (3.12.0)
     rack (2.0.7)
@@ -399,6 +402,7 @@ GEM
       skylight-core (= 3.1.2)
     skylight-core (3.1.2)
       activesupport (>= 4.2.0)
+    slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -513,6 +517,7 @@ DEPENDENCIES
   prawn-rails
   pry-nav
   pry-rails
+  pry-remote
   puma
   rails (~> 5.2.2)
   rails-controller-testing


### PR DESCRIPTION
Pry remote is a dependency that makes testing applications that run in the background easier.

You can drop a `binding.pry_remote` in your code and then form the console run `bundle exec pry-remote` and you get the same goodies available via `binding.pry`. Since we've started using puma-dev in diaper and partner, this dependency will make it easier for us to perform debugging.

More info [here](https://github.com/Mon-Ouie/pry-remote)

This dependency will be added to partner as well (as part of the families PR)