### PR TITLE
823 add single day view

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -41,7 +41,8 @@ toastr.options = {
 $( document ).ready(function() {
     $('#calendar').fullCalendar({
         firstDay: 1,
-        displayEventTime : false,
+        displayEventTime : true,
+        eventLimit: true,
         events: 'pick_ups.json'
     });
 });

--- a/app/assets/stylesheets/admin_layout.scss
+++ b/app/assets/stylesheets/admin_layout.scss
@@ -33,7 +33,12 @@ tr.negative {
 tr.positive {
   background-color: $diaper-color-green-93;
 }
-
 tr.highlight {
   background-color: $diaper-color-blue-95;
+}
+
+.fc-dist-complete {
+  background-color: $diaper-color-green-32;
+  border-color: $diaper-color-green-32;
+  text-decoration: line-through;
 }

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -136,7 +136,7 @@ class DistributionsController < ApplicationController
   end
 
   def picked_up
-    if Distribution.find_by(id: params['id'])&.scheduled? && Distribution.find_by(id: params['id'])&.complete!
+    if Distribution.scheduled.find(params['id'])&.complete!
       flash[:notice] = 'This distribution has been marked as being picked up!'
     else
       flash[:error] = 'Sorry, we encountered an error when trying to mark this distribution as being picked up'

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -5,6 +5,7 @@
 # might want if they were doing direct services.
 class DistributionsController < ApplicationController
   include DateRangeHelper
+  include DistributionHelper
   rescue_from Errors::InsufficientAllotment, with: :insufficient_amount!
 
   def print
@@ -38,7 +39,7 @@ class DistributionsController < ApplicationController
                      .distributions
                      .where(issued_at: selected_range)
                      .includes(:partner, :storage_location, :line_items, :items)
-                     .order(created_at: :desc)
+                     .order(issued_at: :desc)
                      .class_filter(filter_params)
     @paginated_distributions = @distributions.page(params[:page])
     @total_value_all_distributions = total_value(@distributions)
@@ -136,13 +137,20 @@ class DistributionsController < ApplicationController
   end
 
   def picked_up
-    if Distribution.scheduled.find(params['id'])&.complete!
+    distribution = current_organization.distributions.find(params[:id])
+
+    if distribution.scheduled? && distribution.complete!
       flash[:notice] = 'This distribution has been marked as being picked up!'
     else
       flash[:error] = 'Sorry, we encountered an error when trying to mark this distribution as being picked up'
     end
 
-    redirect_to distribution_path
+    redirect_back(fallback_location: distribution_path)
+  end
+
+  def pickup_day
+    @pick_ups = current_organization.distributions.during(pickup_date).order(issued_at: :asc)
+    @selected_date = pickup_day_params[:during]&.to_date || Time.zone.now.to_date
   end
 
   # TODO: This shouldl probably be private

--- a/app/helpers/distribution_helper.rb
+++ b/app/helpers/distribution_helper.rb
@@ -1,0 +1,15 @@
+# Encapsulates methods that need some business logic
+module DistributionHelper
+  def pickup_day_params
+    return {} unless params.key?(:filters)
+
+    params.require(:filters).slice(:during)
+  end
+
+  def pickup_date
+    now = pickup_day_params[:during]&.to_date || Time.zone.today.to_date
+    end_date = now.end_of_day
+
+    now..end_date
+  end
+end

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -36,7 +36,7 @@ class Distribution < ApplicationRecord
 
   before_save :combine_distribution
 
-  enum state: { started: 0, scheduled: 1, complete: 10 }
+  enum state: { scheduled: 0, complete: 10 }
 
   include Filterable
   # add item_id scope to allow filtering distributions by item

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -100,7 +100,7 @@ class Organization < ApplicationRecord
   end
 
   def upcoming_distributions
-    distributions&.this_week&.count || 0
+    distributions&.this_week&.scheduled.count || 0
   end
 
   # Computes full address string based on street, city, state, and zip, adding ', ' and ' ' separators

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -8,7 +8,7 @@
 
   <td class="text-right">
     <%= view_button_to distribution_path(distribution_row) %>
-    <% if distribution_row.future? || current_user.organization_admin? %>
+    <% if !distribution_row.complete? && (distribution_row.future? || current_user.organization_admin?) %>
       <%= edit_button_to edit_distribution_path(distribution_row) %>
     <% end %>
     <%= print_button_to print_distribution_path(distribution_row, format: :pdf) %>

--- a/app/views/distributions/_pickup_day_row.html.erb
+++ b/app/views/distributions/_pickup_day_row.html.erb
@@ -1,0 +1,17 @@
+<tr>
+  <td><%= pickup_day_row.partner.name %></td>
+  <td><%= pickup_day_row.issued_at.strftime("%l:%M %p") %> </td>
+  <td><%= pickup_day_row.storage_location.name %></td>
+  <td><%= pickup_day_row.line_items.total %></td>
+  <td>
+    <% if pickup_day_row.complete? %>
+      Picked up
+    <% else %>
+      Scheduled
+    <% end %>
+  </td>
+  <td class="text-right">
+    <%= update_button_to picked_up_distribution_path(pickup_day_row), {text: "Pick up Complete", size: "xs"} if pickup_day_row.scheduled? %>
+    <%= view_button_to distribution_path(pickup_day_row) %>
+  </td>
+</tr>

--- a/app/views/distributions/pick_ups.html.erb
+++ b/app/views/distributions/pick_ups.html.erb
@@ -1,7 +1,7 @@
 <section class="content-header">
-  <% content_for :title, "Distribution Pick-ups - #{current_organization.name}" %>
+  <% content_for :title, "Distribution Pick-Ups - #{current_organization.name}" %>
   <h1>
-    Pick Up Schedule
+    Pick-Ups Schedule
   </h1>
   <ol class="breadcrumb">
     <li><%= link_to(dashboard_path) do %>
@@ -9,18 +9,15 @@
       <% end %>
     </li>
     <li><%= link_to "Distributions", (distributions_path) %></li>
-    <li class="active"> Pickups</li>
-      </ol>
+    <li class="active"> Pick-Ups</li>
+  </ol>
 </section>
 
 <!-- Main content -->
 <section class="content">
-
   <!-- Default box -->
-
   <div class="box box-primary">
     <div class="box-body">
-
       <div id="calendar" class="fc fc-unthemed fc-ltr"></div>
     </div>
 </section>

--- a/app/views/distributions/pick_ups.json.jbuilder
+++ b/app/views/distributions/pick_ups.json.jbuilder
@@ -2,7 +2,8 @@ json.array!(@pick_ups) do |pickup|
   json.set! :id, pickup.id
   json.set! :title, pickup.partner.name
   json.set! :description, pickup.comment
+  json.set! :className, pickup.complete? ? 'fc-dist-complete' : 'fc-dist-scheduled'
   json.start pickup.issued_at
   json.end pickup.issued_at
-  json.url distribution_url(pickup)
+  json.url pickup_day_distributions_path(filters: { during: pickup.issued_at.to_date })
 end

--- a/app/views/distributions/pickup_day.html.erb
+++ b/app/views/distributions/pickup_day.html.erb
@@ -1,0 +1,43 @@
+<section class="content-header">
+  <% content_for :title, "Pick up Schedule for #{@selected_date.strftime("%B %e, %Y")}" %>
+  <h1>
+    Pick up Schedule for <%= @selected_date.strftime("%B %e, %Y") %>
+  </h1>
+  <ol class="breadcrumb">
+    <li><%= link_to(dashboard_path) do %>
+        <i class="fa fa-dashboard"></i> Home
+      <% end %>
+    </li>
+    <li><%= link_to "Distributions", (distributions_path) %></li>
+    <li class="active"> <%= link_to "Pick-Ups", (pick_ups_distributions_path) %></li>
+  </ol>
+</section>
+
+<!-- Main content -->
+<section class="content">
+  <div class="box">
+      <div class="row">
+        <div class="col-xs-12">
+            <!-- /.box-header -->
+            <div class="box-body table-responsive no-padding">
+              <table class="table table-hover striped">
+                <thead>
+                  <tr>
+                    <th>Partner</th>
+                    <th>Time of Distribution</th>
+                    <th>Source Inventory</th>
+                    <th>Total items</th>
+                    <th>State</th>
+                    <th class="pull-right">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <%= render partial: "pickup_day_row", collection: @pick_ups %>
+                </tbody>
+              </table>
+            </div><!-- /.box-body.table-responsive -->
+        </div><!-- /.col-xs-12 -->
+      </div><!-- /.row -->
+    </div><!-- /.box-body -->
+  </div><!-- /.box -->
+</section><!-- /.content -->

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -55,7 +55,7 @@
       </div>
     </div>
     <div class="box-footer with-border">
-      <%= update_button_to picked_up_distribution_path(@distribution), {text: "Complete pickup", size: "lg"} if @distribution.scheduled? %>
+      <%= update_button_to picked_up_distribution_path(@distribution), {text: "Pick up Complete", size: "lg"} if @distribution.scheduled? %>
       <% if @distribution.future? || current_user.organization_admin? %>
         <%= edit_button_to edit_distribution_path(@distribution), {text: "Make a Correction", size: "lg"} %>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -85,6 +85,7 @@ Rails.application.routes.draw do
       get :print, on: :member
       collection do
         get :pick_ups
+        get :pickup_day
       end
       patch :picked_up, on: :member
     end

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe DistributionsController, type: :controller do
       subject { patch :picked_up, params: default_params.merge(id: distribution.id) }
 
       context 'when the distribution is successfully updated' do
-        let(:distribution) { create(:distribution, state: 'scheduled') }
+        let(:distribution) { create(:distribution, state: :scheduled) }
 
         it "updates the state to 'complete'" do
           subject
@@ -98,15 +98,20 @@ RSpec.describe DistributionsController, type: :controller do
       end
 
       context 'when the distribution update fails' do
-        let(:distribution) { create(:distribution, state: 'started') }
+        let(:distribution) { create(:distribution, state: :complete) }
 
-        it 'raises a warning' do
-          expect(subject.request.flash[:error]).to_not be_nil
-        end
-
-        it 'redirects the user back to the distributions page' do
+        it "redirects the user back to the distributions page with an error message" do
+          subject
           expect(subject).to redirect_to distribution_path
+          expect(flash[:error]).to be_present
         end
+      end
+    end
+
+    describe "GET #pickup_day" do
+      subject { get :pickup_day, params: default_params }
+      it "returns http success" do
+        expect(subject).to be_successful
       end
     end
 

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     partner
     organization { Organization.try(:first) || create(:organization) }
     issued_at { nil }
-    state { 0 }
+    state { :scheduled }
 
     trait :with_items do
       transient do


### PR DESCRIPTION
Ref #823 

### Description

Few updates here:

* Remove Distribution `started` state. The default for the Distribution state is `scheduled`.
* Add a new route `pickup_day` for the single-day view
* Calendar changes 
* Hide the Distribution edit button if the Distribution is complete (picked up)

@armahillo Hopefully, I'm on the right track here. 

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

* Passed `bundle exec rake`

### Screenshots

<img width="1431" alt="Screen Shot 2019-10-13 at 8 53 17 PM" src="https://user-images.githubusercontent.com/89159/66725064-942c0d80-edfb-11e9-8c3b-b5e3e878ecb9.png">

Calendar changes here by displaying event time and different styles for completed (picked up) distributions. Clicking the listing will go to a single day view for that day.

<img width="1432" alt="Screen Shot 2019-10-13 at 8 53 39 PM" src="https://user-images.githubusercontent.com/89159/66725103-e3723e00-edfb-11e9-98e8-c61a151c0f12.png">

Single-day view. `Pick up Complete` button only show for distribution that hasn't been picked up.
