### PR TITLE
Switch nested fields to simple_form

### DIFF
--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -4,12 +4,12 @@
     <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
     <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner"> </div>
   </span>
-  <span class="col-md-4 col-sm-12">  
+  <span class="col-md-4 col-sm-12">
     <label>OR</label>
-    <%= f.input_field :item_id, collection: @items, prompt: "Choose an item", class: 'form-control' %>
+    <%= f.input :item_id, collection: @items, prompt: "Choose an item", label: false %>
   </span>
   <div class='col-md-3 col-12'>
-  <%= f.input_field :quantity, placeholder: "Quantity", class: 'quantity form-control' %>
+    <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity" } %>
   </div>
   <div class='col-md-2 col-12'>
     <%= delete_line_item_button f %>

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -154,7 +154,7 @@ RSpec.describe "Donations", type: :system, js: true do
         page.find(:css, "#__add_line_item").click
         select_id = page.find(:xpath, '//*[@id="donation_line_items"]/section[2]//select')[:id]
         select Item.alphabetized.first.name, from: select_id
-        text_id = page.find(:css, '#donation_line_items > section:nth-child(2) > div > div.col-md-3.col-12 > input')[:id]
+        text_id = page.find(:css, '#donation_line_items > section:nth-child(2) > div > div.col-md-3.col-12 > div.donation_line_items_quantity > input')[:id]
         fill_in text_id, with: "10"
 
         expect do
@@ -309,6 +309,22 @@ RSpec.describe "Donations", type: :system, js: true do
           # wait for the next page to load
           expect(page).not_to have_xpath("//select[@id='donation_line_items_attributes_0_item_id']")
         end.to change { Donation.count }.by(1)
+      end
+
+      it "Displays nested errors" do
+        select Donation::SOURCES[:misc], from: "donation_source"
+        select StorageLocation.first.name, from: "donation_storage_location_id"
+        select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
+        fill_in "donation_line_items_attributes_0_quantity", with: "10000000000000000000000"
+
+        expect do
+          accept_confirm do
+            click_button "Save"
+          end
+          expect(page).to have_xpath("//select[@id='donation_line_items_attributes_0_item_id']")
+        end.not_to change { Donation.count }
+        expect(page).to have_content("Start a new donation")
+        expect(page).to have_content("must be less than")
       end
     end
 

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -100,9 +100,9 @@ RSpec.describe "Purchases", type: :system, js: true do
         select Vendor.first.business_name, from: "purchase_vendor_id"
         fill_in "purchase_line_items_attributes_0_quantity", with: "5"
         page.find(:css, "#__add_line_item").click
-        select_id = page.find(:xpath, '//*[@id="purchase_line_items"]/section[2]/div/*/select')[:id]
+        select_id = page.find(:xpath, '//*[@id="purchase_line_items"]/section[2]/div/*/div/select')[:id]
         select Item.alphabetized.first.name, from: select_id
-        text_id = page.find(:xpath, '//*[@id="purchase_line_items"]/section[2]/div/*/input[@type="number"]')[:id]
+        text_id = page.find(:xpath, '//*[@id="purchase_line_items"]/section[2]/div/*/div/input[@type="number"]')[:id]
         fill_in text_id, with: "10"
         fill_in "purchase_amount_spent_in_cents", with: "10"
 


### PR DESCRIPTION
Resolves #1103

### Description

This also adds tests and updates the effected tests to use the valid xpath selectors (in Donations and Purchases).

#### Tradeoffs/Decisions

* This doesn't change the behavior if for non-numeric line item quantities: it still silently discards that line item. If we want to change that, we might want a client-side validation/to play with the
field type.

* This also doesn't change the pattern of the tests. Some of the tests assume a lot about the page structure (e.g. selecting a field with `page.find(:xpath, '//*[@id="purchase_line_items"]/section[2]/div/*/div/input[@type="number"]')`). Simple Form generates some standard tags; would it be worth refactoring tests to take advantage of that?

* A confirmation box pops up even for item quantities that'll cause validation errors. This is a bit redundant, but I figure that the error might as well be caught in client-side validation. Should I handle this differently?

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

* System spec verifying that an error appears for too-large integers (`bundle exec rspec specs/system/dashboard_system_spec.rb`)
* Visual verification

### Screenshots

#### Old:
![no visible errors](https://user-images.githubusercontent.com/814638/61998693-b37b9000-b081-11e9-9671-f2be8d607e50.png)

#### New:
![visible errors](https://user-images.githubusercontent.com/814638/61998697-bd9d8e80-b081-11e9-8e0a-8db67b9cb2a6.png)
