### PR TITLE
Remove recent from diaper driver calculation

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -3,7 +3,9 @@ class DashboardController < ApplicationController
   respond_to :html, :js
 
   def index
-    @recent_donations = current_organization.donations.includes(:line_items).during(helpers.selected_range).recent
+    @donations = current_organization.donations.includes(:line_items).during(helpers.selected_range)
+    @diaper_drives_donations = @donations.by_source(:diaper_drive)
+    @recent_donations = @donations.recent
     @recent_purchases = current_organization.purchases.includes(:line_items).during(helpers.selected_range).recent
     @recent_distributions = current_organization.distributions.includes(:line_items).during(helpers.selected_range).recent
     @total_inventory = current_organization.total_inventory
@@ -12,7 +14,7 @@ class DashboardController < ApplicationController
 
     # calling .recent on recent donations by manufacturers will only count the last 3 donations
     # which may not make sense when calculating total count using a date range
-    @recent_donations_from_manufacturers = current_organization.donations.includes(:line_items).during(helpers.selected_range).by_source(:manufacturer)
+    @recent_donations_from_manufacturers = @donations.by_source(:manufacturer)
     @top_manufacturers = current_organization.manufacturers.by_donation_count
   end
 end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -140,7 +140,7 @@
               </div>
             </div>
             <div class="box-body text-center float-center">
-              <h3 class="text-center"><%= @recent_donations.by_source(:diaper_drive).count %> Diaper Drives <%= display_interval %> for a total of <%= number_with_delimiter(@recent_donations.by_source(:diaper_drive).sum { |d| d.line_items.total }) %> items collected</h3>
+              <h3 class="text-center"><%= @diaper_drives_donations.count %> Diaper Drives <%= display_interval %> for a total of <%= number_with_delimiter(@diaper_drives_donations.sum { |d| d.line_items.total }) %> items collected</h3>
             </div>
             <div class="box-body">
               <div class="box-body text-center float-center">

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -40,5 +40,9 @@ FactoryBot.define do
         instance.line_items << build(:line_item, quantity: evaluator.item_quantity, item: item)
       end
     end
+
+    trait :diaper_drive do
+      source { Donation::SOURCES[:diaper_drive] }
+    end
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -1,0 +1,42 @@
+RSpec.feature "Dashboard", type: :feature do
+  let!(:diaper_donation_on_today) do
+    create(:donation, :diaper_drive, issued_at: Time.current)
+  end
+  let!(:diaper_donation_on_last_month) do
+    create(:donation, :diaper_drive, issued_at: Time.current - 1.month)
+  end
+  let!(:diaper_donation_on_last_yesterday) do
+    create(:donation, :diaper_drive, issued_at: Time.current.yesterday)
+  end
+  let!(:diaper_donation_on_last_week) do
+    create(:donation, :diaper_drive, issued_at: Time.current.last_week)
+  end
+
+  before do
+    sign_in(@user)
+  end
+
+  scenario 'Filter Diaper drive by date', js: true do
+    visit root_path
+
+    expect(page).to have_content("4 Diaper Drives year to date for")
+
+    filter_by_date('today')
+    expect(page).to have_content("1 Diaper Drives today for")
+
+    filter_by_date('last_month')
+    expect(page).to have_content("1 Diaper Drives last month for")
+
+    filter_by_date('yesterday')
+    expect(page).to have_content("1 Diaper Drives yesterday for")
+
+    filter_by_date('week_to_date')
+    expect(page).to have_content("2 Diaper Drives week to date for")
+  end
+
+  def filter_by_date(option)
+    within '#dashboard_filter_interval' do
+      find("option[value=#{option}]").click
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1029 

### Description
The Diaper drive calculation was coming from recent_donations, so was getting only 3.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Acceptance Test plus manual
