### PR TITLE
[WIP] Add state to distribution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ end
 
 ruby "2.6.2"
 
+gem 'aasm'
 gem "api-auth", "~> 2.3"
 gem "bootstrap-sass"
 gem "bugsnag"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
+    aasm (5.0.5)
+      concurrent-ruby (~> 1.0)
     actioncable (5.2.2)
       actionpack (= 5.2.2)
       nio4r (~> 2.0)
@@ -470,6 +472,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aasm
   actiontext!
   annotate
   api-auth (~> 2.3)

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -110,6 +110,16 @@ class DistributionsController < ApplicationController
     end
   end
 
+  def picked_up
+    if Distribution.find(params["id"]).picked_up!
+      flash[:notice] = "Distribution status updated!"
+    else
+      flash[:error] = "The status couldn't be updated"
+    end
+
+    redirect_to distribution_path
+  end
+
   # TODO: This needs a little more context. Is it JSON only? HTML?
   def pick_ups
     @pick_ups = current_organization.distributions

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -111,8 +111,8 @@ class DistributionsController < ApplicationController
   end
 
   def picked_up
-    if Distribution.find(params["id"]).picked_up!
-      flash[:notice] = "Distribution status updated!"
+    if Distribution.find(params['id']).picked_up!
+      flash[:notice] = 'Distribution status updated!'
     else
       flash[:error] = "The status couldn't be updated"
     end

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -37,7 +37,7 @@ class Distribution < ApplicationRecord
 
   include AASM
 
-  # States to track the status of a Distribution about whether or not it has been picked up.
+  # States to track the status of a Distribution about whether it has been picked up or not.
   aasm do
     state :started, initial: true
     state :scheduled

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -9,6 +9,7 @@ require 'time_util'
 #  updated_at          :datetime
 #  storage_location_id :integer
 #  partner_id          :integer
+#  aasm_state          :string
 #  organization_id     :integer
 #  issued_at           :datetime
 #  agency_rep          :string
@@ -33,6 +34,23 @@ class Distribution < ApplicationRecord
   validate :line_item_items_exist_in_inventory
 
   include IssuedAt
+
+  include AASM
+
+  # States to track the status of a Distribution about whether or not it has been picked up.
+  aasm do
+    state :started, initial: true
+    state :scheduled
+    state :complete
+
+    event :notify_partner do
+      transitions from: :started, to: :scheduled
+    end
+
+    event :picked_up do
+      transitions from: :scheduled, to: :complete
+    end
+  end
 
   before_save :combine_distribution
 

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -4,6 +4,7 @@
   <td><%= distribution_row.storage_location.name %></td>
   <td><%= distribution_row.line_items.total %></td>
   <td><%= item_value(distribution_row.value_per_itemizable) %></td>
+  <td><%= distribution_row.aasm_state.humanize %>
   <td class="text-right">
     <%= view_button_to distribution_path(distribution_row) %>
     <%= edit_button_to edit_distribution_path(distribution_row) %>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -41,6 +41,7 @@
                   <th>Source Inventory</th>
                   <th>Total items</th>
                   <th>Total value</th>
+                  <th>Status</th>
                   <th>&nbsp;</th>
                 </tr>
               </thead>

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -30,6 +30,7 @@
 
       <p>Source location: <%= @distribution.storage_location.name %></p>
       <p>Agency representative: <%= @distribution.agency_rep %></p>
+      <p>Status: <%= @distribution.aasm_state.humanize %>
       <h4>Total Items Distributed</h4>
       <div class="row">
         <div class="col-xs-12">
@@ -53,6 +54,7 @@
       </div>
     </div>
     <div class="box-footer with-border">
+      <%= edit_button_to picked_up_distributions_path(@distribution), {text: "Complete pickup", size: "lg"} if @distribution.scheduled? %>
       <%= edit_button_to edit_distribution_path(@distribution), {text: "Make a Correction", size: "lg"} %>
       <%= print_button_to print_distribution_path(@distribution, format: :pdf), {size: "lg"} %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
       get :print, on: :member
       collection do
         get :pick_ups
