### PR TITLE
Add distribution quantity and package size fields to items

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,7 +37,6 @@ class ItemsController < ApplicationController
 
   def update
     @item = current_organization.items.find(params[:id])
-    binding.pry
     if @item.update(item_params)
       redirect_to items_path, notice: "#{@item.name} updated!"
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -37,6 +37,7 @@ class ItemsController < ApplicationController
 
   def update
     @item = current_organization.items.find(params[:id])
+    binding.pry
     if @item.update(item_params)
       redirect_to items_path, notice: "#{@item.name} updated!"
     else

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -59,7 +59,7 @@ class ItemsController < ApplicationController
   private
 
   def item_params
-    params.require(:item).permit(:name, :partner_key, :value)
+    params.require(:item).permit(:name, :partner_key, :value, :package_size, :distribution_quantity)
   end
 
   def filter_params(parameters = nil)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -103,7 +103,6 @@ class Item < ApplicationRecord
   end
 
   def default_quantity
-    # TODO: actual logic for calculating and letting users configure this calculation
-    50
+    distribution_quantity || 50
   end
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -22,4 +22,8 @@ class LineItem < ApplicationRecord
   def value_per_line_item
     item.value_in_cents * quantity
   end
+
+  def package_count
+    quantity / item.package_size.to_f if item.package_size
+  end
 end

--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -11,11 +11,11 @@ class DistributionPdf
       text organization.address, align: :right
       text organization.email, align: :right
     end
-    data = [["Items Received", "Value/item", "Total value", "Quantity"]]
+    data = [["Items Received", "Value/item", "Total value", "Quantity", "Packages"]]
     data += @distribution.line_items.sorted.map do |c|
-      [c.item.name, item_value(c.item.value_in_cents), item_value(c.value_per_line_item), c.quantity]
+      [c.item.name, item_value(c.item.value_in_cents), item_value(c.value_per_line_item), c.quantity, c.package_count]
     end
-    data += [["", "", "", ""], ["Total Items Received", "", item_value(@distribution.value_per_itemizable), @distribution.line_items.total]]
+    data += [["", "", "", "", ""], ["Total Items Received", "", item_value(@distribution.value_per_itemizable), @distribution.line_items.total, ""]]
 
     move_down 55
 
@@ -51,23 +51,24 @@ class DistributionPdf
       row(0).borders = [:bottom]
       row(0).border_width = 2
       row(0).font_style = :bold
+      row(0).size = 10
       row(0).column(1..-1).borders = %i(bottom left)
 
       # Total Items footer row
       row(-1).borders = [:top]
       row(-1).font_style = :bold
-      row(-1).column(2..-1).borders = %i(top left)
-      row(-1).column(2..-1).border_left_color = "aaaaaa"
+      row(-1).column(1..-1).borders = %i(top left)
+      row(-1).column(1..-1).border_left_color = "aaaaaa"
 
       # Footer spacing row
       row(-2).borders = [:top]
       row(-2).padding = [2, 0, 2, 0]
 
-      column(0).width = 250
+      column(0).width = 190
 
       # Quantity column
-      column(1..3).row(1..-3).borders = [:left]
-      column(1..3).row(1..-3).border_left_color = "aaaaaa"
+      column(1..-1).row(1..-3).borders = [:left]
+      column(1..-1).row(1..-3).border_left_color = "aaaaaa"
       column(1).style align: :right
     end
 

--- a/app/views/distributions/_distribution_item_row.html.erb
+++ b/app/views/distributions/_distribution_item_row.html.erb
@@ -1,5 +1,6 @@
 <tr>
   <td><%= distribution_item_row.quantity %></td>
+  <td><%= distribution_item_row.package_count %></td>
   <td><%= item_value(distribution_item_row.item.value_in_cents) %></td>
   <td><%= item_value(distribution_item_row.value_per_line_item) %></td>
   <td><%= distribution_item_row.item.name %></td>

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -38,6 +38,7 @@
             <table class="table table-hover">
               <tr>
                 <th><b>Quantity</b></th>
