### PR TITLE
Commit update Gemfile.lock with bootstrap-datepicker gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
     bindex (0.5.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
+    bootstrap-datepicker-rails (1.8.0.1)
+      railties (>= 3.0)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
       sassc (>= 2.0.0)
@@ -500,6 +502,7 @@ DEPENDENCIES
   awesome_print
   better_errors
   binding_of_caller
+  bootstrap-datepicker-rails
   bootstrap-sass
   bugsnag
   capistrano-bundler


### PR DESCRIPTION
### Description

Commit change to `Gemfile.lock` due to addition (commit: 838a5ef6). This change occurs automatically on `bundle install` and should be committed (without it, all new developers will have to discard it to create clean PRs)

### Type of change

* App setup change (nodoc)

### How Has This Been Tested?

App runs, tests pass
