### PR TITLE
Add test for PartnerMailerJob

### DIFF
--- a/app/jobs/partner_mailer_job.rb
+++ b/app/jobs/partner_mailer_job.rb
@@ -5,6 +5,6 @@ class PartnerMailerJob
   def perform(org_id, dist_id, subject)
     current_organization = Organization.find(org_id)
     distribution = Distribution.find(dist_id)
-    DistributionMailer.partner_mailer(current_organization, distribution, subject).deliver_now if Rails.env.production?
+    DistributionMailer.partner_mailer(current_organization, distribution, subject).deliver_now
   end
 end

--- a/spec/jobs/partner_mailer_job_spec.rb
+++ b/spec/jobs/partner_mailer_job_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe PartnerMailerJob, type: :job do
+  describe '#perform' do
+    let(:organization) { create :organization }
+    let(:distribution) { create :distribution }
+    let(:mailer_subject) { 'PartnerMailerJob subject' }
+
+    it 'adds job to the queue' do
+      Sidekiq::Testing.fake! do
+        expect do
+          PartnerMailerJob.perform_async(organization.id, distribution.id, mailer_subject)
+        end.to change(PartnerMailerJob.jobs, :size).by(1)
+      end
+    end
+
+    it 'sends an email' do
+      Sidekiq::Testing.inline! do
+        expect do
+          PartnerMailerJob.perform_async(organization.id, distribution.id, mailer_subject)
+        end .to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related #1024 

### Description

This change adds specs around the `PartnerMailerJob`. I'm new here so I decided to add a test since that's what #1024  calls for. The only change on the code side is removing the environment check in the job code, which I would suggest is an anti-pattern.

This makes an assumption that this project does not have email credentials in CI or that people do not have email credentials in local dev environments. If that is the case, I could put the environment check back in, but I'd have to change the specs to not actually check the mailer.

### Type of change

* Addition of specs

### How Has This Been Tested?

Yup 😸 . Try it yourself: `bundle exec rake`

### Screenshots
before:
![before](https://user-images.githubusercontent.com/2006658/60762774-80b71c80-a02c-11e9-969f-25be52a223d6.png)


after:
![after](https://user-images.githubusercontent.com/2006658/60762778-93315600-a02c-11e9-9abc-1c27a63e1757.png)
