### PR TITLE
Update README with "diaper_dev" as db name

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This app uses Ruby version 2.6.2, indicated in `/.ruby-version` and `Gemfile`, w
 If you don't have Yarn installed, you can install with Homebrew on macOS `brew install yarn` or visit [https://yarnpkg.com/en/docs/install](https://yarnpkg.com/en/docs/install). Be sure to run `yarn install` after installing Yarn. NOTE: It's possible that Node version 12 may cause you problems, see issue #751. Node 10 or 11 seem to be fine. 
 
 ### Database Configuration
-This app uses PostgreSQL for all environments. You'll also need to create the `dev` and `test` databases, the app is expecting them to be named `diaper_development` and `diaper_test`, respectively. This should all be handled with `rails db:setup`.
+This app uses PostgreSQL for all environments. You'll also need to create the `dev` and `test` databases, the app is expecting them to be named `diaper_dev` and `diaper_test`, respectively. This should all be handled with `rails db:setup`.
 
 ### Create your .env with database credentials
 Be sure to create a `.env` file in the root of the app that includes the following lines (change to whatever is appropriate for your system):


### PR DESCRIPTION
### Description
The development database name in `database.yml` is "diaper_dev", but the README identifies it as "diaper_development". This commit updates the README to match the value in `database.yml`.

### Type of change
* Documentation update

### How Has This Been Tested?
Passes `bundle exec rake`!