### PR TITLE
Value per item, distribution quantity and package size on item show page

### DIFF
--- a/app/assets/stylesheets/AdminLTE.scss
+++ b/app/assets/stylesheets/AdminLTE.scss
@@ -1738,6 +1738,11 @@ a:focus {
   margin: 0;
   line-height: 1;
 }
+.box-header > .box-subtitle {
+  font-size: 12px;
+  margin-left: 9px;
+  color: #676565;
+}
 .box-header > .fa,
 .box-header > .glyphicon,
 .box-header > .ion {

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -21,6 +21,11 @@
 <div class="box">
   <div class="box-header with-border">
     <h3 class="box-title"><%= @item.name %>  <%= item_value(@item.value_in_cents, ', value per Item (in cents): ') %></h3>
+    <small class="box-subtitle">
+      Value per item: <%= @item.value_in_cents ? @item.value_in_cents : 0 %> | 
+      Distribution quantity: <%= @item.distribution_quantity ? @item.distribution_quantity : 0 %> |
+      Package size: <%= @item.package_size ? @item.package_size : 0 %>
+    </small>
   </div>
   <div class="box-body">
 


### PR DESCRIPTION
Resolves #1076  <!--fill issue number-->

### Description

Hello everyone! I saw the issue and I thought that it is abandoned, so what I did was to insert this data on the item show view, of course than I can change the style if anyone have better idea :) 

### Screenshots
Before:
![Screenshot from 2019-09-17 10-19-03](https://user-images.githubusercontent.com/49662698/65045285-e4b36680-d934-11e9-8d05-f2f81f31fbd6.png)

After:
![Screenshot from 2019-09-17 10-18-54](https://user-images.githubusercontent.com/49662698/65045286-e715c080-d934-11e9-9d1f-efa3ad49c105.png)
