### PR TITLE
Update the prawn-rails gem to remove deprecation warning.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,7 +283,7 @@ GEM
     prawn (2.2.2)
       pdf-core (~> 0.7.0)
       ttfunk (~> 1.5)
-    prawn-rails (1.2.0)
+    prawn-rails (1.3.0)
       prawn
       prawn-table
       rails (>= 3.1.0)


### PR DESCRIPTION
There is a deprecation warning with the rails 6.0 upgrade, this pull request fixes that. 