+        get ':id/picked_up', to: 'distributions#picked_up', as: :picked_up
       end
     end
 

--- a/db/migrate/20190621192607_add_aasm_state_to_distribution.rb
+++ b/db/migrate/20190621192607_add_aasm_state_to_distribution.rb
@@ -1,0 +1,5 @@
+class AddAasmStateToDistribution < ActiveRecord::Migration[5.2]
+  def change
+    add_column :distributions, :aasm_state, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_20_033128) do
+ActiveRecord::Schema.define(version: 2019_06_21_192607) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,6 +118,7 @@ ActiveRecord::Schema.define(version: 2019_05_20_033128) do
     t.integer "organization_id"
     t.datetime "issued_at"
     t.string "agency_rep"
+    t.string "aasm_state"
     t.index ["organization_id"], name: "index_distributions_on_organization_id"
     t.index ["partner_id"], name: "index_distributions_on_partner_id"
     t.index ["storage_location_id"], name: "index_distributions_on_storage_location_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -66,7 +66,7 @@ DonationSite.find_or_create_by!(name: "Waffle House") do |location|
   location.organization = pdx_org
 end
 DonationSite.find_or_create_by!(name: "Eagleton Country Club") do |location|
-  location.address = "4567 Some Blvd., Pawnee, OR 12345"
+  location.address = "4567 Some Blvd., Eagleton, OR 12345"
   location.organization = pdx_org
 end
 

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -113,4 +113,24 @@ RSpec.describe Distribution, type: :model do
       end
     end
   end
+
+  context 'Aasm States' do
+    describe '#notify_partner' do
+      subject { create(:distribution) }
+
+      it 'transitions from :started to :scheduled' do
+        expect(subject).to transition_from(:started).to(:scheduled).on_event(:notify_partner)
+        expect(subject).to have_state(:scheduled)
+      end
+    end
+
+    describe '#picked_up' do
+      subject { create(:distribution) }
+
+      it 'transitions from :scheduled to :complete' do
+        expect(subject).to transition_from(:scheduled).to(:complete).on_event(:picked_up)
+        expect(subject).to have_state(:complete)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,8 @@
 # users commonly want.
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+require 'aasm/rspec'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
Related to #823.

**This is still a work in progress!**

This adds `state` to `Distribution` using the `aasm` gem, a simple yet powerful tool to create states for ActiveRecord models.

The gem automatically generates a couple of methods to manipulate the states of the model. Here's how `aasm` looks in  `app/models/distribution.rb`:

```
aasm do
    state :started, initial: true
    state :scheduled
    state :complete

    event :notify_partner  do
        transitions from: :started, to: :scheduled
    end

    event :picked_up  do
        transitions from: :scheduled, to: :complete
    end
end
```
Using the nomenclature suggested on the issue, I can now change the states by simply calling `.notify_partner!` and `.picked_up!` on an instance of `distribution` and its state will be changed to `scheduled` and `complete` respectively.  I can also check an instance's state by using the `started?`, `scheduled?` and `completed?` methods.

Like I said earlier, this is still a work in progress, but I wanted to make a PR before so I get y'all input on these changes and tell me what you guys think.

Here's how the changes to the project look so far: 
_status on the index table_
![image](https://user-images.githubusercontent.com/33486409/59985798-f2916e00-9609-11e9-8a0b-915cb1578abf.png)

_the complete pickup option (only appears for distributions with the `scheduled` state)_
![image](https://user-images.githubusercontent.com/33486409/59985851-35ebdc80-960a-11e9-9dfb-9783b1c5fd7b.png)


ps: I also made a _very important_ change on the seeds. There was a seed being created on line 68, where an Eagleton donation site had their city on `location.address` set as Pawnee! which is completely absurd! :D