### PR TITLE
Extracts Date range helpers to separate helpers file

### DIFF
--- a/app/assets/javascripts/dashboard.coffee
+++ b/app/assets/javascripts/dashboard.coffee
@@ -3,5 +3,5 @@
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
 $ ->
-  $("select#dashboard_filter_interval").on "change", (e) ->
+  $("#filters.submit-on-change select#filters_interval").on "change", (e) ->
     this.form.submit()

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -1,48 +1,5 @@
 # Encapsulates methods used on the Dashboard that need some business logic
 module DashboardHelper
-  def display_interval
-    selected_interval.humanize.downcase
-  end
-
-  def filter_intervals
-    [
-      %w(Today today),
-      %w(Yesterday yesterday),
-      ["This Week", "this_week"],
-      ["This Month", "this_month"],
-      ["Last Month", "last_month"],
-      ["This Year", "this_year"],
-      ["Last Year", "last_year"],
-      ["All Time", "all_time"],
-    ]
-  end
-
-  def selected_interval
-    params.dig(:dashboard_filter, :interval) || "this_year"
-  end
-
-  def selected_range
-    now = Time.zone.now
-    case selected_interval
-    when "today"
-      now.beginning_of_day..now
-    when "yesterday"
-      (now - 1.day).beginning_of_day..(now - 1.day).end_of_day
-    when "this_week"
-      now.beginning_of_week..now
-    when "this_month"
-      now.beginning_of_month..now
-    when "last_month"
-      (now - 1.month).beginning_of_month..(now - 1.month).end_of_month
-    when "this_year"
-      now.beginning_of_year..now
-    when "last_year"
-      (now - 1.year).beginning_of_year..(now - 1.year).end_of_year
-    else
-      Time.zone.local(2017, 1, 1, 0, 0, 0)..now
-    end
-  end
-
   def received_distributed_data(range = selected_range)
     {
       "Received donations" => total_received_donations_unformatted(range),

--- a/app/helpers/date_range_helper.rb
+++ b/app/helpers/date_range_helper.rb
@@ -1,0 +1,45 @@
+# Encapsulates methods used on the Dashboard that need some business logic
+module DateRangeHelper
+  def display_interval
+    selected_interval.humanize.downcase
+  end
+
+  def filter_intervals
+    [
+      %w(Today today),
+      %w(Yesterday yesterday),
+      ["This Week", "this_week"],
+      ["This Month", "this_month"],
+      ["Last Month", "last_month"],
+      ["This Year", "this_year"],
+      ["Last Year", "last_year"],
+      ["All Time", "all_time"],
+    ]
+  end
+
+  def selected_interval
+    params.dig(:filters, :interval) || "this_year"
+  end
+
+  def selected_range
+    now = Time.zone.now
+    case selected_interval
+    when "today"
+      now.beginning_of_day..now
+    when "yesterday"
+      (now - 1.day).beginning_of_day..(now - 1.day).end_of_day
+    when "this_week"
+      now.beginning_of_week..now
+    when "this_month"
+      now.beginning_of_month..now
+    when "last_month"
+      (now - 1.month).beginning_of_month..(now - 1.month).end_of_month
+    when "this_year"
+      now.beginning_of_year..now
+    when "last_year"
+      (now - 1.year).beginning_of_year..(now - 1.year).end_of_year
+    else
+      Time.zone.local(2017, 1, 1, 0, 0, 0)..now
+    end
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -47,9 +47,9 @@
 
 
       <div class="box-header with-border bg-gray">
-        <section id="filters">
+        <section id="filters" class="submit-on-change">
           <div class="box-body">
-              <%= simple_form_for :dashboard_filter, url: dashboard_path(current_organization), remote: true, method: :get do |f| %>
+              <%= simple_form_for :filters, url: dashboard_path(current_organization), remote: true, method: :get do |f| %>
                 <div class="form-group col-md-offset-10 col-md-2 col-sm-offset-6 col-sm-6 col-xs-12">
                   <label for="interval">Date Range</label>
                   <%= f.select :interval, filter_intervals, { selected: selected_interval }, class: "form-control" %>

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
               expect(page).to have_content("333")
             end
 
-            page.select "Last Year", from: "dashboard_filter_interval"
+            page.select "Last Year", from: "filters_interval"
 
             within "#summary" do
               expect(page).to have_content("333")
@@ -163,7 +163,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Year" do
             before do
-              page.select "This Year", from: "dashboard_filter_interval"
+              page.select "This Year", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations.values.map(&:total_quantity).sum }
@@ -183,7 +183,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Today" do
             before do
-              page.select "Today", from: "dashboard_filter_interval"
+              page.select "Today", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations[:today].total_quantity }
@@ -203,7 +203,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Yesterday" do
             before do
-              page.select "Yesterday", from: "dashboard_filter_interval"
+              page.select "Yesterday", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations[:yesterday].total_quantity }
@@ -223,7 +223,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Week" do
             before do
-              page.select "This Week", from: "dashboard_filter_interval"
+              page.select "This Week", from: "filters_interval"
             end
 
             let(:total_inventory) { [@this_years_donations[:today], @this_years_donations[:yesterday], @this_years_donations[:earlier_this_week]].map(&:total_quantity).sum }
