### PR TITLE
Fixes value_in_cents line item bug

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -154,8 +154,8 @@ class DonationsController < ApplicationController
 
   def total_value(donations)
     total_value_all_donations = 0
-    donations.each do |distribution|
-      total_value_all_donations += distribution.value_per_itemizable
+    donations.each do |donation|
+      total_value_all_donations += donation.value_per_itemizable
     end
     total_value_all_donations
   end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -22,8 +22,9 @@ class LineItem < ApplicationRecord
   validates :quantity, numericality: { only_integer: true, less_than: MAX_INT, greater_than: MIN_INT }, exclusion: { in: [0] }
   scope :active, -> { joins(:item).where(items: { active: true }) }
 
+  # FIXME: This is a temporary hack to stop a 500 from showing up. We need to remove the default_scope from Item
   def value_per_line_item
-    item.value_in_cents * quantity
+    (item&.value_in_cents || 0) * quantity
   end
 
   def has_packages

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -21,6 +21,15 @@ RSpec.describe "Donations", type: :system, js: true do
     it "Displays Total quantity on the index page" do
       expect(page.find(:css, "table.table-hover", visible: true)).to have_content("20")
     end
+
+    # FIXME: We can remove this after unscoping items, I think.
+    it "doesn't die when an inactive item is in a donation" do
+      item = create(:item, :active, name: "INACTIVE ITEM")
+      create(:donation, :with_items, item: item)
+      item.update(active: false)
+      item.reload
+      visit @url_prefix + "/donations"
+    end
   end
 
   context "When filtering on the index page" do


### PR DESCRIPTION
We've discussed this with Rachel and Megan and there's actually quite a lot more work to do with this, with how we display items. We need to remove `default_scope` and instead only hide inactive items in the collections and when adding new items.

For now, this just resolves the 500.