### PR TITLE
#1042 - Show devise flash error on sign_in page

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,7 +3,7 @@
 </div>
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 
-  <%= render "shared/flash"  %>
+  <%= render partial: "shared/flash"  %>
 
   <div class="form-inputs">
     <%= f.input :email, label: "E-mail:", autofocus: true, wrapper: :vertical_input_group do %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -10,7 +10,7 @@
           <span class="input-group-addon"><i class="fa fa-envelope"></i></span>
           <%= f.input_field :email, class: "form-control" %>
         <% end %>    
-			<%= f.input :email, label: "Password:", wrapper: :vertical_input_group do %>
+			<%= f.input :password, label: "Password:", wrapper: :vertical_input_group do %>
           <span class="input-group-addon"><i class="fa fa-lock"></i></span>
           <%= f.input_field :password, class: "form-control" %>
         <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,9 +2,9 @@
 	<h2>Sign In</h2>
 </div>
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <% flash.each do |key, value| %>
-      <div class="alert alert-error" role="alert"><%= value %></div>
-  <% end %>
+
+  <%= render 'shared/flash' %>
+
   <div class="form-inputs">
 			<%= f.input :email, label: "E-mail:", autofocus: true, wrapper: :vertical_input_group do %>
           <span class="input-group-addon"><i class="fa fa-envelope"></i></span>
@@ -16,15 +16,15 @@
         <% end %>
     <%= f.input :remember_me, label: " Remember me", as: :boolean if devise_mapping.rememberable? %>
   </div>
-<div class="medium-offset-3 medium-6">
+  <div class="medium-offset-3 medium-6">
 
-  <div class="form-actions">
-    <%= f.button :submit, "Log in" %>
+    <div class="form-actions">
+      <%= f.button :submit, "Log in" %>
+    </div>
+
+  <%= render "devise/shared/links" %>
   </div>
 <% end %>
