### PR TITLE
Allow users to use normal currency formats for purchases.

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -26,7 +26,7 @@ class PurchasesController < ApplicationController
       load_form_collections
       @purchase.line_items.build if @purchase.line_items.count.zero?
       flash[:error] = "There was an error starting this purchase, try again?"
-      Rails.logger.error "[!] PurchasesController#create ERROR: #{@purchase.errors}"
+      Rails.logger.error "[!] PurchasesController#create ERROR: #{@purchase.errors.full_messages}"
       render action: :new
     end
   end
@@ -70,6 +70,12 @@ class PurchasesController < ApplicationController
 
   private
 
+  def clean_purchase_amount
+    return nil unless params[:purchase][:amount_spent_in_cents]
+
+    params[:purchase][:amount_spent_in_cents] = params[:purchase][:amount_spent_in_cents].gsub(/[$,.]/, "")
+  end
+
   def load_form_collections
     @storage_locations = current_organization.storage_locations
     @items = current_organization.items.alphabetized
@@ -77,6 +83,7 @@ class PurchasesController < ApplicationController
   end
 
   def purchase_params
+    clean_purchase_amount
     params = compact_line_items
     params.require(:purchase).permit(:comment, :amount_spent_in_cents, :purchased_from, :storage_location_id, :issued_at, :vendor_id, line_items_attributes: %i(id item_id quantity _destroy)).merge(organization: current_organization)
   end

--- a/app/views/purchases/_purchase_form.html.erb
+++ b/app/views/purchases/_purchase_form.html.erb
@@ -27,6 +27,7 @@
     <div class="row">
       <div class="col-xs-8 col-md-6">
         <%= f.input :amount_spent_in_cents,
+                    label: "Purchase Total",
                     wrapper: :vertical_input_group %>
       </div>
     </div>

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -29,21 +29,34 @@ RSpec.describe PurchasesController, type: :controller do
       let(:line_items) { [create(:line_item)] }
       let(:vendor) { create(:vendor, organization: @organization) }
 
-      it "redirects to GET#edit on success" do
-        post :create, params: default_params.merge(
-          purchase: { storage_location_id: storage_location.id,
-                      purchased_from: "Google",
-                      vendor_id: vendor.id,
-                      amount_spent_in_cents: 10,
-                      line_items: line_items }
-        )
-        expect(response).to redirect_to(purchases_path)
+      context "on success" do
+        let(:purchase) do
+          { storage_location_id: storage_location.id,
+            purchased_from: "Google",
+            vendor_id: vendor.id,
+            amount_spent_in_cents: 10,
+            line_items: line_items }
+        end
+
+        it "redirects to GET#edit" do
+          post :create, params: default_params.merge(purchase: purchase)
+          expect(response).to redirect_to(purchases_path)
+        end
+
+        it "accepts :amount_spent_in_cents with dollar signs, commas, and periods" do
+          formatted_purchase = purchase.merge(amount_spent_in_cents: "$1,000.54")
+          post :create, params: default_params.merge(purchase: formatted_purchase)
+
+          expect(Purchase.last.amount_spent_in_cents).to eq 100_054
+        end
       end
 
-      it "renders GET#new with error on failure" do
-        post :create, params: default_params.merge(purchase: { storage_location_id: nil, amount_spent_in_cents: nil })
-        expect(response).to be_successful # Will render :new
-        expect(flash[:error]).to match(/error/i)
+      context "on failure" do
+        it "renders GET#new with error" do
+          post :create, params: default_params.merge(purchase: { storage_location_id: nil, amount_spent_in_cents: nil })
+          expect(response).to be_successful # Will render :new
+          expect(flash[:error]).to match(/error/i)
+        end
       end
     end
 


### PR DESCRIPTION
Resolves #1022 

### Description
This PR allows users to input normal currency values when making purchases by stripping periods, commas, and dollar signs from input before saving. The draw back is that it doesn't actually _check_ that it's a valid input (i.e. "123$4..345" would still work), but I would imagine this is not a use case we're concerned with.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
This PR includes tests that involve input with dollar signs, commas, and periods. These tests, as well as existing tests, all still pass.
