### PR TITLE
adds the SimpleCov gem to the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ yarn-debug.log*
 
 # Ignore master key for decrypting credentials and more.
 /config/master.key
+
+# Ignore SimpleCov assets
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ group :test do
   gem "launchy"
   gem 'webdrivers', '~> 3.0'
   gem "rails-controller-testing"
+  gem 'simplecov'
   gem "webmock", "~> 3.5"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,7 @@ GEM
       actionmailer (>= 4.1.0)
       devise (>= 4.0.0)
     diff-lcs (1.3)
+    docile (1.3.1)
     dotenv (2.5.0)
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
@@ -211,6 +212,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
+    json (2.2.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     libv8 (3.16.14.19)
@@ -398,6 +400,11 @@ GEM
     simple_form (4.1.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     skylight (3.1.2)
       skylight-core (= 3.1.2)
     skylight-core (3.1.2)
@@ -528,6 +535,7 @@ DEPENDENCIES
   sass-rails
   sidekiq
   simple_form
+  simplecov
   skylight
   spring
   spring-watcher-listen

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,9 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'simplecov'
+SimpleCov.start 'rails'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again
-->

Somewhat related to #1024  <!--fill issue number-->

### Description
To help keep track of the test coverage we are currently working to improve, I think it's a good idea to have the SimpleCov gem on the project, so we can have a better idea of the areas we need to focus on.
   
List any dependencies that are required for this change. (gems, js libraries, etc.)
- `gem install 'simplecov'`

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
Here's how the simplecov navbar looks right now: 
![image](https://user-images.githubusercontent.com/33486409/59129646-c73d2c80-8943-11e9-88dd-ff6763d0161a.png)

As you can see, this gem can be of great assistance for developers in the future looking to help increase the test coverage of the project.