### PR TITLE
Fixes PDF spacing issue so that logos don't run into text on the left and makes some text bigger

### DIFF
--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -7,40 +7,47 @@ class DistributionPdf
     @distribution = distribution
     font_families["OpenSans"] = PrawnRails.config["font_families"][:OpenSans]
     font "OpenSans"
-    font_size 9
+    font_size 10
 
     image organization.logo_path, fit: [325, 110]
-    bounding_box [bounds.right - 225, bounds.top - 20], width: 225 do
+
+    bounding_box [bounds.right - 225, bounds.top], width: 225, height: 50 do
       text organization.name, align: :right
       text organization.address, align: :right
       text organization.email, align: :right
     end
+
+    text "Issued to:", style: :bold, align: :right
+    font_size 12
+    text @distribution.partner.name, align: :right
+    font_size 10
+    move_down 10
+
+    text "Issued on:", style: :bold, align: :right
+    font_size 12
+    text @distribution.distributed_at, align: :right
+    font_size 10
+    move_down 10
+
+    text "Items Received Year-to-Date:", style: :bold, align: :right
+    font_size 12
+    text @distribution.partner.quantity_year_to_date.to_s, align: :right
+    font_size 10
+    move_up 10
+
+    text "Comments:", style: :bold
+    font_size 12
+    text @distribution.comment
+
+    move_down 20
+
     data = [["Items Received", "Value/item", "Total value", "Quantity", "Packages"]]
     data += @distribution.line_items.sorted.map do |c|
       [c.item.name, item_value(c.item.value_in_cents), item_value(c.value_per_line_item), c.quantity, c.package_count]
     end
     data += [["", "", "", "", ""], ["Total Items Received", "", item_value(@distribution.value_per_itemizable), @distribution.line_items.total, ""]]
 
-    move_down 35
-
-    text "Issued to:", style: :bold
-    text @distribution.partner.name
-    move_down 10
-
-    text "Issued on:", style: :bold
-    text @distribution.distributed_at
-    move_down 10
-
-    text "Items Received Year-to-Date", style: :bold
-    text @distribution.partner.quantity_year_to_date.to_s
-    move_down 10
-
-    text "Comments:", style: :bold
-    text @distribution.comment
-
-    move_down 20
-
-    font_size 9
+    font_size 11
     # Line item table
     table(data) do
       self.header = true
@@ -89,16 +96,7 @@ class DistributionPdf
         font_size 9
         stroke_horizontal_rule
         move_down(5)
-        # table([
-        #   [organization.name, organization.address_inline, ""],
-        # ]) do
-        #   self.width = bounds.width
-        #   cells.borders = []
-        #   column(0).width = 125
-        #   column(2).width = 125
-        #   column(1).style align: :center
-        #   column(2).style align: :right
-        # end
+
         logo_offset = (bounds.width - 190) / 2
         bounding_box([logo_offset, 0], width: 190, height: 33) do
           text "Lovingly created with", valign: :center


### PR DESCRIPTION
We had some feedback that the logo was running into the header text on the PDF.

I updated this to push most of the header text to the right (known widths) and leave the comments to the left (unknown length / width).

I also made user-entered text a little bigger in the header, and as big as I could make it (11) in the table. labels are still size 10 to conserve on space. 