### PR TITLE
Bugfix: Dashboard recent purchases value

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,7 +4,9 @@ class DashboardController < ApplicationController
 
   def index
     @recent_donations = current_organization.donations.includes(:line_items).during(helpers.selected_range).recent
-    @recent_purchases = current_organization.purchases.includes(:line_items).during(helpers.selected_range).recent
+    @purchases = current_organization.purchases.includes(:line_items).during(helpers.selected_range)
+    @recent_purchases = @purchases.recent
+
     @recent_distributions = current_organization.distributions.includes(:line_items).during(helpers.selected_range).recent
     @total_inventory = current_organization.total_inventory
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -225,8 +225,8 @@
                 <%= total_purchased %> items purchased <%= display_interval %>
               </h3>
               <h3>
-                <%= item_value(@recent_purchases.sum(&:amount_spent_in_cents))%>
-                 spent 
+                <%= item_value(@purchases.sum(&:amount_spent_in_cents))%>
+                 spent
                 <%= display_interval %>
               </h3>
               <div class="box-body">


### PR DESCRIPTION
Resolves #1205 

### Description
On dashboard controllers, the query was correct just before calling `.recent` so I added a new variable to track the purchases from the selected_range then keep recent_purchases with the recent call.

### Type of change

* Bugfix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Thought the local development environment.

### Screenshots
before:
![image](https://user-images.githubusercontent.com/9721558/64894233-90b43380-d64f-11e9-81c2-6efb27cdf725.png)
after:
![image](https://user-images.githubusercontent.com/9721558/64894333-c5c08600-d64f-11e9-9689-39ca261a741e.png)


