### PR TITLE
fix(TestCoverage)[LB] Add test for method storage view on purchases

### DIFF
--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -95,6 +95,13 @@ RSpec.describe Purchase, type: :model do
       end
     end
 
+    describe "storage_view" do
+      let!(:purchase) { create(:purchase, :with_items) }
+      it "returns name of storage location" do
+        expect(purchase.storage_view).to eq("Smithsonian Conservation Center")
+      end
+    end
+
     describe "replace_increase!" do
       let!(:storage_location) { create(:storage_location, organization: @organization) }
       subject { create(:purchase, :with_items, item_quantity: 5, storage_location: storage_location, organization: @organization) }


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Ref #1024

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* additional test coverage

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
I added test coverage for the method `storage_view`, which returns either the name of the storage_location or "N/A" if none exists. I tried to add a test in case `storage_location` is nil but there is validation making it so purchases can't exist without storage_locations so I don't actually think storage_location can be nil. 

I just realized I forgot to follow proper convention for branch naming. Can close and put on a new branch if important. 