### PR TITLE
Reorganize routes.rb.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ def set_up_sidekiq
 
     Sidekiq::Web.use Rack::Auth::Basic do |username, password|
       compare.(username, ENV["SIDEKIQ_USERNAME"]) && compare.(password, ENV["SIDEKIQ_PASSWORD"])
+    end
   end
 
   mount Sidekiq::Web => '/sidekiq'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,20 +1,17 @@
 def set_up_sidekiq
-
   require 'sidekiq/web'
   require 'sidekiq-scheduler/web'
 
   if Rails.env.production?
     Sidekiq::Web.use Rack::Auth::Basic do |username, password|
-      ActiveSupport::SecurityUtils.secure_compare(username, ENV["SIDEKIQ_USERNAME"]) \
-          && \
-          ActiveSupport::SecurityUtils.secure_compare(password, ENV["SIDEKIQ_PASSWORD"])
+      compare = ->(s1, s2) { ActiveSupport::SecurityUtils.secure_compare(s1, s2) }
+      compare.(username, ENV["SIDEKIQ_USERNAME"]) && compare.(password, ENV["SIDEKIQ_PASSWORD"])
     end
   end
 
   mount Sidekiq::Web => '/sidekiq'
   Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
 end
-
 
 def set_up_flipper
   flipper_app = Flipper::UI.app(Flipper.instance) do |builder|
@@ -24,7 +21,6 @@ def set_up_flipper
   end
   mount flipper_app, at: "/flipper"
 end
-
 
 Rails.application.routes.draw do
   devise_for :users

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,8 @@ def set_up_sidekiq
   if Rails.env.production?
     Sidekiq::Web.use Rack::Auth::Basic do |username, password|
       ActiveSupport::SecurityUtils.secure_compare(username, ENV["SIDEKIQ_USERNAME"]) \
-      && \
-      ActiveSupport::SecurityUtils.secure_compare(password, ENV["SIDEKIQ_PASSWORD"])
+          && \
+          ActiveSupport::SecurityUtils.secure_compare(password, ENV["SIDEKIQ_PASSWORD"])
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,15 +4,10 @@ def set_up_sidekiq
   require 'sidekiq-scheduler/web'
 
   if Rails.env.production?
-
-    digest = ->(string) { ::Digest::SHA256.hexdigest(string) }
-
-    compare = ->(string1, string2) do
-      ActiveSupport::SecurityUtils.secure_compare(digest.(string1), digest.(string2))
-    end
-
     Sidekiq::Web.use Rack::Auth::Basic do |username, password|
-      compare.(username, ENV["SIDEKIQ_USERNAME"]) && compare.(password, ENV["SIDEKIQ_PASSWORD"])
+      ActiveSupport::SecurityUtils.secure_compare(username, ENV["SIDEKIQ_USERNAME"]) \
+      && \
+      ActiveSupport::SecurityUtils.secure_compare(password, ENV["SIDEKIQ_PASSWORD"])
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ def set_up_sidekiq
   if Rails.env.production?
     Sidekiq::Web.use Rack::Auth::Basic do |username, password|
       compare = ->(s1, s2) { ActiveSupport::SecurityUtils.secure_compare(s1, s2) }
-      compare.(username, ENV["SIDEKIQ_USERNAME"]) && compare.(password, ENV["SIDEKIQ_PASSWORD"])
+      compare.call(username, ENV["SIDEKIQ_USERNAME"]) && compare.call(password, ENV["SIDEKIQ_PASSWORD"])
     end
   end
 


### PR DESCRIPTION
I'd like to propose the following changes to routes.rb:

* Move code setting up sidekiq and flipper to separate functions. This makes it more explicit and clear that those lines of code are used for those purposes, and separates high from low level code, enabling simple one line calls in the main routes code block.
* Define lambdas for `digest` and `compare`, which
  * also separates high and low level code
  * makes the code more DRY
  * more clearly defines the logic.
* Change `&` to `&&` for the logical operation.

It looks like `secure_compare` already creates digests of the strings it compares (see https://api.rubyonrails.org/classes/ActiveSupport/SecurityUtils.html#method-c-secure_compare), so I will remove that code. This might eliminate the need for the lambdas.

I have not tested this code yet; I don't know how I would do that.