### PR TITLE
Fixes autofocus issue with barcode scanning -- booping now automatica…

### DIFF
--- a/app/assets/javascripts/barcode_items.js.erb
+++ b/app/assets/javascripts/barcode_items.js.erb
@@ -92,6 +92,6 @@ $(document).ready(function() {
     // Saving this to the modal so the modal knows which field to trigger when it's done.
     $("#trigger-field-id").val($(src).attr('id'));
     $("#newBarcode").modal();
-    // TODO: Prompt the user with a dialog to create a new barcode entry, then add that to the form
+    $("#barcode_item_quantity").focus();
   }
 });

--- a/app/views/barcode_items/_barcode_modal.html.erb
+++ b/app/views/barcode_items/_barcode_modal.html.erb
@@ -16,7 +16,7 @@
           <div class="row">
             <%= f.input :quantity, label: "Quantity", wrapper: :vertical_input_group do %>
               <span class="input-group-addon"><i class="fa fa-sort-numeric-desc"></i></span>
-              <%= f.input_field :quantity, class: "form-control" %>
+              <%= f.input_field :quantity, class: "form-control", autofocus: true %>
               <% end %>
           </div><!-- /.row -->
           <div class="row">

--- a/app/views/barcode_items/create.js.erb
+++ b/app/views/barcode_items/create.js.erb
@@ -18,4 +18,4 @@ line_item = $('#' + source_field).closest('.nested-fields');
 $(line_item).find('input[type=number]').val(quantity);
 $(line_item).find('[value="' + item_id + '"]').attr("selected", true);
 $('#__add_line_item').trigger('click');
-$(line_item).parent().find('.nested-fields:last-child input.__barcode_item_lookup').focus();
+$("input.__barcode_item_lookup").last().focus();


### PR DESCRIPTION
This does 2 things:

 - Simplifies the focus() change after a barcode is booped (we were using a complicated jquery selector, but I switched it to a simpler one)
 - Adds an autofocus to the quantity field of the barcode modal

This restores the workflow we had previously