### PR TITLE
1117 took out the validation for 0, only skip it instead

### DIFF
--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -23,6 +23,7 @@ module Itemizable
         parent_id = first.itemizable_id
         each do |line_item|
           next unless line_item.valid?
+          next unless line_item.quantity != 0
 
           combined[line_item.item_id] ||= 0
           combined[line_item.item_id] += line_item.quantity

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -19,7 +19,7 @@ class LineItem < ApplicationRecord
   belongs_to :item
 
   validates :item_id, presence: true
-  validates :quantity, numericality: { only_integer: true, less_than: MAX_INT, greater_than: MIN_INT }, exclusion: { in: [0] }
+  validates :quantity, numericality: { only_integer: true, less_than: MAX_INT, greater_than: MIN_INT }
   scope :active, -> { joins(:item).where(items: { active: true }) }
 
   def value_per_line_item

--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe LineItem, type: :model do
     it "the quantity must be a valid integer and cannot be 0" do
       expect(build(:line_item, :purchase, quantity: "a")).not_to be_valid
       expect(build(:line_item, :purchase, quantity: "1.0")).not_to be_valid
-      expect(build(:line_item, :purchase, quantity: 0)).not_to be_valid
+      expect(build(:line_item, :purchase, quantity: 0)).to be_valid
       expect(build(:line_item, :purchase, quantity: 2**31)).not_to be_valid
       expect(build(:line_item, :purchase, quantity: -2**32)).not_to be_valid
       expect(build_stubbed(:line_item, :purchase, quantity: -1)).to be_valid


### PR DESCRIPTION
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

rspec ran, changed 
rspec ./spec/models/line_item_spec.rb:24

Provide instructions so we can reproduce. 

Create a new distribution with an item with the quantity of 0, hit save, check and make sure that no item was saved.
