### PR TITLE
#1142 Add instructions for Ubuntu installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ This project took what we built for the [Portland Diaper Bank in 2016](https://g
 
 ## Development
 
+### Installation Instructions
+
+The `ubuntu_installation.md` file ([https://github.com/rubyforgood/diaper/blob/master/ubuntu-installation.md](https://github.com/rubyforgood/diaper/blob/master/ubuntu-installation.md)) has detailed instructions for installation and configuration of an Ubuntu host to run this software. Although there is not a document for Mac OS, it may be helpful for that as well.
+
 ### Ruby Version
 This app uses Ruby version 2.6.2, indicated in `/.ruby-version` and `Gemfile`, which will be auto-selected if you use a Ruby versioning manager like `rvm` or `rbenv`.
 

--- a/ubuntu-installation.md
+++ b/ubuntu-installation.md
@@ -1,0 +1,113 @@
+# Installing on Ubuntu
+
+Following are instructions for installing DiaperBase on a freshly installed Ubuntu Desktop host. This will probably work identically on Ubuntu Server but that has not been tested yet.
+
+Many of these instructions can probably work as is, or easily be translated to work on a Mac.
+
+There are two kinds of installations; one for a developer and another for a deployment. The only difference between the two is that the former will need git installed and need to `git clone` the repo, whereas the latter can just download a copy of master.
+
+Obviously, if any of these steps are already done you will probably not need to do them, so just ignore those steps.
+
+
+### Project Page
+
+The Github project page is at [https://github.com/rubyforgood/diaper](https://github.com/rubyforgood/diaper).
+
+
+### Installing OS Packages
+
+You'll need to add some packages to those that are included in the installation by default:
+
+`sudo apt install curl  git  nodejs  npm  postgresql  libpq-dev`
+
+
+### Installing the Diaper Software
+
+If you will be using this machine for development, you will need to `git clone` the repo:
+
+`git clone https://github.com/rubyforgood/diaper.git`
+
+If you only need to have the files but don't need to use git, you can download the zip file and unzip it:
+
+```
+curl -o diaper.zip https://codeload.github.com/rubyforgood/diaper/zip/master \
+    && unzip diaper.zip \
+    && rm diaper.zip
+```
+
+
+### Installing Yarn
+ 
+Go to your diaper project directory and do this:
+
+```
+sudo npm -g install yarn
+yarn install
+```
+
+
+### Installing rvm
+
+Go to https://rvm.io/rvm/install and find and run the commands that install the gpg key and install rvm. At the time of this writing (2019-07-26), they are:
+
+```
+gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+\curl -sSL https://get.rvm.io | bash
+```
+
+_Open a new terminal tab or window (this will not work in your current shell!)._ To test rvm, do:
+
+`rvm list`
+
+If you see something like ‘rvm not found’, you may need to change your terminal settings so that something like “Run command as a login shell” is selected. In the default Ubuntu terminal, you would go to the Edit menu, then select the profile to edit, then select the “Command” tab, and select “Run command as a login shell”. Then open a new shell to proceed.
+
+
+### Installing Ruby and Ruby Gems
+
+Install the required version of Ruby (you may be prompted for your system password so that rvm can install some required packages):
+
+`rvm install $(cat .ruby-version)`
+
+Then, from your project directory, install the gems required for the project:
+
+`bundle`
+
+
+### Configuring Postgres
+
+By default, Postgres has no password for the admin user. You'll need to set one. Run `psql` as the Unix user `postgres` that was added by the Postgres installation:
+
+`sudo -u postgres psql`
+
+In `psql`, the following command would add a password whose value is `password`:
+
+`alter user postgres password 'password';`
+
+Don't forget that semicolon!
+
+You can now exit `psql`, by pressing `<Ctrl-D>` or typing `\q<Enter>`.
+
+
+### Making the Postgres Credentials Available in Your Environment 
+
+You will see in `config/database.yml` that the Postgres username and password are fetched from the environment variables `PG_USERNAME` and `PG_PASSWORD`, respectively. (The production environment password is an exception, coming from `DIAPER_DATABASE_PASSWORD`.) You'll need to make this happen, for example by putting them in a startup script, or (quick and dirty) typing `export` commands in the terminal:
+
+```
+export PG_USERNAME=postgres
+export PG_PASSWORD=password
+```
+
+### Initializing the Data Base
+
+From your project directory, initialize the data base:
+
+`bundle exec rake db:setup`
+
+
+### Testing the Application
+
+You should now be able to successfully run the application:
+
+`rails server`
+
+Point a browser to `localhost:3000`. You should see the Diaper home page. For login credentials, consult the README.md file (at the time of this writing at [https://github.com/rubyforgood/diaper/blob/master/README.md#login](https://github.com/rubyforgood/diaper/blob/master/README.md#login).


### PR DESCRIPTION
This adds an ubuntu-installation.md file, and refers to it in the README.

These instructions are based on my installation of the software on 3 Ubuntu 18.04 systems.