### PR TITLE
Create rspec helper for flash testing and update tests.

### DIFF
--- a/spec/controllers/admin/barcode_items_controller_spec.rb
+++ b/spec/controllers/admin/barcode_items_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Admin::BarcodeItemsController, type: :controller do
         expect do
           delete :destroy, params: { id: other_barcode.to_param }
         end.to change { BarcodeItem.count }.by(-1)
-        expect(flash.to_h).not_to have_key("error")
+        expect(response).not_to have_error
       end
 
       it "allows deletion of a global barcode" do
@@ -21,7 +21,7 @@ RSpec.describe Admin::BarcodeItemsController, type: :controller do
         expect do
           delete :destroy, params: { id: other_barcode.to_param }
         end.to change { BarcodeItem.count }.by(-1)
-        expect(flash.to_h).not_to have_key("error")
+        expect(response).not_to have_error
       end
     end
   end

--- a/spec/controllers/admin_controller_spec.rb
+++ b/spec/controllers/admin_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AdminController, type: :controller do
         sign_in(u)
         get :dashboard
         expect(response).to redirect_to(dashboard_path)
-        expect(flash[:error].size).not_to be_zero
+        expect(response).to have_error
       end
     end
   end

--- a/spec/controllers/barcode_items_controller_spec.rb
+++ b/spec/controllers/barcode_items_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe BarcodeItemsController, type: :controller do
         other_barcode = create(:barcode_item, organization_id: other_org.id, global: false)
         delete :destroy, params: default_params.merge(id: other_barcode.to_param)
         expect(response).not_to be_successful
-        expect(flash[:error]).to match(/permission/)
+        expect(response).to have_error(/permission/)
       end
 
       it "disallows a non-superadmin to delete a global barcode" do
@@ -74,7 +74,7 @@ RSpec.describe BarcodeItemsController, type: :controller do
         global_barcode = create(:global_barcode_item)
         delete :destroy, params: default_params.merge(id: global_barcode.to_param)
         expect(response).not_to be_successful
-        expect(flash[:error]).to match(/permission/)
+        expect(response).to have_error(/permission/)
       end
 
       it "redirects to the index" do

--- a/spec/controllers/diaper_drive_participants_controller_spec.rb
+++ b/spec/controllers/diaper_drive_participants_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe DiaperDriveParticipantsController, type: :controller do
       it "flash error" do
         post :create, xhr: true, params: default_params.merge(diaper_drive_participant: { name: "test" })
         expect(response).to be_successful
-        expect(flash[:error]).to match(/try again/i)
+        expect(response).to have_error(/try again/i)
       end
     end
 
@@ -66,13 +66,13 @@ RSpec.describe DiaperDriveParticipantsController, type: :controller do
         post :create, params: default_params.merge(diaper_drive_participant: { business_name: "businesstest",
                                                                                contact_name: "test", email: "123@mail.ru" })
         expect(response).to redirect_to(diaper_drive_participants_path)
-        expect(flash[:notice]).to match(/added!/i)
+        expect(response).to have_notice(/added!/i)
       end
 
       it "flash error" do
         post :create, xhr: true, params: default_params.merge(diaper_drive_participant: { name: "test" })
         expect(response).to be_successful
-        expect(flash[:error]).to match(/try again/i)
+        expect(response).to have_error(/try again/i)
       end
     end
 

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe DistributionsController, type: :controller do
       it "renders #new again on failure, with notice" do
         post :create, params: default_params.merge(distribution: { comment: nil, partner_id: nil, storage_location_id: nil })
         expect(response).to be_successful
-        expect(flash[:error]).to match(/error/i)
+        expect(response).to have_error(/error/i)
       end
     end
 

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DonationsController, type: :controller do
       it "renders GET#new with error on failure" do
         post :create, params: default_params.merge(donation: { storage_location_id: nil, donation_site_id: nil, source: nil })
         expect(response).to be_successful # Will render :new
-        expect(flash[:error]).to match(/error/i)
+        expect(response).to have_error(/error/i)
       end
     end
 

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe OrganizationsController, type: :controller do
 
       it "denies access and redirects with an error" do
         expect(subject).to have_http_status(:redirect)
-        expect(flash[:error]).to be_present
+        expect(subject).to have_error
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe OrganizationsController, type: :controller do
 
       it "denies access" do
         expect(subject).to have_http_status(:redirect)
-        expect(flash[:error]).to be_present
+        expect(subject).to have_error
       end
     end
   end

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PurchasesController, type: :controller do
       it "renders GET#new with error on failure" do
         post :create, params: default_params.merge(purchase: { storage_location_id: nil, amount_spent_in_cents: nil })
         expect(response).to be_successful # Will render :new
