### PR TITLE
#1260 input correction

### DIFF
--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,11 +1,13 @@
 <section class="row">
 <div class="nested-fields list-line-items">
-  <span class='col-md-3 col-sm-12'>
+  <span class='col-md-3 col-10'>
     <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
     <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner"> </div>
   </span>
-  <span class="col-md-4 col-sm-12">
+  <span class="col-xs-6 col-md-12 col-sm-12">
     <label>OR</label>
+  </span>
+  <span class="col-md-3 col-10">
     <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
   </span>
   <div class='col-md-3 col-12'>


### PR DESCRIPTION
Resolves issue #1260 

the "choose an item" and "barcode entry" options didn't open in small resolutions (768-991 pixels), so i fixed it.

the currently behaviour:
![Screen Shot 2019-10-15 at 11 47 16](https://user-images.githubusercontent.com/25162312/66844110-23443d00-ef44-11e9-8669-66a6cc109009.png)

I also changed the position of the "OR"
![Screen Shot 2019-10-15 at 11 47 00](https://user-images.githubusercontent.com/25162312/66844151-36efa380-ef44-11e9-8b97-531ac334924c.png)

