### PR TITLE
#1149 Removes item default scope

### DIFF
--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -19,7 +19,8 @@ class AdjustmentsController < ApplicationController
   def new
     @adjustment = current_organization.adjustments.new
     @adjustment.line_items.build
-    load_form_collections
+    @storage_locations = current_organization.storage_locations
+    @items = current_organization.items.active.alphabetized
   end
 
   # POST /adjustments

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -77,7 +77,7 @@ class DistributionsController < ApplicationController
       @distribution.line_items.build
       @distribution.copy_from_donation(params[:donation_id], params[:storage_location_id])
     end
-    @items = current_organization.items.alphabetized
+    @items = current_organization.items.active.alphabetized
     @storage_locations = current_organization.storage_locations.alphabetized
   end
 

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -105,7 +105,7 @@ class DonationsController < ApplicationController
     @donation_sites = current_organization.donation_sites.alphabetized
     @diaper_drive_participants = current_organization.diaper_drive_participants.alphabetized
     @manufacturers = current_organization.manufacturers.alphabetized
-    @items = current_organization.items.alphabetized
+    @items = current_organization.items.active.alphabetized
   end
 
   def donation_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@
 # they like with their own Items.
 class ItemsController < ApplicationController
   def index
-    @items = current_organization.items.includes(:base_item).alphabetized.class_filter(filter_params)
+    @items = current_organization.items.active.includes(:base_item).alphabetized.class_filter(filter_params)
     @storages = current_organization.storage_locations.order(id: :asc)
     @items_with_counts = ItemsByStorageCollectionQuery.new(organization: current_organization, filter_params: filter_params).call
     @items_by_storage_collection_and_quantity = ItemsByStorageCollectionAndQuantityQuery.new(organization: current_organization, filter_params: filter_params).call

--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -78,7 +78,7 @@ class PurchasesController < ApplicationController
 
   def load_form_collections
     @storage_locations = current_organization.storage_locations.alphabetized
-    @items = current_organization.items.alphabetized
+    @items = current_organization.items.active.alphabetized
     @vendors = current_organization.vendors.alphabetized
   end
 

--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -74,7 +74,8 @@ class StorageLocationsController < ApplicationController
                                            .includes(inventory_items: :item)
                                            .find(params[:id])
                                            .inventory_items
-    @inventory_items = @inventory_items.active if params[:include_inactive_items] == "true"
+                 
+    @inventory_items = @inventory_items.active unless params[:include_inactive_items] == "true"
     respond_to :json
   end
 

--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -69,11 +69,12 @@ class StorageLocationsController < ApplicationController
   end
 
   def inventory
+    
     @inventory_items = current_organization.storage_locations
                                            .includes(inventory_items: :item)
                                            .find(params[:id])
                                            .inventory_items
-                                           .active
+    @inventory_items = @inventory_items.active if params[:include_inactive_items] == "true"
     respond_to :json
   end
 

--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -69,7 +69,11 @@ class StorageLocationsController < ApplicationController
   end
 
   def inventory
-    @storage_location = current_organization.storage_locations.includes(inventory_items: :item).find(params[:id])
+    @inventory_items = current_organization.storage_locations
+                                           .includes(inventory_items: :item)
+                                           .find(params[:id])
+                                           .inventory_items
+                                           .active
     respond_to :json
   end
 

--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -69,12 +69,11 @@ class StorageLocationsController < ApplicationController
   end
 
   def inventory
-    
     @inventory_items = current_organization.storage_locations
                                            .includes(inventory_items: :item)
                                            .find(params[:id])
                                            .inventory_items
-                 
+
     @inventory_items = @inventory_items.active unless params[:include_inactive_items] == "true"
     respond_to :json
   end

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -35,7 +35,8 @@ class TransfersController < ApplicationController
   def new
     @transfer = current_organization.transfers.new
     @transfer.line_items.build
