### PR TITLE
Fix: Remove fdescribe from specs

### DIFF
--- a/spec/controllers/barcode_items_controller_spec.rb
+++ b/spec/controllers/barcode_items_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe BarcodeItemsController, type: :controller do
       end
     end
 
-    fdescribe "GET #edit" do
+    describe "GET #edit" do
       context "with a normal barcode item" do
         subject { get :edit, params: default_params.merge(id: create(:barcode_item)) }
 
@@ -41,7 +41,7 @@ RSpec.describe BarcodeItemsController, type: :controller do
       end
     end
 
-    fdescribe "GET #show" do
+    describe "GET #show" do
       context "with a normal barcode item" do
         subject { get :show, params: default_params.merge(id: create(:barcode_item)) }
 


### PR DESCRIPTION
Resolves #1211

### Description
Remove `fdecribe` from specific specs to let rspec run all specs instead of only these ones. Specs helper has `config.filter_run_when_matching :focus` so if any spec has `fdescribe`, `fcontext` or the tag `:focus` Rspec will run only these ones. My change consisted of removing `fdescribe` only, but if needed we can remove or comment the config to avoid further problems, `fdescibe` can easily go unnoticed on pull requests.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Running the suite through `rspec` command.
