### PR TITLE
Add specs for ReminderDeadlineJob

### DIFF
--- a/spec/jobs/reminder_deadline_job_spec.rb
+++ b/spec/jobs/reminder_deadline_job_spec.rb
@@ -3,16 +3,29 @@ require 'spec_helper'
 RSpec.describe ReminderDeadlineJob, type: :job do
   describe '#perform' do
     let(:organization) { create :organization, reminder_day: Date.current.day, deadline_day: Date.current.day + 10 }
-    let(:message_delivery) { instance_double(ActionMailer::MessageDelivery) }
 
     before do
       travel_to Date.new(2019, 6, 10)
-      allow(ReminderDeadlineMailer).to receive(:notify_deadline).and_return(message_delivery)
-      allow(message_delivery).to receive(:deliver_now)
     end
 
     after do
       travel_back
+    end
+
+    it 'adds job to the queue' do
+      Sidekiq::Testing.fake! do
+        expect do
+          ReminderDeadlineJob.perform_async
+        end.to change(ReminderDeadlineJob.jobs, :size).by(1)
+      end
+    end
+
+    it 'sends an email' do
+      Sidekiq::Testing.inline! do
+        expect do
+          ReminderDeadlineJob.perform_async
+        end .to change { ActionMailer::Base.deliveries.count }.by(1)
+      end
     end
 
     context 'partner with send reminders active' do


### PR DESCRIPTION
related #1024 , #1083 

### Description
Similar to #1083 this adds specs that exercise the code under test and satisfy simplecov. I noticed that `ActionMailer::MessageDelivery` was not actually doing anything and the specs pass without it, so I have removed it.

This adds some duplication and perhaps we could look at perhaps extracting it into a shared example but I don't know the code base well enough at this point to make that call. I'm open to suggestion, of course. 😄 


### Type of change

<!-- Please delete options that are not relevant. -->

* Test addition

### How Has This Been Tested?

`bundle exec rake`

### Screenshots
Before
![before](https://user-images.githubusercontent.com/2006658/60762924-0cca4380-a02f-11e9-9bba-15c5989582f7.png)

After
![after](https://user-images.githubusercontent.com/2006658/60762926-13f15180-a02f-11e9-9696-00627466567e.png)


