### PR TITLE
HOTFIX distribution insufficient quantity bug

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -62,8 +62,8 @@ class DistributionsController < ApplicationController
       redirect_to(distributions_path) && return
     end
   rescue StandardError => e
-    flash[:error] = e.message
-    logger.error "[!] DistributionsController#create failed to save distribution: #{@distribution.errors.full_messages}"
+    flash[:error] = "Sorry, we weren't able to save the distribution. #{@distribution.errors.full_messages.join(', ')}."
+    logger.error "[!] DistributionsController#create failed to save distribution for #{current_organization.short_name}: #{@distribution.errors.full_messages}"
     @distribution.line_items.build if @distribution.line_items.count.zero?
     @items = current_organization.items.alphabetized
     @storage_locations = current_organization.storage_locations.alphabetized

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -63,7 +63,7 @@ class DistributionsController < ApplicationController
     end
   rescue StandardError => e
     flash[:error] = "Sorry, we weren't able to save the distribution. #{@distribution.errors.full_messages.join(', ')}."
-    logger.error "[!] DistributionsController#create failed to save distribution for #{current_organization.short_name}: #{@distribution.errors.full_messages}"
+    logger.error "[!] DistributionsController#create failed to save distribution for #{current_organization.short_name}: #{@distribution.errors.full_messages} [#{e.inspect}]"
     @distribution.line_items.build if @distribution.line_items.count.zero?
     @items = current_organization.items.alphabetized
     @storage_locations = current_organization.storage_locations.alphabetized

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -52,16 +52,16 @@ class DistributionsController < ApplicationController
   def create
     @distribution = Distribution.new(distribution_params.merge(organization: current_organization))
 
-    @distribution.transaction do 
+    @distribution.transaction do
       @distribution.save
       @distribution.storage_location.decrease_inventory @distribution
       update_request(params[:distribution][:request_attributes], @distribution.id)
       send_notification(current_organization.id, @distribution.id)
       flash[:notice] = "Distribution created!"
       session[:created_distribution_id] = @distribution.id
-      redirect_to distributions_path and return
+      redirect_to(distributions_path) && return
     end
-  rescue Exception => e
+  rescue StandardError => e
     flash[:error] = e.message
     logger.error "[!] DistributionsController#create failed to save distribution: #{@distribution.errors.full_messages}"
     @distribution.line_items.build if @distribution.line_items.count.zero?

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -62,7 +62,8 @@ class DistributionsController < ApplicationController
       redirect_to(distributions_path) && return
     end
   rescue StandardError => e
-    flash[:error] = "Sorry, we weren't able to save the distribution. #{@distribution.errors.full_messages.join(', ')}."
+    insufficient_message = e.message if e.is_a?(Errors::InsufficientAllotment)
+    flash[:error] = "Sorry, we weren't able to save the distribution. #{@distribution.errors.full_messages.join(', ')} #{insufficient_message}"
     logger.error "[!] DistributionsController#create failed to save distribution for #{current_organization.short_name}: #{@distribution.errors.full_messages} [#{e.inspect}]"
     @distribution.line_items.build if @distribution.line_items.count.zero?
     @items = current_organization.items.alphabetized

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -51,27 +51,22 @@ class DistributionsController < ApplicationController
 
   def create
     @distribution = Distribution.new(distribution_params.merge(organization: current_organization))
-    @storage_locations = current_organization.storage_locations
 
-    if @distribution.save
+    @distribution.transaction do 
+      @distribution.save
       @distribution.storage_location.decrease_inventory @distribution
       update_request(params[:distribution][:request_attributes], @distribution.id)
       send_notification(current_organization.id, @distribution.id)
       flash[:notice] = "Distribution created!"
       session[:created_distribution_id] = @distribution.id
-      redirect_to distributions_path
-    else
-      flash[:error] = "An error occurred, try again?"
-      logger.error "[!] DistributionsController#create failed to save distribution: #{@distribution.errors.full_messages}"
-      @distribution.line_items.build if @distribution.line_items.count.zero?
-      @items = current_organization.items.alphabetized
-      @storage_locations = current_organization.storage_locations.alphabetized
-      render :new
+      redirect_to distributions_path and return
     end
-  rescue Errors::InsufficientAllotment => ex
-    @storage_locations = current_organization.storage_locations
+  rescue Exception => e
+    flash[:error] = e.message
+    logger.error "[!] DistributionsController#create failed to save distribution: #{@distribution.errors.full_messages}"
+    @distribution.line_items.build if @distribution.line_items.count.zero?
     @items = current_organization.items.alphabetized
-    flash[:error] = ex.message
+    @storage_locations = current_organization.storage_locations.alphabetized
     render :new
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -35,9 +35,9 @@ module ApplicationHelper
 
   def flash_class(level)
     case level
-    when "notice" then "alert alert-info"
-    when "success" then "alert alert-success"
-    when "error" then "alert alert-danger"
+    when "notice" then "alert notice alert-info"
+    when "success" then "alert success alert-success"
+    when "error" then "alert error alert-danger"
     when "alert" then "alert alert-warning"
     end
   end

