### PR TITLE
1189 | when creating new org as site admin, do not require PW

### DIFF
--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -27,7 +27,14 @@ class Admin::OrganizationsController < AdminController
     @organization = Organization.create(organization_params)
     if @organization.save
       Organization.seed_items(@organization)
-      @organization.users.try(:last).try(:invite!)
+      # @organization.users.try(:last).try(:invite!)
+      # binding.pry
+      User.invite!(params[:organization][:users_attributes]['0'], organization_id: @organization.id)
+      # User.invite!(name: params[:organization][:users_attributes]['0'][:name],
+      #              email: params[:organization][:users_attributes]['0'][:email],
+      #              organization_admin: params[:organization][:users_attributes]['0'][:organization_admin],
+      #              organization_id: @organization.id)
+      # binding.pry
       redirect_to admin_organizations_path, notice: "Organization added!"
     else
       flash[:error] = "Failed to create Organization."
@@ -52,7 +59,14 @@ class Admin::OrganizationsController < AdminController
 
   def organization_params
     params.require(:organization)
-          .permit(:name, :short_name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location, :default_email_text,
-                  users_attributes: %i(name email password password_confirmation organization_admin))
+          .permit(:name, :short_name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location, :default_email_text)
+                  # users_attributes: %i(name email organization_admin))
+  end
+
+  def user_params
+    params.require(:organization)
+      .permit(users_attributes: %i(name email organization_admin))
+
+    # params.require(:user).permit(:name, :organization_id, :email)
   end
 end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -25,10 +25,10 @@ class Admin::OrganizationsController < AdminController
 
   def create
     @organization = Organization.create(organization_params)
-    @organization.users.try(:last).try { |user| user.password = SecureRandom.uuid }
+    @organization.users.last.update(password: SecureRandom.uuid)
     if @organization.save
       Organization.seed_items(@organization)
-      @organization.users.try(:last).try(:invite!)
+      @organization.users.last.invite!
       redirect_to admin_organizations_path, notice: "Organization added!"
     else
       flash[:error] = "Failed to create Organization."

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -56,5 +56,4 @@ class Admin::OrganizationsController < AdminController
           .permit(:name, :short_name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location, :default_email_text,
                   users_attributes: %i(name email organization_admin))
   end
-
 end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -25,16 +25,10 @@ class Admin::OrganizationsController < AdminController
 
   def create
     @organization = Organization.create(organization_params)
+    @organization.users.try(:last).try { |user| user.password = SecureRandom.uuid }
     if @organization.save
       Organization.seed_items(@organization)
-      # @organization.users.try(:last).try(:invite!)
-      # binding.pry
-      User.invite!(params[:organization][:users_attributes]['0'], organization_id: @organization.id)
-      # User.invite!(name: params[:organization][:users_attributes]['0'][:name],
-      #              email: params[:organization][:users_attributes]['0'][:email],
-      #              organization_admin: params[:organization][:users_attributes]['0'][:organization_admin],
-      #              organization_id: @organization.id)
-      # binding.pry
+      @organization.users.try(:last).try(:invite!)
       redirect_to admin_organizations_path, notice: "Organization added!"
     else
       flash[:error] = "Failed to create Organization."
@@ -59,14 +53,8 @@ class Admin::OrganizationsController < AdminController
 
   def organization_params
     params.require(:organization)
-          .permit(:name, :short_name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location, :default_email_text)
-                  # users_attributes: %i(name email organization_admin))
+      .permit(:name, :short_name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location, :default_email_text, :reminder_day, :deadline_day,
+              users_attributes: %i(name email organization_admin))
   end
 
-  def user_params
-    params.require(:organization)
-      .permit(users_attributes: %i(name email organization_admin))
-
-    # params.require(:user).permit(:name, :organization_id, :email)
-  end
 end

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -53,7 +53,7 @@ class Admin::OrganizationsController < AdminController
 
   def organization_params
     params.require(:organization)
