### PR TITLE
Add tests for Admin::OrganizationsController

### DIFF
--- a/spec/controllers/admin/organizations_controller_spec.rb
+++ b/spec/controllers/admin/organizations_controller_spec.rb
@@ -61,6 +61,17 @@ RSpec.describe Admin::OrganizationsController, type: :controller do
         end
       end
     end
+
+    describe "DELETE #destroy" do
+      let(:organization) { create(:organization) }
+
+      context "with a valid organization id" do
+        it "redirects to #index" do
+          delete :destroy, params: { id: organization.id }
+          expect(response).to redirect_to(admin_organizations_path)
+        end
+      end
+    end
   end
 =begin
 

--- a/spec/controllers/admin/organizations_controller_spec.rb
+++ b/spec/controllers/admin/organizations_controller_spec.rb
@@ -91,9 +91,18 @@ RSpec.describe Admin::OrganizationsController, type: :controller do
 
     describe "GET #edit" do
       let!(:organization) { create(:organization) }
-      
+
       it "returns http success" do
         get :edit, params: { id: organization.id }
+        expect(response).to be_successful
+      end
+    end
+
+    describe "GET #show" do
+      let!(:organization) { create(:organization) }
+
+      it "returns http success" do
+        get :show, params: { id: organization.id }
         expect(response).to be_successful
       end
     end

--- a/spec/controllers/admin/organizations_controller_spec.rb
+++ b/spec/controllers/admin/organizations_controller_spec.rb
@@ -88,6 +88,15 @@ RSpec.describe Admin::OrganizationsController, type: :controller do
         end
       end
     end
+
+    describe "GET #edit" do
+      let!(:organization) { create(:organization) }
+      
+      it "returns http success" do
+        get :edit, params: { id: organization.id }
+        expect(response).to be_successful
+      end
+    end
   end
 =begin
 

--- a/spec/controllers/admin/organizations_controller_spec.rb
+++ b/spec/controllers/admin/organizations_controller_spec.rb
@@ -16,9 +16,25 @@ RSpec.describe Admin::OrganizationsController, type: :controller do
     end
 
     describe "POST #create" do
-      it "redirects" do
-        post :create, params: { organization: attributes_for(:organization) }
-        expect(response).to be_redirect
+      let(:valid_organization_params) { attributes_for(:organization) }
+
+      context "with valid params" do
+        it "redirects to #index" do
+          post :create, params: { organization: valid_organization_params }
+
+          expect(response).to redirect_to(admin_organizations_path)
+        end
+      end
+
+      context "with invalid params" do
+        let(:invalid_params) { valid_organization_params.merge(name: nil) }
+
+        it "renders #create with an error message" do
+          post :create, params: { organization: invalid_params }
+
+          expect(subject).to render_template("new")
+          expect(flash[:error]).to be_present
+        end
       end
     end
 

--- a/spec/controllers/admin/organizations_controller_spec.rb
+++ b/spec/controllers/admin/organizations_controller_spec.rb
@@ -28,6 +28,39 @@ RSpec.describe Admin::OrganizationsController, type: :controller do
         expect(response).to be_successful
       end
     end
+
+    describe "PATCH #update" do
+      let(:organization) { create(:organization, name: "Original Name") }
+      subject do
+        patch :update,
+              params: default_params.merge(
+                id: organization.id,
+                organization: { name: updated_name }
+              )
+      end
+
+      context "with a valid update" do
+        let(:updated_name) { "Updated Name" }
+
+        it "redirects to #index" do
+          expect(subject).to have_http_status(:redirect)
+          expect(subject).to redirect_to(admin_organizations_path)
+        end
+      end
+
+      context "with an invalid update" do
+        let(:updated_name) { nil }
+
+        it "returns http success" do
+          expect(subject).to be_successful
+        end
+
+        it "redirects to #edit with an error message" do
+          expect(subject).to render_template("edit")
+          expect(flash[:error]).to be_present
+        end
+      end
+    end
   end
 =begin
 


### PR DESCRIPTION
### Description
Ref #1024 - it expands test coverage for `Admin::OrganizationsController`

Adds tests for the following methods that had no tests:
- update
- delete
- edit
- show

Adds additional test for failure scenario for method that already had one test for success:
- create
   
### Type of change

* Test update

### How Has This Been Tested?

`bundle exec rake` has been run successfully on these test changes.
