### PR TITLE
[1219] Assign a one dollar value to random items in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -263,7 +263,7 @@ end
 end
 
 # Assign a value to all items so we can verify that totals are working
-Item.where(value_in_cends: 0).update_all(value_in_cents: 100)
+Item.where(value_in_cents: 0).update_all(value_in_cents: 100)
 
 # Create some Vendors so Purchases can have vendor_ids
 5.times do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,6 +48,11 @@ sf_org = Organization.find_or_create_by!(short_name: "sf_bank") do |organization
 end
 Organization.seed_items(sf_org)
 
+# Assign a value to some organization items to verify totals are working
+Organization.all.each do |org|
+  org.items.where(value_in_cents: 0).limit(10).update_all(value_in_cents: 100)
+end
+
 # super admin
 user = User.create email: 'superadmin@example.com', password: 'password', password_confirmation: 'password', organization_admin: false, super_admin: true
 
@@ -261,9 +266,6 @@ end
     status: status
   )
 end
-
-# Assign a value to all items so we can verify that totals are working
-Item.where(value_in_cents: 0).update_all(value_in_cents: 100)
 
 # Create some Vendors so Purchases can have vendor_ids
 5.times do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -262,6 +262,9 @@ end
   )
 end
 
+# Assign a value to all items so we can verify that totals are working
+Item.update_all(value_in_cents: 100)
+
 # Create some Vendors so Purchases can have vendor_ids
 5.times do
   Vendor.create(

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -263,7 +263,7 @@ end
 end
 
 # Assign a value to all items so we can verify that totals are working
-Item.update_all(value_in_cents: 100)
+Item.where(value_in_cends: 0).update_all(value_in_cents: 100)
 
 # Create some Vendors so Purchases can have vendor_ids
 5.times do


### PR DESCRIPTION
Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- [x] I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- [x] Title include "WIP" if work is in progress.

Resolves https://github.com/rubyforgood/diaper/issues/1219

### Description

This assigns a non-zero value to some donation items in the seeds to allow developers to quickly (and visually) confirm that the totals are working on the donations listing page. Per the issue, the value is set to $1.00 for only some of the items. This ensures that a quick visual check works, but also allows some items' value to be 0, which is a valid value.

Note that the seeds randomly create donation items, so I didn't specify _which_ items will get a value. But, all seeded organizations will receive items with values. It seems that donations are only created for the `pdx_org` in the seeds.

Another note -- there is a method defined on `Organization` for seeding the item data. I didn't change this method as I wasn't comfortable changing the code in the model itself. But, if these methods are truly only used for seeding data, it might not be necessary to define them in the model or have associated unit tests. 🤷‍♀  

### Type of change

* Seeds update

### How Has This Been Tested?

* Re-ran seeds: `bin/rake db:seed`
* Tested visually on http://localhost:3000/diaper_bank/donations
* Ran tests just for fun: bundle exec rake

### Screenshots

<img width="989" alt="Screen Shot 2019-10-03 at 9 58 03 PM" src="https://user-images.githubusercontent.com/7559041/66175873-5e33a000-e629-11e9-8a03-70a4d30b1f9c.png">

