### PR TITLE
Adds factory_bot:lint back to CI. Forces default line item factory to be a donation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ install:
 - yarn install
 script:
 - bundle exec rubocop
+- bundle exec rake factory_bot:lint
 - export RAILS_ENV=test
 - bundle exec rake db:create db:schema:load
 - bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ install:
 - yarn install
 script:
 - bundle exec rubocop
-- bundle exec rake factory_bot:lint
 - export RAILS_ENV=test
 - bundle exec rake db:create db:schema:load
+- bundle exec rake factory_bot:lint
 - bundle exec rspec
 after_success:
 - if [ $TRAVIS_PULL_REQUEST == false ] && [ $TRAVIS_BRANCH == "master" ]; then

--- a/spec/factories/line_items.rb
+++ b/spec/factories/line_items.rb
@@ -14,9 +14,15 @@
 FactoryBot.define do
   factory :line_item do
     quantity { 1 }
-    item
+    item { create(:item) }
+    for_donation
 
     trait :donation do
+      itemizable_type { "Donation" }
+      itemizable_id { create(:donation).id }
+    end
+
+    trait :for_donation do
       itemizable_type { "Donation" }
       itemizable_id { create(:donation).id }
     end


### PR DESCRIPTION
- This allows us to automatically verify our factories. 
- This makes testing more realistic as line_items are not valid without an itemizable.

Caveats: I really don't like defining both donation and for_donation, but it seems the trait has to start with `for_` to be recognized as a valid default???