--- a/app/models/errors.rb
+++ b/app/models/errors.rb
@@ -37,7 +37,7 @@ module Errors
     ###
     def message
       super.to_s + ("<ul><li>" + insufficient_items.map do |i|
-        "#{i[:quantity_requested]} #{i[:item]} requested, only #{i[:quantity_on_hand]} available." \
+        "#{i[:quantity_requested]} #{i[:item_name]} requested, only #{i[:quantity_on_hand]} available." \
         "(Reduce by #{i[:quantity_requested].to_i - i[:quantity_on_hand].to_i})"
       end.join("</li><li>") + "</li></ul>")
     end

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |key, message| %>
   <div class="<%= flash_class(key) %> alert-dismissible" role="alert">
     <a href="#" class="close" data-dismiss="alert" aria-label="close" style="text-decoration: none;"><%= fa_icon('times') %></a>
-    <%= message %>
+    <%= message.html_safe %>
   </div>
 <% end %>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,6 +1,6 @@
 <% flash.each do |key, message| %>
   <div class="<%= flash_class(key) %> alert-dismissible" role="alert">
     <a href="#" class="close" data-dismiss="alert" aria-label="close" style="text-decoration: none;"><%= fa_icon('times') %></a>
-    <%= message.html_safe %>
+    <%== message %>
   </div>
 <% end %>

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe DistributionsController, type: :controller do
       it "renders #new again on failure, with notice" do
         post :create, params: default_params.merge(distribution: { comment: nil, partner_id: nil, storage_location_id: nil })
         expect(response).to be_successful
-        expect(response).to have_error(/error/i)
+        expect(response).to have_error
       end
     end
 

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe DonationsController, type: :controller do
           donation_params = { source: donation.source, storage_location: new_storage_location, line_items_attributes: line_item_params }
           expect do
             put :update, params: default_params.merge(id: donation.id, donation: donation_params)
-          end.to raise_error
+          end.to raise_error(Errors::InsufficientAllotment)
           expect(original_storage_location.size).to eq 5
           expect(new_storage_location.size).to eq 0
           expect(donation.reload.line_items.first.quantity).to eq 10

--- a/spec/controllers/purchases_controller_spec.rb
+++ b/spec/controllers/purchases_controller_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe PurchasesController, type: :controller do
           purchase_params = { storage_location: new_storage_location, line_items_attributes: line_item_params }
           expect do
             put :update, params: default_params.merge(id: purchase.id, purchase: purchase_params)
-          end.to raise_error
+          end.to raise_error(Errors::InsufficientAllotment)
           expect(original_storage_location.size).to eq 5
           expect(new_storage_location.size).to eq 0
           expect(purchase.reload.line_items.first.quantity).to eq 10

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -91,19 +91,19 @@ RSpec.describe ApplicationHelper, type: :helper do
 
   describe "flash_class" do
     it "returns appropriate class for notice" do
-      expect(helper.flash_class("notice")).to eq "alert alert-info"
+      expect(helper.flash_class("notice")).to match(/alert|alert-info/)
     end
 
     it "returns appropriate class for success" do
-      expect(helper.flash_class("success")).to eq "alert alert-success"
+      expect(helper.flash_class("success")).to match(/alert|alert-success/)
     end
 
     it "returns appropriate class for error" do
-      expect(helper.flash_class("error")).to eq "alert alert-danger"
+      expect(helper.flash_class("error")).to match(/alert|alert-danger/)
     end
 
     it "returns appropriate class for alert" do
-      expect(helper.flash_class("alert")).to eq "alert alert-warning"
+      expect(helper.flash_class("alert")).to match(/alert|alert-warning/)
     end
   end
 

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -94,7 +94,8 @@ RSpec.feature "Distributions", type: :system do
     select "", from: "From storage location"
 
     click_button "Save", match: :first
-    expect(page).to have_content "An error occurred, try again?"
+    page.find('.alert')
+    expect(page).to have_css('.alert.error', text: /storage location/i)
   end
 
   context "With an existing distribution" do

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -63,8 +63,8 @@ RSpec.feature "Distributions", type: :system do
         expect do
           click_button "Save", match: :first
           page.find('.alert')
-        end.not_to change{Distribution.count}
-        
+        end.not_to change { Distribution.count }
+
         expect(page).to have_content("New Distribution")
         expect(page.find(".alert")).to have_content "exceed"
       end

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Distributions", type: :system do
       end
     end
 
-    fcontext "when there is insufficient inventory to fulfill the Distribution" do
+    context "when there is insufficient inventory to fulfill the Distribution" do
       it "gracefully handles the error" do
         visit @url_prefix + "/distributions/new"
 
@@ -64,8 +64,9 @@ RSpec.feature "Distributions", type: :system do
           click_button "Save", match: :first
           page.find('.alert')
         end.not_to change{Distribution.count}
-
-        expect(page.find(".alert-info")).to have_content "reated"
+        
+        expect(page).to have_content("New Distribution")
+        expect(page.find(".alert")).to have_content "exceed"
       end
     end
   end


### PR DESCRIPTION
Michael discovered a bug wherein a Distribution would still be created if there was insufficient inventory. 

This PR modifies the `DistributionsController#create` action to use a transaction. If the distribution itself is invalid, or if there is insufficient inventory, it will roll back the whole process. It also improves the flash display to render HTML. 