### PR TITLE
Remove duplicate scopes (code cleanup)

### DIFF
--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -34,7 +34,6 @@ class Donation < ApplicationRecord
   scope :at_storage_location, ->(storage_location_id) {
     where(storage_location_id: storage_location_id)
   }
-  scope :by_source, ->(source) { where(source: source) }
   scope :from_donation_site, ->(donation_site_id) { where(donation_site_id: donation_site_id) }
   scope :by_diaper_drive_participant, ->(diaper_drive_participant_id) {
     where(diaper_drive_participant_id: diaper_drive_participant_id)

--- a/app/models/donation_site.rb
+++ b/app/models/donation_site.rb
@@ -29,8 +29,6 @@ class DonationSite < ApplicationRecord
   }
   scope :alphabetized, -> { order(:name) }
 
-  scope :alphabetized, -> { order(:name) }
-
   def self.import_csv(csv, organization)
     csv.each do |row|
       loc = DonationSite.new(row.to_hash)


### PR DESCRIPTION
### Description

There are a few duplicate `scope` entries -- the lastmost one in each file is the one getting used, so here we remove the earlier ones. That should decrease any possible confusion and not affect the application or tests.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Test suite!
