### PR TITLE
Add DiaperPartnerClient specs

### DIFF
--- a/spec/services/diaper_partner_client_spec.rb
+++ b/spec/services/diaper_partner_client_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DiaperPartnerClient, type: :service do
           email: attributes["email"]
         }
       }.to_json
-      stub_request(:post, "https://partner-register.com/")
+      stub_request(:post, 'https://partner-register.com/')
         .with(
           body: expected_body,
           headers: {
@@ -52,6 +52,33 @@ RSpec.describe DiaperPartnerClient, type: :service do
         .to_return(status: 200, body: 'success', headers: {})
       result = DiaperPartnerClient.get(id: 123)
       expect(result).to eq 'success'
+    end
+  end
+
+  describe '::put' do
+    it 'performs a PUT request' do
+      attributes = { partner_id: 123, status: 'status' }
+      expected_body = {
+        partner: {
+          diaper_partner_id: attributes[:partner_id],
+          status: attributes[:status]
+        }
+      }.to_json
+      stub_request(:put, 'https://partner-register.com/123')
+        .with(
+          body: expected_body,
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type' => 'application/json',
+            'Host' => 'partner-register.com',
+            'User-Agent' => 'Ruby',
+            'X-Api-Key' => 'partner-key'
+          }
+        )
+        .to_return(status: 200, body: 'success', headers: {})
+      result = DiaperPartnerClient.put(attributes)
+      expect(result.body).to eq 'success'
     end
   end
 end

--- a/spec/services/diaper_partner_client_spec.rb
+++ b/spec/services/diaper_partner_client_spec.rb
@@ -18,19 +18,7 @@ RSpec.describe DiaperPartnerClient, type: :service do
           email: attributes["email"]
         }
       }.to_json
-      stub_request(:post, 'https://partner-register.com/')
-        .with(
-          body: expected_body,
-          headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Type' => 'application/json',
-            'Host' => 'partner-register.com',
-            'User-Agent' => 'Ruby',
-            'X-Api-Key' => 'partner-key'
-          }
-        )
-        .to_return(status: 200, body: 'success', headers: {})
+      stub_partner_request(:post, 'https://partner-register.com/', body: expected_body)
       result = DiaperPartnerClient.post(attributes)
       expect(result).to eq 'success'
     end
@@ -38,18 +26,7 @@ RSpec.describe DiaperPartnerClient, type: :service do
 
   describe '::get' do
     it 'performs a GET request' do
-      stub_request(:get, "https://partner-register.com/123")
-        .with(
-          headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Type' => 'application/json',
-            'Host' => 'partner-register.com',
-            'User-Agent' => 'Ruby',
-            'X-Api-Key' => 'partner-key'
-          }
-        )
-        .to_return(status: 200, body: 'success', headers: {})
+      stub_partner_request(:get, 'https://partner-register.com/123')
       result = DiaperPartnerClient.get(id: 123)
       expect(result).to eq 'success'
     end
@@ -64,21 +41,26 @@ RSpec.describe DiaperPartnerClient, type: :service do
           status: attributes[:status]
         }
       }.to_json
-      stub_request(:put, 'https://partner-register.com/123')
-        .with(
-          body: expected_body,
-          headers: {
-            'Accept' => '*/*',
-            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-            'Content-Type' => 'application/json',
-            'Host' => 'partner-register.com',
-            'User-Agent' => 'Ruby',
-            'X-Api-Key' => 'partner-key'
-          }
-        )
-        .to_return(status: 200, body: 'success', headers: {})
+      stub_partner_request(:put, 'https://partner-register.com/123', body: expected_body)
       result = DiaperPartnerClient.put(attributes)
       expect(result.body).to eq 'success'
     end
+  end
+
+  private
+
+  def stub_partner_request(method, url, request = {}, response = {})
+    stub_request(method, url)
+      .with({
+        headers: {
+          'Accept' => '*/*',
+          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Content-Type' => 'application/json',
+          'Host' => 'partner-register.com',
+          'User-Agent' => 'Ruby',
+          'X-Api-Key' => 'partner-key'
+        }
+      }.merge(request))
+      .to_return({ status: 200, body: 'success', headers: {} }.merge(response))
   end
 end

