### PR TITLE
1302 distribution index summing

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -172,7 +172,7 @@ class DistributionsController < ApplicationController
   end
 
   def total_items(distributions)
-    distributions.includes(:line_items).sum('line_items.quantity')
+    LineItem.where(itemizable_type: "Distribution", itemizable_id: distributions.pluck(:id)).sum('quantity')
   end
 
   def total_value(distributions)

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -36,6 +36,15 @@ RSpec.describe DistributionsController, type: :controller do
       it "returns http success" do
         expect(subject).to be_successful
       end
+
+      it "sums distribution totals accurately" do
+        distribution = create(:distribution, :with_items, item_quantity: 10)
+        create(:distribution, :with_items, item_quantity: 5)
+        create(:line_item, :distribution, itemizable_id: distribution.id, quantity: 7)
+        subject
+        expect(assigns(:total_items_all_distributions)).to eq(22)
+        expect(assigns(:total_items_paginated_distributions)).to eq(22)
+      end
     end
 
     describe "POST #create" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1302 <!--fill issue number-->

### Description
Total items summary at bottom of Distributions#index table was wrong. This fixes it.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added a controller test to ensure we're getting the right value back. You can confirm the old values are wrong by running the new test on the old summation code.

### Screenshots
BEFORE:
![Screen Shot 2019-10-18 at 2 44 23 PM](https://user-images.githubusercontent.com/43351221/67119789-d798ca00-f1b5-11e9-98ec-4900bfeae8e5.png)

AFTER:
![Screen Shot 2019-10-18 at 2 43 49 PM](https://user-images.githubusercontent.com/43351221/67119793-da93ba80-f1b5-11e9-9677-1fece7fbcbf1.png)