-    load_form_collections
+    @storage_locations = current_organization.storage_locations.alphabetized
+    @items = current_organization.items.active.alphabetized
   end
 
   def show

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -75,7 +75,7 @@ module Itemizable
   def to_a
     line_items.map do |l|
       # When the item isn't found, it's probably just inactive. This ensures it's available.
-      item = Item.unscoped.find(l.item_id)
+      item = Item.find(l.item_id)
       { item_id: item.id, name: item.name, quantity: l.quantity, active: item.active }.with_indifferent_access
     end
   end

--- a/app/models/inventory_item.rb
+++ b/app/models/inventory_item.rb
@@ -22,6 +22,7 @@ class InventoryItem < ApplicationRecord
   validates :quantity, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than: MAX_INT }
 
   scope :by_partner_key, ->(partner_key) { joins(:item).merge(Item.by_partner_key(partner_key)) }
+  scope :active, -> { joins(:item).where(items: { active: true }) }
 
   delegate :name, to: :item, prefix: true
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -42,7 +42,7 @@ class Item < ApplicationRecord
       .alphabetized
   }
 
-  default_scope { active }
+  # default_scope { active }
 
   def self.barcoded_items
     joins(:barcode_items).order(:name).group(:id)
@@ -58,7 +58,7 @@ class Item < ApplicationRecord
 
   def self.reactivate(item_ids)
     item_ids = Array.wrap(item_ids)
-    Item.unscoped.where(id: item_ids).find_each { |item| item.update(active: true) }
+    Item.where(id: item_ids).find_each { |item| item.update(active: true) }
   end
 
   # Override `destroy` to ensure Item isn't accidentally destroyed

--- a/app/queries/items_by_storage_collection_query.rb
+++ b/app/queries/items_by_storage_collection_query.rb
@@ -14,6 +14,7 @@ class ItemsByStorageCollectionQuery
   def call
     @items ||=  organization
                 .items
+                .active
                 .joins(' LEFT OUTER JOIN "inventory_items" ON "inventory_items"."item_id" = "items"."id"')
                 .joins(' LEFT OUTER JOIN "storage_locations" ON "storage_locations"."id" = "inventory_items"."storage_location_id"')
                 .select('

--- a/app/views/audits/_form.html.erb
+++ b/app/views/audits/_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for @audit, html: { class: "storage-location-required" } do |f| %>
-  <%= render partial: "storage_locations/source", object: f%>
+  <%= render partial: "storage_locations/source", object: f, include_inactive_items: true %>
   <fieldset style="margin-bottom: 2rem;" class="form-inline">
     <legend>Items in this audit</legend>
     <%= f.simple_fields_for :line_items do |item| %>

--- a/app/views/audits/_form.html.erb
+++ b/app/views/audits/_form.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for @audit, html: { class: "storage-location-required" } do |f| %>
-  <%= render partial: "storage_locations/source", object: f, include_inactive_items: true %>
+  <%= render partial: "storage_locations/source", object: f, locals: { include_inactive_items: true } %>
   <fieldset style="margin-bottom: 2rem;" class="form-inline">
     <legend>Items in this audit</legend>
     <%= f.simple_fields_for :line_items do |item| %>

--- a/app/views/storage_locations/_source.html.erb
+++ b/app/views/storage_locations/_source.html.erb
@@ -3,6 +3,7 @@
   label ||= "From storage location"
   error ||= "Which location are you moving inventory from?"
   association_field ||= :storage_location
+  include_inactive_items ||= false
 %>
 <%= source.association association_field,
   collection: storage_locations,
@@ -13,6 +14,7 @@
       storage_location_inventory_path: inventory_storage_location_path(
         organization_id: current_organization,
         id: ":id",
+        include_inactive_items: include_inactive_items,
         format: :json
       )
     },

--- a/app/views/storage_locations/inventory.json.jbuilder
+++ b/app/views/storage_locations/inventory.json.jbuilder
@@ -1,4 +1,4 @@
-json.array! @storage_location.inventory_items do |inventory|
+json.array! @inventory_items do |inventory|
   json.item_id inventory.item.id
   json.item_name inventory.item.name
   json.quantity inventory.quantity

