### PR TITLE
Removes css class that was interfering with blanks showing on distributions given item lookup failure

### DIFF
--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -39,7 +39,7 @@
     <fieldset style="margin-bottom: 2rem;" class="form-inline">
       <legend>Items in this distribution</legend>
       <%= f.simple_fields_for :line_items do |item| %>
-        <div id="distribution_line_items" class="line-item-fields" data-capture-barcode="true">
+        <div id="distribution_line_items" data-capture-barcode="true">
           <%= render 'line_items/line_item_fields', f: item %>
         </div>
       <% end %>


### PR DESCRIPTION
With this class present, distribution edit page does not have blank and does not have "Choose this item". This removal fixes that.