### PR TITLE
Add the reminder button to distribution new page.

### DIFF
--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -32,6 +32,7 @@
       error: "Which partner is this distribution going to?" %>
 
       <%= f.input :issued_at, as: :datetime, ampm: true, minute_step: 15, label: "Distribution date" %>
+      <%= f.input :reminder_email_enabled, as: :boolean, checked_value: true, unchecked_value: false, label: "Send Email Reminder The Day Before?" %>
       <%= f.input :agency_rep, label: "Agency representative" %>
 
     <%= render partial: "storage_locations/source", object: f %>


### PR DESCRIPTION
One of our stakeholders pointed out that they should be able to check this when they create a distribution, not just when they edit it.