--- a/spec/services/diaper_partner_client_spec.rb
+++ b/spec/services/diaper_partner_client_spec.rb
@@ -2,10 +2,42 @@ require 'spec_helper'
 require_relative '../support/env_helper'
 
 RSpec.describe DiaperPartnerClient, type: :service do
+  before do
+    stub_env('PARTNER_REGISTER_URL', 'https://partner-register.com')
+    stub_env('PARTNER_KEY', 'partner-key')
+  end
+
+  describe '::post' do
+    it 'performs a POST request' do
+      attributes = { 'id' => 123, 'organization_id' => 456, 'email' => 'foo@bar.com' }
+      expected_body = {
+        partner:
+        {
+          diaper_bank_id: attributes["organization_id"],
+          diaper_partner_id: attributes["id"],
+          email: attributes["email"]
+        }
+      }.to_json
+      stub_request(:post, "https://partner-register.com/")
+        .with(
+          body: expected_body,
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type' => 'application/json',
+            'Host' => 'partner-register.com',
+            'User-Agent' => 'Ruby',
+            'X-Api-Key' => 'partner-key'
+          }
+        )
+        .to_return(status: 200, body: 'success', headers: {})
+      result = DiaperPartnerClient.post(attributes)
+      expect(result).to eq 'success'
+    end
+  end
+
   describe '::get' do
     it 'performs a GET request' do
-      stub_env('PARTNER_REGISTER_URL', 'https://partner-register.com')
-      stub_env('PARTNER_KEY', 'partner-key')
       stub_request(:get, "https://partner-register.com/123")
         .with(
           headers: {
@@ -17,9 +49,9 @@ RSpec.describe DiaperPartnerClient, type: :service do
             'X-Api-Key' => 'partner-key'
           }
         )
-        .to_return(status: 200, body: "success", headers: {})
+        .to_return(status: 200, body: 'success', headers: {})
       result = DiaperPartnerClient.get(id: 123)
-      expect(result).to eq "success"
+      expect(result).to eq 'success'
     end
   end
 end

--- a/spec/services/diaper_partner_client_spec.rb
+++ b/spec/services/diaper_partner_client_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require_relative '../support/env_helper'
+
+RSpec.describe DiaperPartnerClient, type: :service do
+  describe '::get' do
+    it 'performs a GET request' do
+      stub_env('PARTNER_REGISTER_URL', 'https://partner-register.com')
+      stub_env('PARTNER_KEY', 'partner-key')
+      stub_request(:get, "https://partner-register.com/123")
+        .with(
+          headers: {
+            'Accept' => '*/*',
+            'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Content-Type' => 'application/json',
+            'Host' => 'partner-register.com',
+            'User-Agent' => 'Ruby',
+            'X-Api-Key' => 'partner-key'
+          }
+        )
+        .to_return(status: 200, body: "success", headers: {})
+      result = DiaperPartnerClient.get(id: 123)
+      expect(result).to eq "success"
+    end
+  end
+end


### PR DESCRIPTION
Related #1024

### Description
This uses the existing machinery (mostly webmock) to wrap some specs around the `DiaperPartnerClient`. I went back and forth a bit about how exhaustive to get with testing scenarios other than 200 response, but it looks like the code doesn't really care— it just returns the body for the most part regardless of the status of the request.

As always, suggestions welcome. 😄 

### Type of change

* Test Addition

### How Has This Been Tested?
`bundle exec rake`

### Screenshots
before
![before](https://user-images.githubusercontent.com/2006658/60769219-babb0980-a092-11e9-915f-389eef9ffc52.png)
after
![after](https://user-images.githubusercontent.com/2006658/60769222-be4e9080-a092-11e9-8ef8-2f4805a3ebfd.png)

