### PR TITLE
Rails 6 fix for puma-dev so we can keep using it in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,6 +10,7 @@ Rails.application.configure do
 
   # Do not eager load code on boot.
   config.eager_load = false
+  config.hosts << "diaper.test"
 
   # Show full error reports.
   config.consider_all_requests_local = true


### PR DESCRIPTION
Puma-dev is broken with rails 6 unless we do this.