@@ -243,7 +243,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Month" do
             before do
-              page.select "This Month", from: "dashboard_filter_interval"
+              page.select "This Month", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations[:today].total_quantity }
@@ -263,7 +263,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Last Month" do
             before do
-              page.select "Last Month", from: "dashboard_filter_interval"
+              page.select "Last Month", from: "filters_interval"
             end
 
             let(:total_inventory) { [@this_years_donations[:yesterday], @this_years_donations[:earlier_this_week]].map(&:total_quantity).sum }
@@ -283,7 +283,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Last Year" do
             before do
-              page.select "Last Year", from: "dashboard_filter_interval"
+              page.select "Last Year", from: "filters_interval"
             end
 
             let(:total_inventory) { @last_years_donations.map(&:total_quantity).sum }
@@ -303,7 +303,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "All Time" do
             before do
-              page.select "All Time", from: "dashboard_filter_interval"
+              page.select "All Time", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations.values.map(&:total_quantity).sum + @last_years_donations.map(&:total_quantity).sum }
@@ -370,7 +370,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Year" do
             before do
-              page.select "This Year", from: "dashboard_filter_interval"
+              page.select "This Year", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_purchases.values.map(&:total_quantity).sum }
@@ -390,7 +390,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Today" do
             before do
-              page.select "Today", from: "dashboard_filter_interval"
+              page.select "Today", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_purchases[:today].total_quantity }
@@ -410,7 +410,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Yesterday" do
             before do
-              page.select "Yesterday", from: "dashboard_filter_interval"
+              page.select "Yesterday", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_purchases[:yesterday].total_quantity }
@@ -430,7 +430,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Week" do
             before do
-              page.select "This Week", from: "dashboard_filter_interval"
+              page.select "This Week", from: "filters_interval"
             end
 
             let(:total_inventory) { [@this_years_purchases[:today], @this_years_purchases[:yesterday], @this_years_purchases[:earlier_this_week]].map(&:total_quantity).sum }
@@ -450,7 +450,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Month" do
             before do
-              page.select "This Month", from: "dashboard_filter_interval"
+              page.select "This Month", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_purchases[:today].total_quantity }
@@ -470,7 +470,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Last Month" do
             before do
-              page.select "Last Month", from: "dashboard_filter_interval"
+              page.select "Last Month", from: "filters_interval"
             end
 
             let(:total_inventory) { [@this_years_purchases[:yesterday], @this_years_purchases[:earlier_this_week]].map(&:total_quantity).sum }
@@ -490,7 +490,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Last Year" do
             before do
-              page.select "Last Year", from: "dashboard_filter_interval"
+              page.select "Last Year", from: "filters_interval"
             end
 
             let(:total_inventory) { @last_years_purchases.map(&:total_quantity).sum }
@@ -510,7 +510,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "All Time" do
             before do
-              page.select "All Time", from: "dashboard_filter_interval"
+              page.select "All Time", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_purchases.values.map(&:total_quantity).sum + @last_years_purchases.map(&:total_quantity).sum }
@@ -562,7 +562,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Year" do
             before do
-              page.select "This Year", from: "dashboard_filter_interval"
+              page.select "This Year", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations.values.map(&:total_quantity).sum }
@@ -583,7 +583,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Today" do
             before do
-              page.select "Today", from: "dashboard_filter_interval"
+              page.select "Today", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations[:today].total_quantity }
@@ -604,7 +604,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Yesterday" do
             before do
-              page.select "Yesterday", from: "dashboard_filter_interval"
+              page.select "Yesterday", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations[:yesterday].total_quantity }
@@ -625,7 +625,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Week" do
             before do
-              page.select "This Week", from: "dashboard_filter_interval"
+              page.select "This Week", from: "filters_interval"
             end
 
             let(:total_inventory) { [@this_years_donations[:today], @this_years_donations[:yesterday], @this_years_donations[:earlier_this_week]].map(&:total_quantity).sum }
@@ -646,7 +646,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Month" do
             before do
-              page.select "This Month", from: "dashboard_filter_interval"
+              page.select "This Month", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations[:today].total_quantity }
@@ -667,7 +667,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Last Month" do
             before do
-              page.select "Last Month", from: "dashboard_filter_interval"
+              page.select "Last Month", from: "filters_interval"
             end
 
             let(:total_inventory) { [@this_years_donations[:yesterday], @this_years_donations[:earlier_this_week]].map(&:total_quantity).sum }
@@ -688,7 +688,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Last Year" do
             before do
-              page.select "Last Year", from: "dashboard_filter_interval"
+              page.select "Last Year", from: "filters_interval"
             end
 
             let(:total_inventory) { @last_years_donations.map(&:total_quantity).sum }
@@ -709,7 +709,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "All Time" do
             before do
-              page.select "All Time", from: "dashboard_filter_interval"
+              page.select "All Time", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations.values.map(&:total_quantity).sum + @last_years_donations.map(&:total_quantity).sum }
@@ -803,7 +803,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Year" do
             before do