-
-<%= render "devise/shared/links" %>
-</div>
 <script>
     $(document).ready(function() {
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -2,6 +2,9 @@
 	<h2>Sign In</h2>
 </div>
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <% flash.each do |key, value| %>
+      <div class="alert alert-error" role="alert"><%= value %></div>
+  <% end %>
   <div class="form-inputs">
 			<%= f.input :email, label: "E-mail:", autofocus: true, wrapper: :vertical_input_group do %>
           <span class="input-group-addon"><i class="fa fa-envelope"></i></span>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,26 +3,25 @@
 </div>
 <%= simple_form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 
-  <%= render 'shared/flash' %>
+  <%= render "shared/flash"  %>
 
   <div class="form-inputs">
-			<%= f.input :email, label: "E-mail:", autofocus: true, wrapper: :vertical_input_group do %>
-          <span class="input-group-addon"><i class="fa fa-envelope"></i></span>
-          <%= f.input_field :email, class: "form-control" %>
-        <% end %>    
-			<%= f.input :password, label: "Password:", wrapper: :vertical_input_group do %>
-          <span class="input-group-addon"><i class="fa fa-lock"></i></span>
-          <%= f.input_field :password, class: "form-control" %>
-        <% end %>
+    <%= f.input :email, label: "E-mail:", autofocus: true, wrapper: :vertical_input_group do %>
+      <span class="input-group-addon"><i class="fa fa-envelope"></i></span>
+      <%= f.input_field :email, class: "form-control" %>
+    <% end %>    
+    <%= f.input :password, label: "Password:", wrapper: :vertical_input_group do %>
+      <span class="input-group-addon"><i class="fa fa-lock"></i></span>
+      <%= f.input_field :password, class: "form-control" %>
+    <% end %>
     <%= f.input :remember_me, label: " Remember me", as: :boolean if devise_mapping.rememberable? %>
   </div>
   <div class="medium-offset-3 medium-6">
-
     <div class="form-actions">
       <%= f.button :submit, "Log in" %>
     </div>
 
-  <%= render "devise/shared/links" %>
+    <%= render "devise/shared/links" %>
   </div>
 <% end %>
 <script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -76,12 +76,7 @@
   <div class="content-wrapper">
     <!-- Content Header (Page header) -->
     <div id="flash-message-container">
-      <% flash.each do |key, value| %>
-        <div class="<%= flash_class(key) %> alert-dismissible">
-          <a href="#" class="close" data-dismiss="alert" aria-label="close" style="text-decoration: none;"><%= fa_icon('times') %></a>
-          <%= value %>
-        </div>
-      <% end %>
+      <%= render partial: "shared/flash"  %>
     </div>
     <%= yield %>
     <!-- /.content -->

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |key, message| %>
+  <div class="<%= flash_class(key) %>" role="alert">
+    <%= message %>
+  </div>
+<% end %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,5 +1,6 @@
 <% flash.each do |key, message| %>
-  <div class="<%= flash_class(key) %>" role="alert">
-    <%= message %>
+  <div class="<%= flash_class(key) %> alert-dismissible" role="alert">
+    <a href="#" class="close" data-dismiss="alert" aria-label="close" style="text-decoration: none;"><%= fa_icon('times') %></a>
+    <%= value %>
   </div>
 <% end %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |key, message| %>
   <div class="<%= flash_class(key) %> alert-dismissible" role="alert">
     <a href="#" class="close" data-dismiss="alert" aria-label="close" style="text-decoration: none;"><%= fa_icon('times') %></a>
-    <%= value %>
+    <%= message %>
   </div>
 <% end %>

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -38,12 +38,6 @@ FactoryBot.define do
     password_confirmation { "password" }
     organization { Organization.try(:first) || create(:organization) }
 
-    factory :user_no_org do
-      name { "User No Org" }
-      sequence(:email, 100) { |n| "person_no_org#{n}@example.com" }
-      organization_id { nil }
-    end
-
     factory :organization_admin do
       name { "Very Organized Admin" }
       organization_admin { true }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -38,6 +38,12 @@ FactoryBot.define do
     password_confirmation { "password" }
     organization { Organization.try(:first) || create(:organization) }
 
+    factory :user_no_org do
+      name { "User No Org" }
+      sequence(:email, 100) { |n| "person_no_org#{n}@example.com" }
+      organization_id { nil }
+    end
+
     factory :organization_admin do
       name { "Very Organized Admin" }
       organization_admin { true }

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -1,0 +1,42 @@
+RSpec.feature "User sign in form", type: :feature do
+  before do
+    visit new_user_session_path
+  end
+
+  after do
+    Capybara.reset_sessions!
+  end
+
+  context "when user are invalid" do
+    scenario "shows invalid credentials alert" do
+      fill_in "E-mail", with: 'invalid_username'
+      fill_in "Password", with: 'invalid_password'
+      click_button "Log in"
+
+      expect(page).to have_content('Invalid Email or password.')
+    end
+  end
+
+  context "when users are valid and has organization" do
+    scenario "redirects to user's dashboard" do
+      fill_in "E-mail", with: @user.email
+      fill_in "Password", with: @user.password
+      click_button "Log in"
+
+      expect(page).to have_current_path(
+        dashboard_path(organization_id: @user.organization)
+      )
+    end
+  end
+
+  context "when users are valid and do not has organization" do
+    scenario "redirects to home " do
+      user_no_org = create(:user_no_org)
+      fill_in "E-mail", with: user_no_org.email
+      fill_in "Password", with: user_no_org.password
+      click_button "Log in"
+
+      expect(page).to have_current_path(root_path)
+    end
+  end
+end

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -3,11 +3,7 @@ RSpec.feature "User sign in form", type: :feature do
     visit new_user_session_path
   end
 
-  after do
-    Capybara.reset_sessions!
-  end
-
-  context "when user are invalid" do
+  context "when users are invalid" do
     scenario "shows invalid credentials alert" do
       fill_in "E-mail", with: 'invalid_username'
       fill_in "Password", with: 'invalid_password'
@@ -17,7 +13,7 @@ RSpec.feature "User sign in form", type: :feature do
     end
   end
 
-  context "when users are valid and has organization" do
+  context "when users are valid and belong to an organization" do
     scenario "redirects to user's dashboard" do
       fill_in "E-mail", with: @user.email
       fill_in "Password", with: @user.password
@@ -29,7 +25,7 @@ RSpec.feature "User sign in form", type: :feature do
     end
   end
 
-  context "when users are valid and do not has organization" do
+  context "when users are valid and don't belong to an organization" do
     scenario "redirects to home " do
       user_no_org = create(:user_no_org)
       fill_in "E-mail", with: user_no_org.email

--- a/spec/features/sign_in_spec.rb
+++ b/spec/features/sign_in_spec.rb
@@ -27,7 +27,7 @@ RSpec.feature "User sign in form", type: :feature do
 
   context "when users are valid and don't belong to an organization" do
     scenario "redirects to home " do
-      user_no_org = create(:user_no_org)
+      user_no_org = create(:user, organization: nil)
       fill_in "E-mail", with: user_no_org.email
       fill_in "Password", with: user_no_org.password
       click_button "Log in"


### PR DESCRIPTION
Resolves #1042 

### Description

On Sign in page, Devise uses flash to show the errors message. This wasn't being shown.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Go to `/users/sign_in` path.
Try to sign in with an invalid user.

### Screenshots

![image](https://user-images.githubusercontent.com/1998649/59290240-79c80480-8c4e-11e9-8b05-f9666188b394.png)