--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -39,13 +39,13 @@
     <fieldset style="margin-bottom: 2rem;" class="form-inline">
       <legend>Items in this donation</legend>
       <%= f.simple_fields_for :line_items do |item| %>
-        <div id="donation_line_items" class="line-item-fields" data-capture-barcode="true">
+        <div id="transfer_line_items" class="line-item-fields" data-capture-barcode="true">
           <%= render 'line_items/line_item_fields', f: item %>
         </div>
       <% end %>
       <div class="row links">
         <div class="col-xs-12">
-          <%= add_line_item_button f, "#donation_line_items" %>
+          <%= add_line_item_button f, "#transfer_line_items" %>
         </div>
       </div>
 

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -14,7 +14,7 @@
 #
 
 def random_request_items
-  keys = Item.all.pluck(:id).sample(3)
+  keys = Item.active.pluck(:id).sample(3)
   keys.map { |k| { "item_id" => k, "quantity" => rand(3..10) } }
 end
 

--- a/spec/features/item_spec.rb
+++ b/spec/features/item_spec.rb
@@ -1,3 +1,4 @@
+# TODO: Can this be deleted?
 RSpec.feature "Item management", type: :feature do
   before do
     sign_in(@user)
@@ -81,7 +82,7 @@ RSpec.feature "Item management", type: :feature do
       within "tr[data-item-id='#{item.id}']" do
         click_on "Delete", match: :first
       end
-    end.not_to change { Item.unscoped.count }
+    end.not_to change { Item.count }
     item.reload
     expect(item).not_to be_active
     visit url_prefix + "/items"

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Donation, type: :model do
             subject.replace_increase!(attributes)
             storage_location.reload
           end.to change { storage_location.size }.by(5) # We had 5 items of a different kind before, now we have 10
-                                                 .and change { Item.count }.by(1)
+                                                 .and change { Item.active.count }.by(1)
         end
       end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe Item, type: :model do
 
       it "only hides an item that has history" do
         item = create(:line_item, :purchase).item
-        expect { item.destroy }.to change { Item.unscoped.count }.by(0).and change { Item.count }.by(-1)
+        expect { item.destroy }.to change { Item.count }.by(0).and change { Item.active.count }.by(-1)
         expect(item).not_to be_active
       end
     end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Item, type: :model do
         create(:item, base_item: c1, partner_key: "foo", organization: @organization)
         create(:item, base_item: c2, partner_key: "bar", organization: @organization)
         expect(Item.by_partner_key("foo").size).to eq(1)
-        expect(Item.all.size).to be > 1
+        expect(Item.active.size).to be > 1
       end
     end
   end

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe Purchase, type: :model do
             subject.replace_increase!(attributes)
             storage_location.reload
           end.to change { storage_location.size }.by(5)
-                                                 .and change { Item.count }.by(1)
+                                                 .and change { Item.active.count }.by(1)
         end
       end
     end

--- a/spec/requests/api/v1/api_v1_family_requests_spec.rb
+++ b/spec/requests/api/v1/api_v1_family_requests_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe "API::V1::FamilyRequests", type: :request do
   describe "POST /api/v1/family_requests" do
