### PR TITLE
1140 I used the existing helpers to display the purchase information

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -190,16 +190,27 @@
             <div class="box-header with-border">
               <h3 class="box-title">Purchases</h3>
               <div class="box-tools pull-right">
-                <button type="button" class="btn btn-box-tool" data-widget="collapse"><i class="fa fa-minus"></i>
+                <button
+                  type="button"
+                  class="btn btn-box-tool"
+                  data-widget="collapse">
+                    <i class="fa fa-minus"></i>
                 </button>
-                <button type="button" class="btn btn-box-tool" data-widget="remove"><i class="fa fa-times"></i></button>
+                <button
+                  type="button"
+                  class="btn btn-box-tool"
+                  data-widget="remove">
+                    <i class="fa fa-times"></i>
+                </button>
               </div>
             </div>
             <div class="box-body text-center float-center">
               <span class="float-center text-center">
                 <div class="dropdown">
                     <%= dropdown_button "dropdownMenu2", { text: "New Inventory", size: "lg" } %>
-                    <ul class="dropdown-menu float-center" style="text-align:center;margin-left: 190px;" aria-labelledby="dropdownMenu2">
+                    <ul class="dropdown-menu float-center"
+                      style="text-align:center;margin-left: 190px;"
+                      aria-labelledby="dropdownMenu2">
                      <li class="center-block">
                       <%= view_button_to purchases_path, { text: "All Purchases", type: '', size: "md" } %>
                     </li>
@@ -209,7 +220,14 @@
                     </ul>
                 </div>
               </span>
-              <h3 class="text-center"><%= total_purchased %> items received <%= display_interval %></h3>
+              <h3 class="text-center">
+                <%= total_purchased %> items purchased <%= display_interval %>
+              </h3>
+              <h3>
+                <%= item_value(@recent_purchases.sum(&:amount_spent_in_cents))%>
+                 spent 
+                <%= display_interval %>
+              </h3>
               <div class="box-body">
                 <h4>Recent purchases</h4>
                 <%= render partial: "purchase", collection: @recent_purchases, as: :purchase %>


### PR DESCRIPTION
Fixes #1140 
  - What motivated this change (if not already described in an issue)?
<img width="608" alt="Screen Shot 2019-07-27 at 3 34 01 PM" src="https://user-images.githubusercontent.com/7873934/61998839-0b1afb00-b084-11e9-8947-bdda865615b4.png">

I used already defined helpers to display the requested changes.


### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

<img width="453" alt="Screen Shot 2019-07-27 at 3 37 36 PM" src="https://user-images.githubusercontent.com/7873934/61998896-95fbf580-b084-11e9-9f01-e88962800381.png">


### How Has This Been Tested?

no new functionality added.


### Screenshots