-      .permit(:name, :short_name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location, :default_email_text, :reminder_day, :deadline_day,
+      .permit(:name, :short_name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location, :default_email_text,
               users_attributes: %i(name email organization_admin))
   end
 

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -53,8 +53,8 @@ class Admin::OrganizationsController < AdminController
 
   def organization_params
     params.require(:organization)
-      .permit(:name, :short_name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location, :default_email_text,
-              users_attributes: %i(name email organization_admin))
+          .permit(:name, :short_name, :street, :city, :state, :zipcode, :email, :url, :logo, :intake_location, :default_email_text,
+                  users_attributes: %i(name email organization_admin))
   end
 
 end

--- a/app/views/admin/users/_user_form_fields.html.erb
+++ b/app/views/admin/users/_user_form_fields.html.erb
@@ -6,11 +6,11 @@
   <span class="input-group-addon"><%= fa_icon "envelope" %></span>
   <%= f.input_field :email, class: "form-control" %>
 <% end %>
-<%= f.input :password, label: "Password", wrapper: :vertical_input_group, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) do %>
-  <span class="input-group-addon"><%= fa_icon "lock" %></span>
-  <%= f.input_field :password, class: "form-control" %>
-<% end %>
-<%= f.input :password_confirmation, label: "Confirm Password", wrapper: :vertical_input_group, required: true do %>
-  <span class="input-group-addon"><%= fa_icon "check" %></span>
-  <%= f.input_field :password_confirmation, class: "form-control" %>
-<% end %>
+<%#= f.input :password, label: "Password", wrapper: :vertical_input_group, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) do %>
+<!--  <span class="input-group-addon"><%#= fa_icon "lock" %></span>-->
+  <%#= f.input_field :password, class: "form-control" %>
+<%# end %>
+<%#= f.input :password_confirmation, label: "Confirm Password", wrapper: :vertical_input_group, required: true do %>
+<!--  <span class="input-group-addon"><%#= fa_icon "check" %></span>-->
+  <%#= f.input_field :password_confirmation, class: "form-control" %>
+<%# end %>

--- a/app/views/admin/users/_user_form_fields.html.erb
+++ b/app/views/admin/users/_user_form_fields.html.erb
@@ -6,6 +6,7 @@
   <span class="input-group-addon"><%= fa_icon "envelope" %></span>
   <%= f.input_field :email, class: "form-control" %>
 <% end %>
+<!-- Only display password fields when not nested within organization form -->
 <% if @organization.nil? %>
   <%= f.input :password, label: "Password", wrapper: :vertical_input_group, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) do %>
     <span class="input-group-addon"><%= fa_icon "lock" %></span>

--- a/app/views/admin/users/_user_form_fields.html.erb
+++ b/app/views/admin/users/_user_form_fields.html.erb
@@ -6,11 +6,14 @@
   <span class="input-group-addon"><%= fa_icon "envelope" %></span>
   <%= f.input_field :email, class: "form-control" %>
 <% end %>
-<%#= f.input :password, label: "Password", wrapper: :vertical_input_group, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) do %>
-<!--  <span class="input-group-addon"><%#= fa_icon "lock" %></span>-->
-  <%#= f.input_field :password, class: "form-control" %>
-<%# end %>
-<%#= f.input :password_confirmation, label: "Confirm Password", wrapper: :vertical_input_group, required: true do %>
-<!--  <span class="input-group-addon"><%#= fa_icon "check" %></span>-->
-  <%#= f.input_field :password_confirmation, class: "form-control" %>
-<%# end %>
+<% if @organization.nil? %>
+  <%= f.input :password, label: "Password", wrapper: :vertical_input_group, required: true, hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length) do %>
+    <span class="input-group-addon"><%= fa_icon "lock" %></span>
+    <%= f.input_field :password, class: "form-control" %>
+  <% end %>
+  <%= f.input :password_confirmation, label: "Confirm Password", wrapper: :vertical_input_group, required: true do %>
+    <span class="input-group-addon"><%= fa_icon "check" %></span>
+    <%= f.input_field :password_confirmation, class: "form-control" %>
+  <% end %>
+<% end %>
+