+                <th><b>Package count</b></th>
                 <th><b>Value per item</b></th>
                 <th><b>Total value</b></th>
                 <th><b>Item</b></th>

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -9,6 +9,12 @@
       <span class="input-group-addon"><i class="fa fa-money"></i></span>
       <%= f.input_field :value_in_cents, class: "form-control" %>
     <% end %>
+    <%= f.input :name, label: "Distribution quantity", wrapper: :vertical_input_group do %>
+      <%= f.input_field :distribution_quantity, class: "form-control" %>
+    <% end %>
+    <%= f.input :name, label: "Package size", wrapper: :vertical_input_group do %>
+      <%= f.input_field :package_size, class: "form-control" %>
+    <% end %>
 
     <%= submit_button %>
   <% end %>

--- a/db/migrate/20190604192016_add_distribution_quantity_and_package_size_to_items.rb
+++ b/db/migrate/20190604192016_add_distribution_quantity_and_package_size_to_items.rb
@@ -1,0 +1,6 @@
+class AddDistributionQuantityAndPackageSizeToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_column :items, :package_size, :integer
+    add_column :items, :distribution_quantity, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_20_033128) do
+ActiveRecord::Schema.define(version: 2019_06_04_192016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,7 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "adjustments", id: :serial, force: :cascade do |t|
+  create_table "adjustments", force: :cascade do |t|
     t.integer "organization_id"
     t.integer "storage_location_id"
     t.text "comment"
@@ -70,7 +70,7 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["user_id"], name: "index_audits_on_user_id"
   end
 
-  create_table "barcode_items", id: :serial, force: :cascade do |t|
+  create_table "barcode_items", force: :cascade do |t|
     t.string "value"
     t.integer "barcodeable_id"
     t.integer "quantity"
@@ -94,7 +94,7 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.string "partner_key"
   end
 
-  create_table "diaper_drive_participants", id: :serial, force: :cascade do |t|
+  create_table "diaper_drive_participants", force: :cascade do |t|
     t.string "contact_name"
     t.string "email"
     t.string "phone"
@@ -109,10 +109,10 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["latitude", "longitude"], name: "index_diaper_drive_participants_on_latitude_and_longitude"
   end
 
-  create_table "distributions", id: :serial, force: :cascade do |t|
+  create_table "distributions", force: :cascade do |t|
     t.text "comment"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "storage_location_id"
     t.integer "partner_id"
     t.integer "organization_id"
@@ -123,11 +123,11 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["storage_location_id"], name: "index_distributions_on_storage_location_id"
   end
 
-  create_table "donation_sites", id: :serial, force: :cascade do |t|
+  create_table "donation_sites", force: :cascade do |t|
     t.string "name"
     t.string "address"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "organization_id"
     t.float "latitude"
     t.float "longitude"
@@ -135,11 +135,11 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["organization_id"], name: "index_donation_sites_on_organization_id"
   end
 
-  create_table "donations", id: :serial, force: :cascade do |t|
+  create_table "donations", force: :cascade do |t|
     t.string "source"
     t.integer "donation_site_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "storage_location_id"
     t.text "comment"
     t.integer "organization_id"
@@ -179,12 +179,12 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
-  create_table "inventory_items", id: :serial, force: :cascade do |t|
+  create_table "inventory_items", force: :cascade do |t|
     t.integer "storage_location_id"
     t.integer "item_id"
     t.integer "quantity", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
   end
 
   create_table "item_requests", force: :cascade do |t|
@@ -197,21 +197,23 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["request_id"], name: "index_item_requests_on_request_id"
   end
 
-  create_table "items", id: :serial, force: :cascade do |t|
+  create_table "items", force: :cascade do |t|
     t.string "name"
     t.string "category"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "barcode_count"
     t.integer "organization_id"
     t.boolean "active", default: true
     t.string "partner_key"
     t.integer "value_in_cents", default: 0
+    t.integer "package_size"
+    t.integer "distribution_quantity"
     t.index ["organization_id"], name: "index_items_on_organization_id"
     t.index ["partner_key"], name: "index_items_on_partner_key"
   end
 
-  create_table "line_items", id: :serial, force: :cascade do |t|
+  create_table "line_items", force: :cascade do |t|
     t.integer "quantity"
     t.integer "item_id"
     t.integer "itemizable_id"
@@ -229,7 +231,7 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["organization_id"], name: "index_manufacturers_on_organization_id"
   end
 
-  create_table "organizations", id: :serial, force: :cascade do |t|
+  create_table "organizations", force: :cascade do |t|
     t.string "name"
     t.string "short_name"
     t.string "email"
@@ -249,11 +251,11 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["short_name"], name: "index_organizations_on_short_name"
   end
 
-  create_table "partners", id: :serial, force: :cascade do |t|
+  create_table "partners", force: :cascade do |t|
     t.string "name"
     t.string "email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "organization_id"
     t.integer "status", default: 0
     t.boolean "send_reminders", default: false, null: false
@@ -288,11 +290,11 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["status"], name: "index_requests_on_status"
   end
 
-  create_table "storage_locations", id: :serial, force: :cascade do |t|
+  create_table "storage_locations", force: :cascade do |t|
     t.string "name"
     t.string "address"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.integer "organization_id"
     t.float "latitude"
     t.float "longitude"
@@ -300,7 +302,7 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["organization_id"], name: "index_storage_locations_on_organization_id"
   end
 
-  create_table "transfers", id: :serial, force: :cascade do |t|
+  create_table "transfers", force: :cascade do |t|
     t.integer "from_id"
     t.integer "to_id"
     t.string "comment"
@@ -310,7 +312,7 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.index ["organization_id"], name: "index_transfers_on_organization_id"
   end
 
-  create_table "users", id: :serial, force: :cascade do |t|
+  create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"

--- a/spec/features/item_spec.rb
+++ b/spec/features/item_spec.rb
@@ -28,13 +28,6 @@ RSpec.feature "Item management", type: :feature do
     expect(page.find(".alert")).to have_content "updated"
   end
 
-  scenario "User leaves the distribution quantity field empty" do
-    item = create(:item)
-    visit url_prefix + "/items/#{item.id}/edit"
-    click_button "Save"
-    expect(item.reload.distribution_quantity).to be_nil
-  end
-
   scenario "User sets a distribution quantity and package size" do
     item = create(:item)
     visit url_prefix + "/items/#{item.id}/edit"
@@ -44,8 +37,8 @@ RSpec.feature "Item management", type: :feature do
 
     find("[data-item-id=#{item.id}] [href$=edit]").click
 
-    expect(page).to have_selector("input[value='75']")
-    expect(page).to have_selector("input[value='50']")
+    expect(page).to have_selector("input#item_distribution_quantity[value='75']")
+    expect(page).to have_selector("input#package_size[value='50']")
   end
 
   scenario "User updates an existing item with empty attributes" do

--- a/spec/features/item_spec.rb
+++ b/spec/features/item_spec.rb
@@ -38,13 +38,14 @@ RSpec.feature "Item management", type: :feature do
   scenario "User sets a distribution quantity and package size" do
     item = create(:item)
     visit url_prefix + "/items/#{item.id}/edit"
-    fill_in "Distribution quantity", with: 75
-    fill_in "Package size", with: "50"
+    fill_in "item_distribution_quantity", with: "75"
+    fill_in "item_package_size", with: "50"
     click_button "Save"
 
     find("[data-item-id=#{item.id}] [href$=edit]").click
-    expect(page).to have_content("75")
-    expect(page).to have_content("50")
+
+    expect(page).to have_selector("input[value='75']")
+    expect(page).to have_selector("input[value='50']")
   end
 
   scenario "User updates an existing item with empty attributes" do

--- a/spec/features/item_spec.rb
+++ b/spec/features/item_spec.rb
@@ -28,6 +28,25 @@ RSpec.feature "Item management", type: :feature do
     expect(page.find(".alert")).to have_content "updated"
   end
 
+  scenario "User leaves the distribution quantity field empty" do
+    item = create(:item)
+    visit url_prefix + "/items/#{item.id}/edit"
+    click_button "Save"
+    expect(item.reload.distribution_quantity).to be_nil
+  end
+
+  scenario "User sets a distribution quantity and package size" do
+    item = create(:item)
+    visit url_prefix + "/items/#{item.id}/edit"
+    fill_in "Distribution quantity", with: 75
+    fill_in "Package size", with: "50"
+    click_button "Save"
+
+    find("[data-item-id=#{item.id}] [href$=edit]").click
+    expect(page).to have_content("75")
+    expect(page).to have_content("50")
+  end
+
   scenario "User updates an existing item with empty attributes" do
     item = create(:item)
     visit url_prefix + "/items/#{item.id}/edit"

--- a/spec/features/item_spec.rb
+++ b/spec/features/item_spec.rb
@@ -38,7 +38,7 @@ RSpec.feature "Item management", type: :feature do
     find("[data-item-id=#{item.id}] [href$=edit]").click
 
     expect(page).to have_selector("input#item_distribution_quantity[value='75']")
-    expect(page).to have_selector("input#package_size[value='50']")
+    expect(page).to have_selector("input#item_package_size[value='50']")
   end
 
   scenario "User updates an existing item with empty attributes" do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -174,4 +174,11 @@ RSpec.describe Item, type: :model do
       expect(create(:item, distribution_quantity: 75).default_quantity).to eq(75)
     end
   end
+
+  describe "distribution_quantity and package size" do
+    it "have nil values if an empty string is passed" do
+      expect(create(:item, distribution_quantity: '').distribution_quantity).to be_nil
+      expect(create(:item, package_size: '').package_size).to be_nil
+    end
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -164,4 +164,14 @@ RSpec.describe Item, type: :model do
       end
     end
   end
+
+  describe "default_quantity" do
+    it "should return 50 if column is not set" do
+      expect(create(:item).default_quantity).to eq(50)
+    end
+
+    it "should return the value of distribution_quantity if it is set" do
+      expect(create(:item, distribution_quantity: 75).default_quantity).to eq(75)
+    end
+  end
 end

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -30,6 +30,20 @@ RSpec.describe LineItem, type: :model do
     end
   end
 
+  describe "package_count" do
+    it "is equal to the quanity divided by the package_size" do
+      item = create(:item, package_size: 10)
+      line_item = create(:line_item, quantity: 100, item_id: item.id)
+      expect(line_item.package_count).to eq(10)
+    end
+
+    it "is nil if there is no package_size" do
+      item = create(:item)
+      line_item = create(:line_item, quantity: 100, item_id: item.id)
+      expect(line_item.package_count).to be_nil
+    end
+  end
+
   describe "Scopes >" do
     describe "->active" do
       let!(:active_item) { create(:item, :active) }


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1039  <!--fill issue number-->
Paired with @jesus here at Recurse Center.

### Description
- Adds new fields, distribution quantity and package size, to items
- Allows assignment of these fields through the item form
- Updates `default_quantity` method to look at distribution quantity
- Displays number of packages dispersed on the distribution show page and pdf

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
- Added tests to line item and item models, added test to items feature spec
- Manually clicked through app and created PDF to verify changes
- Note: had to shrink text/column size on the PDF to fit the "Packages" column

### Screenshots
<img width="784" alt="Screen Shot 2019-06-05 at 3 57 42 PM" src="https://user-images.githubusercontent.com/5439589/58988051-d2ab1f00-87ae-11e9-9c6f-8810816a85a5.png">
<img width="882" alt="Screen Shot 2019-06-05 at 4 26 08 PM" src="https://user-images.githubusercontent.com/5439589/58988105-e9ea0c80-87ae-11e9-874c-3b85448f2571.png">
<img width="888" alt="Screen Shot 2019-06-05 at 4 26 22 PM" src="https://user-images.githubusercontent.com/5439589/58988111-ee162a00-87ae-11e9-9b29-d1736f4cc44d.png">