-              page.select "This Year", from: "dashboard_filter_interval"
+              page.select "This Year", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations.values.map(&:total_quantity).sum }
@@ -827,7 +827,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Today" do
             before do
-              page.select "Today", from: "dashboard_filter_interval"
+              page.select "Today", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations[:today].total_quantity }
@@ -848,7 +848,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Yesterday" do
             before do
-              page.select "Yesterday", from: "dashboard_filter_interval"
+              page.select "Yesterday", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations[:yesterday].total_quantity }
@@ -869,7 +869,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Week" do
             before do
-              page.select "This Week", from: "dashboard_filter_interval"
+              page.select "This Week", from: "filters_interval"
             end
 
             let(:total_inventory) { [@this_years_donations[:today], @this_years_donations[:yesterday], @this_years_donations[:earlier_this_week]].map(&:total_quantity).sum }
@@ -892,7 +892,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "This Month" do
             before do
-              page.select "This Month", from: "dashboard_filter_interval"
+              page.select "This Month", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations[:today].total_quantity }
@@ -913,7 +913,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Last Month" do
             before do
-              page.select "Last Month", from: "dashboard_filter_interval"
+              page.select "Last Month", from: "filters_interval"
             end
 
             let(:total_inventory) { [@this_years_donations[:yesterday], @this_years_donations[:earlier_this_week]].map(&:total_quantity).sum }
@@ -936,7 +936,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "Last Year" do
             before do
-              page.select "Last Year", from: "dashboard_filter_interval"
+              page.select "Last Year", from: "filters_interval"
             end
 
             let(:total_inventory) { @last_years_donations.map(&:total_quantity).sum }
@@ -959,7 +959,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
           describe "All Time" do
             before do
-              page.select "All Time", from: "dashboard_filter_interval"
+              page.select "All Time", from: "filters_interval"
             end
 
             let(:total_inventory) { @this_years_donations.values.map(&:total_quantity).sum + @last_years_donations.map(&:total_quantity).sum }
@@ -1042,7 +1042,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "with year-to-date selected" do
           before do
-            page.select "This Year", from: "dashboard_filter_interval"
+            page.select "This Year", from: "filters_interval"
           end
 
           let(:total_inventory) { @this_years_distributions.values.map(&:line_items).flatten.map(&:quantity).sum }
@@ -1063,7 +1063,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "with today selected" do
           before do
-            page.select "Today", from: "dashboard_filter_interval"
+            page.select "Today", from: "filters_interval"
           end
 
           let(:total_inventory) { @this_years_distributions[:today].line_items.total }
@@ -1084,7 +1084,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "with yesterday selected" do
           before do
-            page.select "Yesterday", from: "dashboard_filter_interval"
+            page.select "Yesterday", from: "filters_interval"
           end
 
           let(:total_inventory) { @this_years_distributions[:yesterday].line_items.total }
@@ -1105,7 +1105,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "with this week selected" do
           before do
-            page.select "This Week", from: "dashboard_filter_interval"
+            page.select "This Week", from: "filters_interval"
           end
 
           let(:total_inventory) { [@this_years_distributions[:today], @this_years_distributions[:yesterday], @this_years_distributions[:earlier_this_week]].map(&:line_items).flatten.map(&:quantity).sum }
@@ -1128,7 +1128,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "with this month selected" do
           before do
-            page.select "This Month", from: "dashboard_filter_interval"
+            page.select "This Month", from: "filters_interval"
           end
 
           let(:total_inventory) { @this_years_distributions[:today].line_items.total }
@@ -1149,7 +1149,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "with last month selected" do
           before do
-            page.select "Last Month", from: "dashboard_filter_interval"
+            page.select "Last Month", from: "filters_interval"
           end
 
           let(:total_inventory) { [@this_years_distributions[:yesterday], @this_years_distributions[:earlier_this_week]].map(&:line_items).flatten.map(&:quantity).sum }
@@ -1172,7 +1172,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "with last year selected" do
           before do
-            page.select "Last Year", from: "dashboard_filter_interval"
+            page.select "Last Year", from: "filters_interval"
           end
 
           let(:total_inventory) { @last_years_distributions.map(&:line_items).flatten.map(&:quantity).sum }
@@ -1193,7 +1193,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "with All Time selected" do
           before do
-            page.select "All Time", from: "dashboard_filter_interval"
+            page.select "All Time", from: "filters_interval"
           end
 
           let(:total_inventory) { @this_years_distributions.values.map(&:line_items).flatten.map(&:quantity).sum + @last_years_distributions.map(&:line_items).flatten.map(&:quantity).sum }


### PR DESCRIPTION
This PR does the following
 - Extracts the date-range filter helpers from the `DashboardHelper` to a new helper file
 - The behavior of the dashboard filter does auto-post on change, so I added a `submit-on-change` class to the form so that the jQuery that does auto-post can hook onto that (otherwise we'll get auto-post for all filters)
 - Modifies the filters on the dashboard to use the more generalized "filters" name
 - Updates the spec to reflect these changes