### PR TITLE
Allow users to use dollar signs, commas, and periods when inputting Item value.

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -58,8 +58,15 @@ class ItemsController < ApplicationController
 
   private
 
+  def clean_purchase_amount
+    return nil unless params[:item][:value_in_cents]
+
+    params[:item][:value_in_cents] = params[:item][:value_in_cents].gsub(/[$,.]/, "")
+  end
+
   def item_params
-    params.require(:item).permit(:name, :partner_key, :value, :package_size, :distribution_quantity)
+    clean_purchase_amount
+    params.require(:item).permit(:name, :partner_key, :value_in_cents, :package_size, :distribution_quantity)
   end
 
   def filter_params(parameters = nil)

--- a/spec/controllers/items_controller_spec.rb
+++ b/spec/controllers/items_controller_spec.rb
@@ -42,6 +42,55 @@ RSpec.describe ItemsController, type: :controller do
         expect(subject).to redirect_to(items_path)
       end
     end
+
+    describe "POST #create" do
+      let(:item_params) do
+        {
+          item: {
+            name: "Really Good Item",
+            partner_key: create(:base_item).partner_key,
+            value_in_cents: 1001,
+            package_size: 5,
+            distribution_quantity: 30
+          }
+        }
+      end
+
+      context "with valid params" do
+        it "should create an item" do
+          expect do
+            post :create, params: default_params.merge(item_params)
+          end.to change { Item.count }.by(1)
+        end
+
+        it "should accept params with dollar signs, periods, and commas" do
+          item_params["value_in_cents"] = "$5,432.10"
+          post :create, params: default_params.merge(item_params)
+
+          expect(response).not_to have_error
+        end
+
+        it "should redirect to the item page" do
+          post :create, params: default_params.merge(item_params)
+
+          expect(response).to redirect_to items_path
+          expect(response).to have_notice
+        end
+      end
+
+      context "with invalid params" do
+        let(:bad_params) do
+          { item: { bad: "params" } }
+        end
+
+        it "should show an error" do
+          post :create, params: default_params.merge(bad_params)
+
+          expect(response).to have_error
+        end
+      end
+    end
+
     context "Looking at a different organization" do
       let(:object) { create(:item, organization: create(:organization)) }
       include_examples "requiring authorization"

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -11,7 +11,7 @@
 #  organization_id :integer
 #  active          :boolean          default(TRUE)
 #  partner_key     :string
-#  value           :integer    default(0)
+#  value_in_cents  :integer          default(0)
 #
 
 FactoryBot.define do


### PR DESCRIPTION
Resolves #1052 

### Description
This PR allows users to use normal currency representations (i.e. using $, comma and period seperators) in the `Items` controller. This is similar to the implementation to #1045.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

This PR includes tests specific to this change. It also adds some tests for more general coverage, since there were _no tests at all_ for the create action on the Items controller. I don't know if there were errors caught before, but this endpoint likely was failing since, prior to this PR, the `item_params` was using `:value` instead of `:value_in_cents`, so presumably any new items wouldn't have values.
