### PR TITLE
Adds pagination to the distributions index page

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -40,8 +40,11 @@ class DistributionsController < ApplicationController
                      .includes(:partner, :storage_location, :line_items, :items)
                      .order(created_at: :desc)
                      .class_filter(filter_params)
+    @paginated_distributions = @distributions.page(params[:page])
     @total_value_all_distributions = total_value(@distributions)
+    @total_value_paginated_distributions = total_value(@paginated_distributions)
     @total_items_all_distributions = total_items(@distributions)
+    @total_items_paginated_distributions = total_items(@paginated_distributions)
     @items = current_organization.items.alphabetized
     @partners = @distributions.collect(&:partner).uniq.sort
   end

--- a/app/views/distributions/_distribution_total.html.erb
+++ b/app/views/distributions/_distribution_total.html.erb
@@ -2,8 +2,16 @@
   <td class="overall-total-label"><strong>Total:</strong></td>
   <td></td>
   <td></td>
-  <td class="overall-total-items"><%= number_with_delimiter(@total_items_all_distributions, :delimiter => ',') %></td>
-  <td class="overall-total-value"><strong><%= item_value(@total_value_all_distributions) %></strong></td>
+  <td class="overall-total-items">
+    <%= number_with_delimiter(@total_items_all_distributions, :delimiter => ',') %> (Total)
+  <br />
+    <%= number_with_delimiter(@total_items_paginated_distributions, :delimiter => ',') %> (This page)
+  </td>
+  <td class="overall-total-value">
+    <strong><%= item_value(@total_value_all_distributions) %></strong> (Total)
+  <br/>
+    <strong><%= item_value(@total_value_paginated_distributions) %></strong> (This page)
+  </td>
   <td>
   </td>
 </tr>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -72,7 +72,7 @@
                   </tr>
                 </thead>
                 <tbody>
-                  <%= render partial: "distribution_row", collection: @distributions %>
+                  <%= render partial: "distribution_row", collection: @paginated_distributions %>
                   <%= render partial: "distribution_total" %>
                 </tbody>
               </table>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -81,4 +81,5 @@
       </div><!-- /.row -->
     </div><!-- /.box-body -->
   </div><!-- /.box -->
+  <%= paginate @paginated_distributions %>
 </section><!-- /.content -->


### PR DESCRIPTION
Resolves #1266  

### Description
Adds pagination to distributions/index page

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
On distributions_controller.rb on the index method I used the per() to limit the results and preview the pagination

```ruby
@paginated_distributions = @distributions.page(params[:page]).per(3)
```

### Screenshots
<img width="1446" alt="Screenshot 2019-10-08 at 9 58 24 PM" src="https://user-images.githubusercontent.com/22100396/66424690-c4983400-ea16-11e9-9d47-eed8da18cef9.png">