--- a/spec/controllers/admin/organizations_controller_spec.rb
+++ b/spec/controllers/admin/organizations_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Admin::OrganizationsController, type: :controller do
     end
 
     describe "POST #create" do
-      let(:valid_organization_params) { attributes_for(:organization) }
+      let(:valid_organization_params) { attributes_for(:organization, :users_attributes => [attributes_for(:organization_admin)]) }
 
       context "with valid params" do
         it "redirects to #index" do

--- a/spec/controllers/admin/organizations_controller_spec.rb
+++ b/spec/controllers/admin/organizations_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Admin::OrganizationsController, type: :controller do
     end
 
     describe "POST #create" do
-      let(:valid_organization_params) { attributes_for(:organization, :users_attributes => [attributes_for(:organization_admin)]) }
+      let(:valid_organization_params) { attributes_for(:organization, users_attributes: [attributes_for(:organization_admin)]) }
 
       context "with valid params" do
         it "redirects to #index" do

--- a/spec/system/admin/organizations_system_spec.rb
+++ b/spec/system/admin/organizations_system_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe "Admin Organization Management", type: :system, js: true do
       admin_user_params = attributes_for(:organization_admin)
       fill_in "organization_users_attributes_0_name", with: admin_user_params[:name]
       fill_in "organization_users_attributes_0_email", with: admin_user_params[:email]
-      fill_in "organization_users_attributes_0_password", with: "123password"
-      fill_in "organization_users_attributes_0_password_confirmation", with: "123password"
       check "organization_users_attributes_0_organization_admin"
 
       click_on "Save"
@@ -44,7 +42,7 @@ RSpec.describe "Admin Organization Management", type: :system, js: true do
       expect(page).to have_content("invited")
     end
   end
-  context "While signd in as an Administrative User with no organization (super admin no org)" do
+  context "While signed in as an Administrative User with no organization (super admin no org)" do
     before :each do
       sign_in(@super_admin_no_org)
     end
@@ -66,8 +64,6 @@ RSpec.describe "Admin Organization Management", type: :system, js: true do
       admin_user_params = attributes_for(:organization_admin)
       fill_in "organization_users_attributes_0_name", with: admin_user_params[:name]
       fill_in "organization_users_attributes_0_email", with: admin_user_params[:email]
-      fill_in "organization_users_attributes_0_password", with: "543password"
-      fill_in "organization_users_attributes_0_password_confirmation", with: "543password"
       check "organization_users_attributes_0_organization_admin"
 
       click_on "Save"


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->
Resolves #1189  <!--fill issue number-->

### Description
Updated `Add New Organization` form to allow for the creation of user in conjunction with organization, _without_ requiring password input (i.e. remove password fields from form without breaking functionality). New user then receives invite email with link they can use to set their password and log in. 

It is possible to rely on Devise's invitable gem to create the user at the time the invite is sent (via `invite!`). However, it does not validate the record, so if an email address is invalid an error will not be displayed and the user will not receive an invite. As a workaround, I removed the password fields and used `SecureRandom` to generate a temporary password on the backend, so the user record is persisted and validated prior to sending the invite, allowing us to surface meaningful validation errors in the form. This is closest to the previous flow, minimizing the risk of introducing bugs.

### Type of change
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?
Manually tested the following user paths:
* Create organization with user (both organization admin & non-admin) using `Add New Organization` form; used invite link issued via email to create password for new user and log in as user
* Verified editing existing user's password & creating new user with password (`Add a User` form) works as expected (since conditional was added to user form field partial)

Updated existing specs to reflect change and verify organization and user can be created together without inputting a user password. 

_May_ want to test creating organization and user in non-local environment just to confirm email invite works as expected and invited users can update their password and log in.

### Screenshots
**Before**
![image](https://user-images.githubusercontent.com/33694669/66046968-7f42a680-e4ec-11e9-9b22-4b1741f392e3.png)

**After**
![image](https://user-images.githubusercontent.com/33694669/66046876-473b6380-e4ec-11e9-8b66-6f17579463ba.png)