### PR TITLE
Eliminate bundler tzinfo warning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,4 +93,9 @@ group :test do
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", "~> 1.2", platforms: %i(mingw mswin x64_mingw jruby)
+
+# This 'if' may seem redundant but for some reason it is necessary to suppress
+# a warning on non (Windows or JRuby) platforms.
+if %w(mingw mswin x64_mingw jruby).include?(RUBY_PLATFORM)
+  gem "tzinfo-data", "~> 1.2", platforms: %i(mingw mswin x64_mingw jruby)
+end


### PR DESCRIPTION
Although the gem call for tzinfo-data specifies platforms, a warning regarding platforms is displayed on Mac OS and probably Linux:

``The dependency tzinfo-data (~> 1.2) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
``

Adding this `if` around it eliminates the warning.

This change eliminates the warning on Mac OS but it has not been tested on other OS's.