-    let(:items) { Item.all.sample(3) }
+    let(:items) { Item.active.sample(3) }
     let(:request_items) do
       items.collect do |item|
         {

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -42,15 +42,17 @@ RSpec.describe "Adjustment management", type: :system, js: true do
 
       item = Item.alphabetized.first
 
-      select @storage_location.name, from: "From storage location"
+      select storage_location.name, from: "From storage location"
       expect(page).to have_content(item.name)
       select item.name, from: "adjustment_line_items_attributes_0_item_id"
 
       item.update(active: false)
 
       page.refresh
-      select @storage_location.name, from: "From storage location"
-      expect(page).to have_no_content(item.name)
+      within "#new_adjustment" do
+        select storage_location.name, from: "From storage location"
+        expect(page).to have_no_content(item.name)
+      end
     end
   end
 

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -36,6 +36,22 @@ RSpec.describe "Adjustment management", type: :system, js: true do
       end.to change { storage_location.size }.by(sub_quantity)
       expect(page).to have_content(/Adjustment was successful/i)
     end
+
+    it "Does not include inactive items in the line item fields" do
+      visit url_prefix + "/adjustments/new"
+
+      item = Item.alphabetized.first
+
+      select @storage_location.name, from: "From storage location"
+      expect(page).to have_content(item.name)
+      select item.name, from: "adjustment_line_items_attributes_0_item_id"
+
+      item.update(active: false)
+
+      page.refresh
+      select @storage_location.name, from: "From storage location"
+      expect(page).to have_no_content(item.name)
+    end
   end
 
   it "can filter the #index by storage location" do

--- a/spec/system/audit_system_spec.rb
+++ b/spec/system/audit_system_spec.rb
@@ -35,6 +35,22 @@ RSpec.describe "Audit management", type: :system, js: true do
       sign_in(@organization_admin)
     end
 
+    it "*Does* include inactive items in the line item fields" do
+      visit url_prefix + "/audits/new"
+
+      item = Item.alphabetized.first
+      
+      select storage_location.name, from: "From storage location"
+      expect(page).to have_content(item.name)
+      select item.name, from: "audit_line_items_attributes_0_item_id"
+
+      item.update(active: false)
+
+      page.refresh
+      select storage_location.name, from: "From storage location"
+      expect(page).to have_content(item.name)
+    end
+
     context "when viewing the audits index" do
       subject { url_prefix + "/audits" }
 

--- a/spec/system/audit_system_spec.rb
+++ b/spec/system/audit_system_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Audit management", type: :system, js: true do
       visit url_prefix + "/audits/new"
 
       item = Item.alphabetized.first
-      
+
       select storage_location.name, from: "From storage location"
       expect(page).to have_content(item.name)
       select item.name, from: "audit_line_items_attributes_0_item_id"

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -47,6 +47,23 @@ RSpec.feature "Distributions", type: :system do
     end
   end
 
+  it "Does not include inactive items in the line item fields" do
+    visit @url_prefix + "/distributions/new"
+
+    item = Item.alphabetized.first
+
+    select @storage_location.name, from: "From storage location"
+    expect(page).to have_content(item.name)
+    select item.name, from: "distribution_line_items_attributes_0_item_id"
+
+    item.update(active: false)
+
+    page.refresh
+    select @storage_location.name, from: "From storage location"
+    expect(page).to have_no_content(item.name)
+  end
+
+
   it "User doesn't fill storage_location" do
     visit @url_prefix + "/distributions/new"
 

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -63,7 +63,6 @@ RSpec.feature "Distributions", type: :system do
     expect(page).to have_no_content(item.name)
   end
 
-
   it "User doesn't fill storage_location" do
     visit @url_prefix + "/distributions/new"
 

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -91,7 +91,7 @@ RSpec.feature "Distributions", type: :system do
             click_on "Reclaim"
           end
           page.find ".alert"
-        end.to change { Distribution.count }.by(-1).and change { Item.count }.by(1)
+        end.to change { Distribution.count }.by(-1).and change { Item.active.count }.by(1)
         expect(page).to have_content "reclaimed"
       end
     end

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -164,6 +164,20 @@ RSpec.describe "Donations", type: :system, js: true do
         expect(Donation.last.line_items.first.quantity).to eq(15)
       end
 
+      it "Does not include inactive items in the line item fields" do
+        item = Item.alphabetized.first
+
+        select StorageLocation.first.name, from: "donation_storage_location_id"
+        expect(page).to have_content(item.name)
+        select item.name, from: "donation_line_items_attributes_0_item_id"
+
+        item.update(active: false)
+
+        page.refresh
+        select StorageLocation.first.name, from: "donation_storage_location_id"
+        expect(page).to have_no_content(item.name)
+      end
+
       it "Allows User to create a donation for a Diaper Drive source" do
         select Donation::SOURCES[:diaper_drive], from: "donation_source"
         expect(page).to have_xpath("//select[@id='donation_diaper_drive_participant_id']")

--- a/spec/system/item_system_spec.rb
+++ b/spec/system/item_system_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe "Item management", type: :system do
             end
           end
           page.find(".alert-info")
-        end.to change { Item.unscoped.count }.by(0).and change { Item.count }.by(-1)
+        end.to change { Item.count }.by(0).and change { Item.active.count }.by(-1)
         subject.reload
         expect(subject).not_to be_active
       end
@@ -83,7 +83,7 @@ RSpec.describe "Item management", type: :system do
             end
           end
           page.find(".alert-info")
-        end.to change { Item.unscoped.count }.by(-1).and change { Item.count }.by(-1)
+        end.to change { Item.count }.by(-1).and change { Item.active.count }.by(-1)
         expect { subject.reload }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -94,6 +94,22 @@ RSpec.describe "Purchases", type: :system, js: true do
         expect(Purchase.last.issued_at).to eq(Date.parse("01/01/2001"))
       end
 
+      it "Does not include inactive items in the line item fields" do
+        visit url_prefix + "/purchases/new"
+
+        item = Item.alphabetized.first
+
+        select StorageLocation.first.name, from: "purchase_storage_location_id"
+        expect(page).to have_content(item.name)
+        select item.name, from: "purchase_line_items_attributes_0_item_id"
+
+        item.update(active: false)
+
+        page.refresh
+        select StorageLocation.first.name, from: "purchase_storage_location_id"
+        expect(page).to have_no_content(item.name)
+      end
+
       it "multiple line items for the same item type are accepted and combined on the backend" do
         select StorageLocation.first.name, from: "purchase_storage_location_id"
         select Item.alphabetized.first.name, from: "purchase_line_items_attributes_0_item_id"

--- a/spec/system/transfer_system_spec.rb
+++ b/spec/system/transfer_system_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe "Transfer management", type: :system do
     end
   end
 
-
   it "can transfer an inventory from a storage location to another as a user" do
     from_storage_location = create(:storage_location, :with_items, item: item, name: "From me", organization: @organization)
     to_storage_location = create(:storage_location, :with_items, name: "To me", organization: @organization)

--- a/spec/system/transfer_system_spec.rb
+++ b/spec/system/transfer_system_spec.rb
@@ -18,6 +18,26 @@ RSpec.describe "Transfer management", type: :system do
     end
   end
 
+  it "Does not include inactive items in the line item fields" do
+    storage_location = create(:storage_location, :with_items, item: item, item_quantity: 10, name: "From me", organization: @organization)
+    item = Item.alphabetized.first
+
+    visit url_prefix + "/transfers/new"
+
+    select storage_location.name, from: "From storage location"
+    expect(page).to have_content(item.name)
+    select item.name, from: "transfer_line_items_attributes_0_item_id"
+
+    item.update(active: false)
+
+    page.refresh
+    within "#new_transfer" do
+      select storage_location.name, from: "From storage location"
+      expect(page).not_to have_content(item.name)
+    end
+  end
+
+
   it "can transfer an inventory from a storage location to another as a user" do
     from_storage_location = create(:storage_location, :with_items, item: item, name: "From me", organization: @organization)
     to_storage_location = create(:storage_location, :with_items, name: "To me", organization: @organization)


### PR DESCRIPTION
Fixes #1149 

This removes the default_scope for `Item`, which previously had all Item queries defaulting to `active: true`. We essentially replaced every instance of `unscoped` with nothing, and checked for instances of `Item.all` etc. 

I can't promise that this is 100% exhaustive, so please be on the lookout for cases where soft-deleted items are showing up where they shouldn't be (just add the `.active` scope in those cases)

We fixed some specs, too.