### PR TITLE
Hide edit button and add alerts when a distribution date has passed

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -28,7 +28,7 @@
 window.setTimeout(function() {
     // When the user is given an error message, we should not auto-hide it so that
     // they can fully read it and potentially copy/paste it into an issue.
-    $(".alert").not(".alert-danger").fadeTo(1000, 0).slideUp(1000, function(){
+    $(".alert").not(".alert-danger, .alert-warning").fadeTo(1000, 0).slideUp(1000, function(){
         $(this).remove();
     });
 }, 2500);

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -92,9 +92,15 @@ class DistributionsController < ApplicationController
 
   def edit
     @distribution = Distribution.includes(:line_items).includes(:storage_location).find(params[:id])
-    @distribution.line_items.build
-    @items = current_organization.items.alphabetized
-    @storage_locations = current_organization.storage_locations.alphabetized
+    if @distribution.future? || current_user.organization_admin?
+      @distribution.line_items.build
+      @items = current_organization.items.alphabetized
+      @storage_locations = current_organization.storage_locations.alphabetized
+    else
+      flash[:error] = 'To edit a distribution,
+      you must be an organization admin or the current date must be major then today.'
+      redirect_to distributions_path
+    end
   end
 
   def update

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -133,4 +133,8 @@ class Distribution < ApplicationRecord
       line_items.total
     ]
   end
+
+  def future?
+    issued_at > Time.zone.today
+  end
 end

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -6,12 +6,14 @@
   <td><%= item_value(distribution_row.value_per_itemizable) %></td>
   <td class="text-right">
     <%= view_button_to distribution_path(distribution_row) %>
-    <%= edit_button_to edit_distribution_path(distribution_row) %>
+    <% if distribution_row.future? || current_user.organization_admin? %>
+      <%= edit_button_to edit_distribution_path(distribution_row) %>
+    <% end %>
     <%= print_button_to print_distribution_path(distribution_row, format: :pdf) %>
     <%= delete_button_to distribution_path(distribution_row),
           { confirm: "Are you sure you want to reclaim this distribution to #{distribution_row.partner.name}?",
             text: "Reclaim",
-            icon: "undo" } 
+            icon: "undo" }
     %>
   </td>
 </tr>

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -17,6 +17,14 @@
 <!-- Main content -->
 <section class="content">
 
+<% unless @distribution.future? %>
+    <div class="alert alert-warning", role="alert">
+      The current date is past the date this distribution was picked up.
+      Please be very careful when editing this record;
+      the contents should match what was given to the recipient.
+    </div>
+<% end %>
+
 <!-- Default box -->
 <div class="box">
   <div class="box-body">

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -54,7 +54,9 @@
       </div>
     </div>
     <div class="box-footer with-border">
-      <%= edit_button_to edit_distribution_path(@distribution), {text: "Make a Correction", size: "lg"} %>
+      <% if @distribution.future? || current_user.organization_admin? %>
+        <%= edit_button_to edit_distribution_path(@distribution), {text: "Make a Correction", size: "lg"} %>
+      <% end %>
       <%= print_button_to print_distribution_path(@distribution, format: :pdf), {size: "lg"} %>
     </div>
   </div>

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -137,5 +137,22 @@ RSpec.describe Distribution, type: :model do
         end.to change { subject.storage_location.size }.by(8)
       end
     end
+
+    describe "#future?" do
+      let(:dist1)    { create(:distribution, issued_at: Time.zone.tomorrow) }
+      let(:dist2)    { create(:distribution, issued_at: Time.zone.yesterday) }
+
+      context "when issued_at has not passed" do
+        it "returns true" do
+          expect(dist1.future?).to be true
+        end
+      end
+
+      context "when issued_at has passed" do
+        it "returns false" do
+          expect(dist2.future?).to be false
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #591  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

The Edit button is hidden to normal users when the issued_at date of a distribution passed. Changes were made on index and show pages. 
When an admin tries to edit a passed distribution, a flash warning message was showed.
Specs are created to test the changes.

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
Specs are created and all tests were green.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

![Screen Shot 2019-08-05 at 21 36 11](https://user-images.githubusercontent.com/27960597/62504957-1206e380-b7d1-11e9-9aca-33b2638d2214.png)
![Screen Shot 2019-08-05 at 22 12 11](https://user-images.githubusercontent.com/27960597/62504965-16cb9780-b7d1-11e9-88ad-8d3234d46ed7.png)

