### PR TITLE
Add date filtering to Transfers#index

### DIFF
--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -1,11 +1,20 @@
 # Provides partial CRUD for managing Transfers, which move inventory from one storage location to another
 class TransfersController < ApplicationController
+  include Dateable
+
   def index
-    @transfers = current_organization.transfers.includes(:line_items).includes(:from).includes(:to).class_filter(filter_params)
+    @transfers = current_organization.transfers
+                                     .includes(:line_items)
+                                     .includes(:from)
+                                     .includes(:to)
+                                     .where(created_at: date_range)
+                                     .class_filter(filter_params)
     @selected_from = filter_params[:from_location]
     @selected_to = filter_params[:to_location]
     @from_storage_locations = Transfer.storage_locations_transferred_from_in(current_organization)
     @to_storage_locations = Transfer.storage_locations_transferred_to_in(current_organization)
+    @date_from = date_params[:date_from]
+    @date_to = date_params[:date_to]
   end
 
   def create

--- a/app/views/transfers/_transfer_row.html.erb
+++ b/app/views/transfers/_transfer_row.html.erb
@@ -1,6 +1,7 @@
 <tr>
   <td><%= transfer_row.from.name %></td>
   <td><%= transfer_row.to.name %></td>
+  <td><%= transfer_row.created_at.strftime("%F") %></td>
   <td><%= transfer_row.comment || "none" %></td>
   <td><%= transfer_row.line_items.total %></td>
   <td class="text-right">

--- a/app/views/transfers/index.html.erb
+++ b/app/views/transfers/index.html.erb
@@ -28,6 +28,15 @@
               <%= label_tag "To this Storage Location" %>
               <%= collection_select(:filters, :to_location, @to_storage_locations || {}, :id, :name, { include_blank: true, selected: (@selected_to) }, class: "form-control") %>
             </div>
+            <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
+              <%= label_tag "from Date" %>
+              <%= date_field :dates, :date_from, class: "form-control", value: @date_from %>
+            </div>
+
+            <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
+              <%= label_tag "to Date" %>
+              <%= date_field :dates, :date_to, class: "form-control", value: @date_to %>
+            </div>
           </div><!-- /.row -->
           <div class="row">
             <div class="col-xs-12">
@@ -52,6 +61,7 @@
                 <tr>
                   <th>From</th>
                   <th>To</th>
+                  <th>Date</th>
                   <th>Comment</th>
                   <th>Total Moved</th>
                   <th>&nbsp;</th>

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe TransfersController, type: :controller do
       end
 
       context 'when filtering by date' do
-        let!(:old_transfter) { create(:transfer, created_at: 7.days.ago) }
+        let!(:old_transfer) { create(:transfer, created_at: 7.days.ago) }
         let!(:new_transfer) { create(:transfer, created_at: 1.day.ago) }
 
         context 'when date parameters are supplied' do
@@ -24,7 +24,7 @@ RSpec.describe TransfersController, type: :controller do
         context 'when date parameters are not supplied' do
           it 'returns all objects' do
             get :index, params: { organization_id: @organization.short_name }
-            expect(assigns(:transfers)).to eq([old_transfter, new_transfer])
+            expect(assigns(:transfers)).to eq([old_transfer, new_transfer])
           end
         end
       end

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe TransfersController, type: :controller do
 
         context 'when date parameters are supplied' do
           it 'only returns the correct obejects' do
-            get :index, params: { organization_id: @organization.short_name, dates: { date_from: 3.days.ago, date_to: Date.today } }
+            get :index, params: { organization_id: @organization.short_name, dates: { date_from: 3.days.ago, date_to: Time.zone.today } }
             expect(assigns(:transfers)).to eq([new_transfer])
           end
         end

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -9,6 +9,25 @@ RSpec.describe TransfersController, type: :controller do
       it "returns http success" do
         expect(subject).to be_successful
       end
+
+      context 'when filtering by date' do
+        let!(:old_transfter) { create(:transfer, created_at: 7.days.ago) }
+        let!(:new_transfer) { create(:transfer, created_at: 1.day.ago) }
+
+        context 'when date parameters are supplied' do
+          it 'only returns the correct obejects' do
+            get :index, params: { organization_id: @organization.short_name, dates: { date_from: 3.days.ago, date_to: Date.today } }
+            expect(assigns(:transfers)).to eq([new_transfer])
+          end
+        end
+
+        context 'when date parameters are not supplied' do
+          it 'returns all objects' do
+            get :index, params: { organization_id: @organization.short_name }
+            expect(assigns(:transfers)).to eq([old_transfter, new_transfer])
+          end
+        end
+      end
     end
 
     describe "POST #create" do

--- a/spec/system/transfer_system_spec.rb
+++ b/spec/system/transfer_system_spec.rb
@@ -74,20 +74,21 @@ RSpec.describe "Transfer management", type: :system do
   end
 
   it "can filter the #index by date" do
-    create(:transfer, created_at: Date.new(2018, 2, 1))
-    create(:transfer, created_at: Date.new(2018, 3, 1))
-    create(:transfer, created_at: Date.new(2018, 4, 1))
+    create(:transfer, created_at: Date.new(2040, 2, 1))
+    create(:transfer, created_at: Date.new(2040, 3, 1))
+    create(:transfer, created_at: Date.new(2040, 4, 1))
     visit url_prefix + "/transfers"
 
-    fill_in "dates_date_from", with: "02/01/2018"
+    fill_in "dates_date_to", with: "01/01/2041"
+    fill_in "dates_date_from", with: "02/01/2040"
     click_button "Filter"
     expect(page).to have_css("table tbody tr", count: 3)
 
-    fill_in "dates_date_from", with: "03/02/2018"
+    fill_in "dates_date_from", with: "03/02/2040"
     click_button "Filter"
     expect(page).to have_css("table tbody tr", count: 2)
 
-    fill_in "dates_date_to", with: "03/30/2018"
+    fill_in "dates_date_to", with: "03/30/2040"
     click_button "Filter"
     expect(page).to have_css("table tbody tr", count: 1)
   end

--- a/spec/system/transfer_system_spec.rb
+++ b/spec/system/transfer_system_spec.rb
@@ -72,4 +72,23 @@ RSpec.describe "Transfer management", type: :system do
 
     expect(page).to have_css("table tr", count: 2)
   end
+
+  it "can filter the #index by date" do
+    create(:transfer, created_at: Date.new(2018, 2, 1))
+    create(:transfer, created_at: Date.new(2018, 3, 1))
+    create(:transfer, created_at: Date.new(2018, 4, 1))
+    visit url_prefix + "/transfers"
+
+    fill_in "dates_date_from", with: "02/01/2018"
+    click_button "Filter"
+    expect(page).to have_css("table tbody tr", count: 3)
+
+    fill_in "dates_date_from", with: "03/02/2018"
+    click_button "Filter"
+    expect(page).to have_css("table tbody tr", count: 2)
+
+    fill_in "dates_date_to", with: "03/30/2018"
+    click_button "Filter"
+    expect(page).to have_css("table tbody tr", count: 1)
+  end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1286 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Adds date filtering to the Transfers page, using similar functionality to the Donation page.

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

Create a selection of transfers and demonstrate the filters are working on Transfers#index. Also demonstrated with unit tests.

### Screenshots
![](http://g.recordit.co/uOcfosLMJ1.gif)

<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
