### PR TITLE
Use `::find_or_create_by!` in seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -187,10 +187,10 @@ DiaperDriveParticipant.create! business_name: "A Mediocre Place to Collect Diape
                                email: "ok@place.is",
                                organization: pdx_org
 
-Manufacturer.create! name: "Manufacturer 1",
-                     organization: pdx_org
-Manufacturer.create! name: "Manufacturer 2",
-                     organization: pdx_org
+Manufacturer.find_or_create_by! name: "Manufacturer 1",
+                                organization: pdx_org
+Manufacturer.find_or_create_by! name: "Manufacturer 2",
+                                organization: pdx_org
 
 def random_record(klass)
   # FIXME: This produces a deprecation warning. Could replace it with: .order(Arel.sql('random()'))


### PR DESCRIPTION
### Description

Running `rails db:seed` produces an error like so if you run it more
than once:
```
ActiveRecord::RecordInvalid: Validation failed: Name Manufacturer
already exists
<snip>/diaper/db/seeds.rb:190:in `<top (required)>''`
```

This change follows the pattern seen elsewhere in this file to use
`::find_or_create_by!` instead of just `::create`

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

Development only

### How Has This Been Tested?

`bundle exec rails db:seed` locally

