### PR TITLE
Fix Distribution Show Page

### DIFF
--- a/app/views/distributions/_distribution_item_row.html.erb
+++ b/app/views/distributions/_distribution_item_row.html.erb
@@ -1,7 +1,7 @@
 <tr>
-  <td><%= distribution_item_row.quantity %></td>
-  <td><%= distribution_item_row.package_count %></td>
+  <td><%= distribution_item_row.item.name %></td>
   <td><%= item_value(distribution_item_row.item.value_in_cents) %></td>
   <td><%= item_value(distribution_item_row.value_per_line_item) %></td>
-  <td><%= distribution_item_row.item.name %></td>
+  <td><%= distribution_item_row.quantity %></td>
+  <td><%= distribution_item_row.package_count %></td>
 </tr>

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -37,11 +37,11 @@
           <div class="box-body table-responsive no-padding">
             <table class="table table-hover">
               <tr>
-                <th><b>Quantity</b></th>
-                <th><b>Package count</b></th>
+                <th><b>Item</b></th>
                 <th><b>Value per item</b></th>
                 <th><b>Total value</b></th>
-                <th><b>Item</b></th>
+                <th><b>Quantity</b></th>
+                <th><b>Package count</b></th>
               </tr>
               <%= render partial: "distribution_item_row", collection: @line_items %>
               <%= render partial: "distribution_item_total" %>

--- a/spec/features/distribution_spec.rb
+++ b/spec/features/distribution_spec.rb
@@ -167,7 +167,7 @@ RSpec.feature "Distributions", type: :feature do
 
         expect(page).to have_css "td"
         item_row = find("td", text: diaper_type).find(:xpath, '..')
-        expect(item_row).to have_content("4 " + diaper_type)
+        expect(item_row).to have_content("#{diaper_type} 4")
       end
     end
   end


### PR DESCRIPTION
Resolves #1068

### Description
Reorder the distribution show page, so the table order matches the generated PDF

### Type of change
* Bug fix

### How Has This Been Tested?

Access `/diaper_bank/distributions/:id`

### Screenshots
![image](https://user-images.githubusercontent.com/7442967/59940505-409f4980-9431-11e9-9859-091836b75af2.png)

