### PR TITLE
#737 Partner Summary Stats

### DIFF
--- a/app/assets/stylesheets/_colors.scss
+++ b/app/assets/stylesheets/_colors.scss
@@ -7,5 +7,8 @@ $off-white: #F9F9F9;
 $blue: #005e74;
 $light-blue: #CEE8F1;
 $lighter-blue: #EDFAFF;
-$error: #ad2000;
-$success: #256600;
+
+$action: #31b0d5;
+$error: #c9302c;
+$success: #449d44;
+$caution: orange;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,7 +20,9 @@
 
  //Use @import in order to process SCSS variables
  // import reusable variables
+ @import 'colors';
  @import 'base/_variables';
+ @import 'resources/*';
 
  // import other stylesheets after variables
 @import 'AdminLTE';
@@ -30,3 +32,4 @@
 @import 'admin_layout';
 @import 'audits';
 @import 'modal-dialog';
+@import 'admin_lte_overrides';

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,4 +32,3 @@
 @import 'admin_layout';
 @import 'audits';
 @import 'modal-dialog';
-@import 'admin_lte_overrides';

--- a/app/assets/stylesheets/resources/partners.scss
+++ b/app/assets/stylesheets/resources/partners.scss
@@ -1,0 +1,46 @@
+ul#partner-status {
+  list-style: none;
+  display: inline;
+  margin: 0;
+  padding: 0;
+
+  li {
+    display: inline;
+    margin: 0;
+    padding: 0;
+    margin-right: 2rem;
+
+    a.filtering {
+      font-weight: bold;
+      border-bottom: 1px dotted;
+    }
+    &:first-of-type {
+      margin-left: 0.5rem;
+    }
+
+    &:last-of-type {
+      border-left: 3px double gray;
+      padding-left: 1rem;
+    }
+  }
+}
+
+i.fa {
+  &.bg-partner {
+    &-uninvited {
+      color: $dark-grey;
+    }
+    &-invited {
+      color: $action;
+    }
+    &-awaiting_review {
+      color: $caution;
+    }
+    &-approved {
+      color: $success;
+    }
+    &-error {
+      color: $error;
+    }
+  }
+}

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -5,7 +5,8 @@ class PartnersController < ApplicationController
   include Importable
 
   def index
-    @partners = current_organization.partners.order(:name)
+    @unfiltered_partners_for_statuses = Partner.where(organization: current_organization)
+    @partners = Partner.where(organization: current_organization).class_filter(filter_params).order(:name)
   end
 
   def create
@@ -82,4 +83,11 @@ class PartnersController < ApplicationController
   def partner_params
     params.require(:partner).permit(:name, :email)
   end
+
+  def filter_params
+    return {} unless params.key?(:filters)
+
+    params.require(:filters).slice(:by_status)
+  end
+
 end

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -89,5 +89,4 @@ class PartnersController < ApplicationController
 
     params.require(:filters).slice(:by_status)
   end
-
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -28,7 +28,7 @@ class Partner < ApplicationRecord
     where(organization: organization)
       .order(:name)
   }
-  
+
   include Filterable
   scope :by_status, ->(status) {
     where(status: status.to_sym)

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -28,6 +28,11 @@ class Partner < ApplicationRecord
     where(organization: organization)
       .order(:name)
   }
+  
+  include Filterable
+  scope :by_status, ->(status) {
+    where(status: status.to_sym)
+  }
 
   # better to extract this outside of the model
   def self.import_csv(csv, organization_id)

--- a/app/views/partners/_statuses.html.erb
+++ b/app/views/partners/_statuses.html.erb
@@ -1,0 +1,24 @@
+<% icon_mapping = { 
+    "uninvited": 'ban',
+    "invited": 'envelope',
+    "awaiting_review": 'question-circle',
+    "approved": 'check-circle',
+    "error": 'exclamation-circle'
+  }.with_indifferent_access
+  current_filtered_status = params.dig(:filters, :by_status)
+%>
+
+<ul id="partner-status">
+  <% partners.statuses.each do |status, _| 
+    selector = (status + "?").to_sym
+    partner_count = partners.select(&selector).size %>
+  <li>
+    <%= fa_icon icon_mapping[status] || '', class: "bg-partner-#{status}  " %>
+    <%= link_to_unless partner_count.zero?, "#{partner_count} #{status.humanize}", partners_path(filters: { by_status: status }), class: ("filtering" if status == current_filtered_status) %>
+  </li>
+  <% end %>
+  <li>
+    <%= fa_icon 'list-alt' %>
+    <%= link_to "#{partners.size} Total", partners_path, class: ("filtering" if current_filtered_status.nil?) %>
+  </li>
+</ul>

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -26,6 +26,8 @@
       </section><!-- /#filters -->
     </div><!-- /.box-header -->
     <div class="box-body">
