### PR TITLE
Add date filtering to Adjustments#index

### DIFF
--- a/app/controllers/adjustments_controller.rb
+++ b/app/controllers/adjustments_controller.rb
@@ -2,14 +2,21 @@
 class AdjustmentsController < ApplicationController
   # GET /adjustments
   # GET /adjustments.json
+  include Dateable
+
   def index
     @selected_location = filter_params[:at_location]
     @selected_user = filter_params[:by_user]
-    @adjustments = current_organization.adjustments.order(created_at: :desc).class_filter(filter_params)
+    @adjustments = current_organization.adjustments
+                                       .order(created_at: :desc)
+                                       .where(created_at: date_range)
+                                       .class_filter(filter_params)
     @paginated_adjustments = @adjustments.page(params[:page])
 
     @storage_locations = Adjustment.storage_locations_adjusted_for(current_organization).uniq
     @users = current_organization.users
+    @date_from = date_params[:date_from]
+    @date_to = date_params[:date_to]
   end
 
   # GET /adjustments/1

--- a/app/views/adjustments/index.html.erb
+++ b/app/views/adjustments/index.html.erb
@@ -28,6 +28,14 @@
               <%= label_tag "Filter by User" %>
               <%= collection_select(:filters, :by_user, @users || {}, :id, :name, { include_blank: true, selected: @selected_user }, class: "form-control") %>
             </div>
+            <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
+              <%= label_tag "from Date" %>
+              <%= date_field :dates, :date_from, class: "form-control", value: @date_from %>
+            </div>
+            <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
+              <%= label_tag "to Date" %>
+              <%= date_field :dates, :date_to, class: "form-control", value: @date_to %>
+            </div>
           </div>
           <div class="row">
             <div class="col-xs-12">

--- a/spec/controllers/adjustments_controller_spec.rb
+++ b/spec/controllers/adjustments_controller_spec.rb
@@ -35,6 +35,25 @@ RSpec.describe AdjustmentsController, type: :controller do
         get :index, params: default_params, session: valid_session
         expect(response).to be_successful
       end
+
+      context 'when filtering by date' do
+        let!(:old_adjustment) { create(:adjustment, created_at: 7.days.ago) }
+        let!(:new_adjustment) { create(:adjustment, created_at: 1.day.ago) }
+
+        context 'when date parameters are supplied' do
+          it 'only returns the correct obejects' do
+            get :index, params: default_params.merge(dates: { date_from: 3.days.ago, date_to: Time.zone.today })
+            expect(assigns(:adjustments)).to contain_exactly(new_adjustment)
+          end
+        end
+
+        context 'when date parameters are not supplied' do
+          it 'returns all objects' do
+            get :index, params: default_params
+            expect(assigns(:adjustments)).to contain_exactly(old_adjustment, new_adjustment)
+          end
+        end
+      end
     end
 
     describe "GET #show" do

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -81,20 +81,21 @@ RSpec.describe "Adjustment management", type: :system, js: true do
   end
 
   it "can filter the #index by date" do
-    create(:adjustment, created_at: Date.new(2018, 2, 1))
-    create(:adjustment, created_at: Date.new(2018, 3, 1))
-    create(:adjustment, created_at: Date.new(2018, 4, 1))
+    create(:adjustment, created_at: Date.new(2040, 2, 1))
+    create(:adjustment, created_at: Date.new(2040, 3, 1))
+    create(:adjustment, created_at: Date.new(2040, 4, 1))
     visit subject
 
-    fill_in "dates_date_from", with: "02/01/2018"
+    fill_in "dates_date_to", with: "01/01/2041"
+    fill_in "dates_date_from", with: "02/01/2040"
     click_button "Filter"
     expect(page).to have_css("table tbody tr", count: 3)
 
-    fill_in "dates_date_from", with: "03/02/2018"
+    fill_in "dates_date_from", with: "03/02/2040"
     click_button "Filter"
     expect(page).to have_css("table tbody tr", count: 2)
 
-    fill_in "dates_date_to", with: "03/30/2018"
+    fill_in "dates_date_to", with: "03/30/2040"
     click_button "Filter"
     expect(page).to have_css("table tbody tr", count: 1)
   end

--- a/spec/system/adjustment_system_spec.rb
+++ b/spec/system/adjustment_system_spec.rb
@@ -79,4 +79,23 @@ RSpec.describe "Adjustment management", type: :system, js: true do
 
     expect(page).to have_css("table tr", count: 2)
   end
+
+  it "can filter the #index by date" do
+    create(:adjustment, created_at: Date.new(2018, 2, 1))
+    create(:adjustment, created_at: Date.new(2018, 3, 1))
+    create(:adjustment, created_at: Date.new(2018, 4, 1))
+    visit subject
+
+    fill_in "dates_date_from", with: "02/01/2018"
+    click_button "Filter"
+    expect(page).to have_css("table tbody tr", count: 3)
+
+    fill_in "dates_date_from", with: "03/02/2018"
+    click_button "Filter"
+    expect(page).to have_css("table tbody tr", count: 2)
+
+    fill_in "dates_date_to", with: "03/30/2018"
+    click_button "Filter"
+    expect(page).to have_css("table tbody tr", count: 1)
+  end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1285 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

Adds date filtering to the Adjustments index page, using similar functionality to the Donation page.

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

Create a selection of adjustments and demonstrate the filters are working on Adjustments#index. Also demonstrated with unit tests.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

![](http://g.recordit.co/Tbre29YQ59.gif)