-        expect(flash[:error]).to match(/error/i)
+        expect(response).to have_error(/error/i)
       end
     end
 

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe TransfersController, type: :controller do
         post :create, params: { organization_id: @organization.short_name, transfer: { from_id: nil, to_id: nil } }
         expect(response).to be_successful # Will render :new
         expect(response).to render_template("new")
-        expect(flash[:error]).to match(/error/i)
+        expect(response).to have_error(/error/i)
       end
     end
 

--- a/spec/controllers/vendors_controller_spec.rb
+++ b/spec/controllers/vendors_controller_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe VendorsController, type: :controller do
       it "flash error" do
         post :create, xhr: true, params: default_params.merge(vendor: { name: "test" })
         expect(response).to be_successful
-        expect(flash[:error]).to match(/try again/i)
+        expect(response).to have_error(/try again/i)
       end
     end
 
@@ -67,13 +67,13 @@ RSpec.describe VendorsController, type: :controller do
                                                              contact_name: "test",
                                                              email: "123@mail.ru" })
         expect(response).to redirect_to(vendors_path)
-        expect(flash[:notice]).to match(/added!/i)
+        expect(response).to have_notice(/added!/i)
       end
 
       it "flash error" do
         post :create, xhr: true, params: default_params.merge(vendor: { name: "test" })
         expect(response).to be_successful
-        expect(flash[:error]).to match(/try again/i)
+        expect(response).to have_error(/try again/i)
       end
     end
 

--- a/spec/support/csv_import_shared_example.rb
+++ b/spec/support/csv_import_shared_example.rb
@@ -12,7 +12,7 @@ RSpec.shared_examples "csv import" do
     end
 
     it "presents a flash notice message" do
-      expect(subject.request.flash[:notice]).to eq "#{model_class.name.underscore.humanize.pluralize} were imported successfully!"
+      expect(subject).to have_notice "#{model_class.name.underscore.humanize.pluralize} were imported successfully!"
     end
   end
 
@@ -24,7 +24,7 @@ RSpec.shared_examples "csv import" do
     end
 
     it "presents a flash error message" do
-      expect(subject.request.flash[:error]).to eq "No file was attached!"
+      expect(subject).to have_error "No file was attached!"
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.shared_examples "csv import" do
     end
 
     it "presents a flash error message" do
-      expect(subject.request.flash[:error]).to eq "Check headers in file!"
+      expect(subject).to have_error "Check headers in file!"
     end
   end
 end

--- a/spec/support/matchers/have_flash.rb
+++ b/spec/support/matchers/have_flash.rb
@@ -1,0 +1,32 @@
+require 'rspec/expectations'
+
+RSpec::Matchers.define :have_flash do |expected = {}|
+  match do
+    expected_value = expected.each_value.first
+    expected_key = expected.each_key.first
+
+    if expected_value.is_a? Regexp
+      flash[expected_key] =~ expected_value
+    elsif expected_value.is_a? String
+      flash[expected_key] == expected_value
+    else
+      raise ArgumentError, "Value of argument must be either a string or regular expression."
+    end
+  end
+end
+
+[:error, :notice, :alert, :success].each do |type|
+  type_symbol = "have_#{type}".to_sym
+
+  RSpec::Matchers.define type_symbol do |expected = //|
+    match do
+      if expected.is_a? Regexp
+        flash[type] =~ expected
+      elsif expected.is_a? String
+        flash[type] == expected
+      else
+        raise ArgumentError, "Value of argument must be either a string or regular expression."
+      end
+    end
+  end
+end

--- a/spec/support/matchers/have_flash.rb
+++ b/spec/support/matchers/have_flash.rb
@@ -18,6 +18,9 @@ end
 [:error, :notice, :alert, :success].each do |type|
   type_symbol = "have_#{type}".to_sym
 
+  # Default case checks the presence of any message of the given type,
+  # but if no message exists, flash[type] is `nil`, which causes
+  # the matcher to return `false`.
   RSpec::Matchers.define type_symbol do |expected = //|
     match do
       if expected.is_a? Regexp


### PR DESCRIPTION
Resolves #1019 

### Description
This PR creates a custom RSpec matcher that checks flash messages and the related flash types (notice, alert, etc.). The `has_flash` method takes an options hash with the flash type as the key and the flash message as the value, while the others (`has_alert`, `has_notice`, `has_error`, and `has_success`) simply take the flash message.

As a side note, the current implementation of this only checks the `flash` object, so the value passed to `expect` is irrelevant as long as it's in the correct context. In the tests, I've generally passed the `response` object (or whatever was already there) for readability, but in other specs this could be `page`, `subject`, `flash`, `"whatever you want"`, and so on. That said, this doesn't check that the flash message is actually _rendered_; it only checks that the `flash` hash has the associated message.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

These helpers currently pass the present tests and will fail under normal failing conditions.