### PR TITLE
Adds shoulda matchers gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -87,6 +87,7 @@ group :test do
   gem "launchy"
   gem 'webdrivers', '~> 3.0'
   gem "rails-controller-testing"
+  gem 'shoulda-matchers'
   gem 'simplecov'
   gem "webmock", "~> 3.5"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -392,6 +392,8 @@ GEM
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
     shellany (0.0.1)
+    shoulda-matchers (4.1.0)
+      activesupport (>= 4.2.0)
     sidekiq (5.2.5)
       connection_pool (~> 2.2, >= 2.2.2)
       rack (>= 1.5.0)
@@ -533,6 +535,7 @@ DEPENDENCIES
   rspec-rails (~> 3.8)
   rubocop
   sass-rails
+  shoulda-matchers
   sidekiq
   simple_form
   simplecov

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -31,13 +31,9 @@
 #
 
 RSpec.describe User, type: :model do
-  context "Validations >" do
-    it "requires a name" do
-      expect(build(:user, name: nil)).not_to be_valid
-    end
-    it "requires an email" do
-      expect(build(:user, email: nil)).not_to be_valid
-    end
+  describe "Validations >" do
+    it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_presence_of :email }
   end
 
   context "Methods >" do

--- a/spec/support/shoulda_matchers.rb
+++ b/spec/support/shoulda_matchers.rb
@@ -1,0 +1,6 @@
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
Related to #1024 

### Description
To help keep specs cleaner and make then more concise and readable, and even easer to test validations and associations. If these changes are accepted, I'll submit a PR with new changes to refactor the model specs.
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

- `gem 'shoulda-matchers'`

### Type of change

- New feature (non-breaking change which adds functionality)

### Example:

```ruby
# Before
  describe "Validations >" do
    it "requires a name" do
      expect(build(:user, name: nil)).not_to be_valid
    end
    it "requires an email" do
      expect(build(:user, email: nil)).not_to be_valid
    end 
  end
```
```ruby
# After
  describe "Validations >" do
    it { is_expected.to validate_presence_of :name }
    it { is_expected.to validate_presence_of :email }
  end
```
