### PR TITLE
#1222  Simplified DonationsController#total_value. 

### DIFF
--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe DonationsController, type: :controller do
       subject { delete :destroy, params: default_params.merge(id: donation.id) }
 
       # normal users are not authorized
-      it "redirects to the dashbaord path" do
+      it "redirects to the dashboard path" do
         expect(subject).to redirect_to(dashboard_path)
       end
     end
@@ -220,6 +220,21 @@ RSpec.describe DonationsController, type: :controller do
 
       patch :remove_item, params: single_params
       expect(response).to be_redirect
+    end
+  end
+
+  context 'calculating total value of multiple donations' do
+    it 'works correctly for multiple line items per donation' do
+      donations = [
+        create(:donation, :with_items, item_quantity: 1),
+        create(:donation, :with_items, item_quantity: 2)
+      ]
+      value = subject.send(:total_value, donations) # private method, need to use `send`
+      expect(value).to eq(300)
+    end
+
+    it 'returns zero for an empty array of donations' do
+      expect(subject.send(:total_value, [])).to be_zero # private method, need to use `send`
     end
   end
 end

--- a/spec/factories/donations.rb
+++ b/spec/factories/donations.rb
@@ -40,8 +40,11 @@ FactoryBot.define do
     end
 
     trait :with_items do
-      storage_location { create :storage_location, :with_items, item: item || create(:item), organization: organization }
-
+      storage_location do
+        create :storage_location, :with_items,
+               item: item || create(:item, value_in_cents: 100),
+               organization: organization
+      end
       transient do
         item_quantity { 100 }
         item { nil }

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -264,7 +264,9 @@ RSpec.feature "Distributions", type: :system do
 
         expect(page).to have_css "td"
         item_row = find("td", text: diaper_type).find(:xpath, '..')
-        expect(item_row).to have_content("#{diaper_type} 4")
+
+        # TODO: Find out how to test for diaper type and 4 without the dollar amounts.
+        expect(item_row).to have_content("#{diaper_type} $1.00 $4.00 4")
       end
     end
   end


### PR DESCRIPTION
Resolves #1222

### Description

Simplified DonationsController#total_value. 

In the course of this, the following changes were also made:

Specify value_in_cents as 100 for items in donation test factory.
Add unit tests to test total value calculation in donation controller.
Remove private on line by itself and instead preface individual method definitions w/private.
Disabled Rubocop that was complaining about `private def...`.
   

### How Has This Been Tested?

RSpec tests added in DonationsController test file.