### PR TITLE
 Adds pagination to the requests index page

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -1,7 +1,9 @@
 # Provides Read-only access to Requests, which are created via an API. Requests are transformed into Distributions.
 class RequestsController < ApplicationController
   def index
-    @requests = current_organization.ordered_requests
+    @paginated_requests = current_organization
+                          .ordered_requests
+                          .page(params[:page])
     respond_to do |format|
       format.html
     end

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -36,7 +36,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <%= render partial: "request_row", collection: @requests %>
+                                <%= render partial: "request_row", collection: @paginated_requests %>
                             </tbody>
                         </table>
                     </div><!-- /.box-body.table-responsive -->
@@ -44,4 +44,5 @@
             </div><!-- /.row -->
         </div><!-- /.box-body -->
     </div><!-- /.box -->
+    <%= paginate @paginated_requests %>
 </section><!-- /.content -->


### PR DESCRIPTION
Resolves #1265

### Description
Adds pagination to requests/index page

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

On requests_controller.rb on the index method I used the per() method to limit the results and preview the pagination

```ruby
 @paginated_requests = current_organization.ordered_requests .page(params[:page]).per(2)
```

### Screenshots
<img width="1419" alt="Screenshot 2019-10-08 at 10 45 06 PM" src="https://user-images.githubusercontent.com/22100396/66427931-aeda3d00-ea1d-11e9-8092-cf393748b019.png">