+      <%= render partial: "statuses", object: @unfiltered_partners_for_statuses, as: :partners %>
+      
       <div class="row">
         <div class="col-xs-12">
           <div class="box-body table-responsive no-padding">

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -28,6 +28,16 @@ RSpec.describe Partner, type: :model do
       expect(build(:partner, email: "boooooooooo")).not_to be_valid
     end
   end
+
+  describe "Filters" do
+    describe "by_status" do
+      it "yields partners with the provided status" do
+        create(:partner, status: :invited)
+        create(:partner, status: :approved)
+        expect(Partner.by_status('invited').count).to eq(1)
+      end
+    end
+  end
   # context "Callbacks >" do
   #   describe "when DIAPER_PARTNER_URL is present" do
   #     let(:diaper_partner_url) { "http://diaper.partner.io" }

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -6,22 +6,37 @@ RSpec.describe "Partner management", type: :system, js: true do
 
   context "When a user views the index page" do
     before(:each) do
-      @second = create(:partner, name: "Bcd")
-      @first = create(:partner, name: "Abc")
-      @third = create(:partner, :approved, name: "Cde")
+      @uninvited = create(:partner, name: "Bcd", status: :uninvited)
+      @invited = create(:partner, name: "Abc", status: :invited)
+      @approved = create(:partner, :approved, name: "Cde", status: :approved)
       visit url_prefix + "/partners"
     end
 
     it "the partner agency names are in alphabetical order" do
       expect(page).to have_css("table tr", count: 5)
-      expect(page.find(:xpath, "//table/tbody/tr[1]/td[1]")).to have_content(@first.name)
-      expect(page.find(:xpath, "//table/tbody/tr[3]/td[1]")).to have_content(@third.name)
+      expect(page.find(:xpath, "//table/tbody/tr[1]/td[1]")).to have_content(@invited.name)
+      expect(page.find(:xpath, "//table/tbody/tr[3]/td[1]")).to have_content(@approved.name)
     end
 
     it "shows invite button only for unapproved partners" do
-      expect(page.find(:xpath, "//table/tbody/tr[1]/td[4]")).to have_content('Invite')
+      expect(page.find(:xpath, "//table/tbody/tr[1]/td[4]")).to have_no_content('Invite')
       expect(page.find(:xpath, "//table/tbody/tr[2]/td[4]")).to have_content('Invite')
-      expect(page.find(:xpath, "//table/tbody/tr[3]/td[4]")).not_to have_content('Invite')
+      expect(page.find(:xpath, "//table/tbody/tr[3]/td[4]")).to have_no_content('Invite')
+    end
+
+    context "when filtering" do
+      it "allows the user to click on one of the statuses at the top to filter the results" do
+        approved_count = Partner.approved.count
+        within "table tbody" do
+          expect(page).to have_css("tr", count: Partner.count)
+        end
+        within "#partner-status" do
+          click_on "Approved"
+        end
+        within "table tbody" do
+          expect(page).to have_css("tr", count: approved_count)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Closes #738 

This does a couple things.

 - Lists out all the statuses of all the partners at the top of Partners#index
 - Lists a total count of Partners for the organization at the top of Partners#index
 - Adds filtering to the Partner model / controller
 - The status types are each links that constrain the output
 - Spec coverage
 - Creates a "resources" subfolder in our SASS. I'm going to be moving resource-specific SASS into these files and out of the stylesheets root, separate PR

![Screenshot from 2019-06-23 19-38-25](https://user-images.githubusercontent.com/502363/59983500-80f7f680-95ee-11e9-9814-b808023fb27d.png)

