### PR TITLE
[BUGFIX] Dropdown not clickable in smaller screen resolution

### DIFF
--- a/app/assets/stylesheets/barcode_reader.scss
+++ b/app/assets/stylesheets/barcode_reader.scss
@@ -19,11 +19,9 @@
     border-radius: 5px;
     cursor: pointer;
   }
-  
+
   .list-line-items {
     padding-bottom: 20px;
     margin-bottom: 20px;
-    border-bottom: solid 5px grey;
   }
 }
-

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,17 +1,19 @@
 <section class="row">
 <div class="nested-fields list-line-items">
-  <span class='col-md-3 col-sm-12'>
+  <div class='col-md-3 col-sm-3'>
     <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
     <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner"> </div>
-  </span>
-  <span class="col-md-4 col-sm-12">
+  </div>
+  <div class="col-md-1 col-sm-1">
     <label>OR</label>
+  </div>
+  <div class="col-md-3 col-sm-3">
     <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
-  </span>
-  <div class='col-md-3 col-12'>
+  </div>
+  <div class='col-md-3 col-sm-3'>
     <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity" } %>
   </div>
-  <div class='col-md-2 col-12'>
+  <div class='col-md-2 col-sm-2'>
     <%= delete_line_item_button f %>
   </div>
 </div>


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1260 

### Description
Ensure bootstrap is properly using columns according to documentation to be compatible in different screen sizes, both desktop and smaller media screens. (e.g. iPad)
![image](https://user-images.githubusercontent.com/42528623/66843045-cd50b300-ef9e-11e9-9a1b-c3d9de9bdc18.png)

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Same way it has been reproduced in #1260, using smaller screen resolutions.

### Screenshots
After:
![image](https://user-images.githubusercontent.com/42528623/66842803-75b24780-ef9e-11e9-88ac-27d0467a6156.png)

