### PR TITLE
1240 - Add filter-by User on Adjustments#index

### DIFF
--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -4,9 +4,11 @@ class AdjustmentsController < ApplicationController
   # GET /adjustments.json
   def index
     @selected_location = filter_params[:at_location]
-    @adjustments = current_organization.adjustments.class_filter(filter_params)
+    @selected_user = filter_params[:by_user]
+    @adjustments = current_organization.adjustments.order(created_at: :desc).class_filter(filter_params)
 
     @storage_locations = Adjustment.storage_locations_adjusted_for(current_organization).uniq
+    @users = current_organization.users
   end
 
   # GET /adjustments/1
@@ -62,6 +64,6 @@ class AdjustmentsController < ApplicationController
   def filter_params
     return {} unless params.key?(:filters)
 
-    params.require(:filters).slice(:at_location)
+    params.require(:filters).slice(:at_location, :by_user)
   end
 end

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -19,6 +19,7 @@ class Adjustment < ApplicationRecord
   include Itemizable
   include Filterable
   scope :at_location, ->(location_id) { where(storage_location_id: location_id) }
+  scope :by_user, ->(user_id) { where(user_id: user_id) }
   scope :for_csv_export, ->(organization) {
     where(organization: organization)
       .includes(:storage_location, :line_items)

--- a/app/views/adjustments/index.html.erb
+++ b/app/views/adjustments/index.html.erb
@@ -24,6 +24,10 @@
               <%= label_tag "Filter by Storage Location" %>
               <%= collection_select(:filters, :at_location, @storage_locations || {}, :id, :name, { include_blank: true, selected: @selected_location }, class: "form-control") %>
             </div>
+            <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
+              <%= label_tag "Filter by User" %>
+              <%= collection_select(:filters, :by_user, @users || {}, :id, :name, { include_blank: true, selected: @selected_user }, class: "form-control") %>
+            </div>
           </div>
           <div class="row">
             <div class="col-xs-12">

--- a/spec/features/adjustment_spec.rb
+++ b/spec/features/adjustment_spec.rb
@@ -64,4 +64,17 @@ RSpec.feature "Adjustment management", type: :feature do
 
     expect(page).to have_css("table tr", count: 2)
   end
+
+  scenario "User can filter the #index by user" do
+    storage_location = create(:storage_location, name: "here", organization: @organization)
+    storage_location2 = create(:storage_location, name: "there", organization: @organization)
+    create(:adjustment, organization: @organization, storage_location: storage_location, user_id: @user.id)
+    create(:adjustment, organization: @organization, storage_location: storage_location2, user_id: @organization_admin.id)
+
+    visit url_prefix + "/adjustments"
+    select @user.name, from: "filters_by_user"
+    click_button "Filter"
+
+    expect(page).to have_css("table tr", count: 2)
+  end
 end

--- a/spec/models/adjustment_spec.rb
+++ b/spec/models/adjustment_spec.rb
@@ -34,6 +34,12 @@ RSpec.describe Adjustment, type: :model do
       create(:adjustment)
       expect(Adjustment.at_location(adj1.storage_location_id).size).to eq(1)
     end
+
+    it "`by_user` can filter out adjustments to a specific user" do
+      adj1 = create(:adjustment, user_id: @user.id)
+      create(:adjustment, user_id: @organization_admin.id)
+      expect(Adjustment.by_user(adj1.user_id).size).to eq(1)
+    end
   end
 
   context "Methods >" do

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -67,4 +67,16 @@ RSpec.describe "Adjustment management", type: :system, js: true do
 
     expect(page).to have_css("table tr", count: 2)
   end
+
+  it "can filter the #index by user" do
+    storage_location2 = create(:storage_location, name: "there", organization: @organization)
+    create(:adjustment, organization: @organization, storage_location: storage_location, user_id: @user.id)
+    create(:adjustment, organization: @organization, storage_location: storage_location2, user_id: @organization_admin.id)
+
+    visit subject
+    select @user.name, from: "filters_by_user"
+    click_on "Filter"
+
+    expect(page).to have_css("table tr", count: 2)
+  end
 end


### PR DESCRIPTION
Resolves #1240 

### Description

* Add filter-by User on Adjustments#index page
* Add new Adjustment scope :by_user
* Modify adjustments listings to ordered by `created_at: :desc`

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

* Added test on adjustment_spec features, models, and system
* All current tests passing `bundle exec rake`