### PR TITLE
Change barcode item string test strategy to avoid false positives

### DIFF
--- a/app/views/admin/barcode_items/_barcode_item_row.html.erb
+++ b/app/views/admin/barcode_items/_barcode_item_row.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= barcode_item_row.barcodeable.name %></td>
+  <td class="td_barcode_name"><%= barcode_item_row.barcodeable.name %></td>
   <td class="numeric"><%= barcode_item_row.quantity %></td>
   <td class="numeric"><%= barcode_item_row.value %></td>
   <td class="text-right">

--- a/app/views/barcode_items/_barcode_item_row.html.erb
+++ b/app/views/barcode_items/_barcode_item_row.html.erb
@@ -1,5 +1,5 @@
 <tr>
-  <td><%= barcode_item_row.barcodeable.name %></td>
+  <td class="tbl_barcode_items_name"><%= barcode_item_row.barcodeable.name %></td>
   <td class=numeric><%= barcode_item_row.quantity %></td>
   <td class=numeric><%= barcode_item_row.value %></td>
   <td class="text-right">

--- a/app/views/barcode_items/_barcode_item_row.html.erb
+++ b/app/views/barcode_items/_barcode_item_row.html.erb
@@ -1,6 +1,6 @@
 <tr>
-  <td class="tbl_barcode_items_name"><%= barcode_item_row.barcodeable.name %></td>
-  <td class=numeric><%= barcode_item_row.quantity %></td>
+  <td class="td_barcode_name"><%= barcode_item_row.barcodeable.name %></td>
+  <td class="numeric text-right"><%= barcode_item_row.quantity %></td>
   <td class=numeric><%= barcode_item_row.value %></td>
   <td class="text-right">
       <%= view_button_to barcode_item_path(barcode_item_row) %>

--- a/app/views/barcode_items/_barcode_item_row.html.erb
+++ b/app/views/barcode_items/_barcode_item_row.html.erb
@@ -1,6 +1,6 @@
 <tr>
   <td class="td_barcode_name"><%= barcode_item_row.barcodeable.name %></td>
-  <td class="numeric text-right"><%= barcode_item_row.quantity %></td>
+  <td class=numeric><%= barcode_item_row.quantity %></td>
   <td class=numeric><%= barcode_item_row.value %></td>
   <td class="text-right">
       <%= view_button_to barcode_item_path(barcode_item_row) %>

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
     it "should edit an existing global barcode"
 
     it "should delete a global barcode" do
-
       visit admin_barcode_items_path
       page.refresh
 

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -23,13 +23,12 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
     end
 
     it "should edit an existing global barcode"
+
     it "should delete a global barcode", focus: true do
       visit admin_barcode_items_path
-      target_name = barcode_item.base_item.name
       page.refresh
 
-      options = page.all('option').map(&:text)
-      expect(options).to include(target_name)
+      expect(page).to have_css(".td_barcode_name", exact_text: barcode_item.base_item.name)
 
       expect(
         accept_confirm do
@@ -37,30 +36,7 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
         end
       ).to include "Are you sure you want to delete"
 
-      test_deletion_using_have_content = -> do
-        expect(page).not_to have_content target_name, exact: true
-      end
-
-      test_deletion_using_options = -> do
-        options = page.all('option').map(&:text)
-        expect(options).not_to include(target_name)
-      end
-
-      test_deletion_using_css = -> do
-        expect page.all('#tbl_barcode_items_name').include?(target_name)
-      end
-
-      test_deletion_using_have_css = -> do
-        expect(page).not_to have_css("#tbl_barcode_items_name", text: target_name)
-      end
-
-      test_deletion_using_options.()
-      test_deletion_using_have_content.()
-      test_deletion_using_css.()
-      test_deletion_using_have_css.()
-      # require 'pry'; binding.pry
-
-
+      expect(page).not_to have_css(".td_barcode_name", exact_text: barcode_item.base_item.name)
     end
 
     it "should view a barcode shows details about it"

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -25,10 +25,12 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
     it "should edit an existing global barcode"
 
     it "should delete a global barcode" do
+
       visit admin_barcode_items_path
       page.refresh
-      have_barcode_in_table = have_css(".td_barcode_name", exact_text: barcode_item.base_item.name)
-      expect(page).to have_barcode_in_table
+
+      barcode_names_in_table = Nokogiri::HTML(page.body).css('.td_barcode_name').map(&:text)
+      expect(barcode_names_in_table).to include(barcode_item.base_item.name)
 
       expect(
         accept_confirm do
@@ -36,7 +38,8 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
         end
       ).to include "Are you sure you want to delete"
 
-      expect(page).not_to have_barcode_in_table
+      barcode_names_in_table = Nokogiri::HTML(page.body).css('.td_barcode_name').map(&:text)
+      expect(barcode_names_in_table).not_to include(barcode_item.base_item.name)
     end
 
     it "should view a barcode shows details about it"

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -24,15 +24,23 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
 
     it "should edit an existing global barcode"
     it "should delete a global barcode" do
+      table_xpath = '//table[@id="tbl_barcode_items"]'
       visit admin_barcode_items_path
       page.refresh
-      expect(page).to have_content barcode_item.base_item.name
+
+      within(:xpath, table_xpath) do
+        expect(page).to have_content barcode_item.base_item.name
+      end
+
       expect(
         accept_confirm do
           click_on "Delete"
         end
       ).to include "Are you sure you want to delete"
-      expect(page).to have_no_content barcode_item.base_item.name
+
+      within(:xpath, table_xpath) do
+        expect(page).not_to have_content barcode_item.base_item.name
+      end
     end
 
     it "should view a barcode shows details about it"

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
       page.refresh
 
       within(:xpath, table_xpath) do
-        expect(page).to have_content barcode_item.base_item.name
+        expect(page).to have_content barcode_item.base_item.name, exact: true
       end
 
       expect(
@@ -39,7 +39,7 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
       ).to include "Are you sure you want to delete"
 
       within(:xpath, table_xpath) do
-        expect(page).not_to have_content barcode_item.base_item.name
+        expect(page).not_to have_content barcode_item.base_item.name, exact: true
       end
     end
 

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
 
     it "should edit an existing global barcode"
 
-    it "should delete a global barcode", focus: true do
+    it "should delete a global barcode" do
       visit admin_barcode_items_path
       page.refresh
 

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -23,14 +23,13 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
     end
 
     it "should edit an existing global barcode"
-    it "should delete a global barcode" do
-      table_xpath = '//table[@id="tbl_barcode_items"]'
+    it "should delete a global barcode", focus: true do
       visit admin_barcode_items_path
+      target_name = barcode_item.base_item.name
       page.refresh
 
-      within(:xpath, table_xpath) do
-        expect(page).to have_content barcode_item.base_item.name, exact: true
-      end
+      options = page.all('option').map(&:text)
+      expect(options).to include(target_name)
 
       expect(
         accept_confirm do
@@ -38,9 +37,8 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
         end
       ).to include "Are you sure you want to delete"
 
-      within(:xpath, table_xpath) do
-        expect(page).not_to have_content barcode_item.base_item.name, exact: true
-      end
+      options = page.all('option').map(&:text)
+      expect(options).not_to include(target_name)
     end
 
     it "should view a barcode shows details about it"

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
     it "should delete a global barcode" do
       visit admin_barcode_items_path
       page.refresh
-
-      expect(page).to have_css(".td_barcode_name", exact_text: barcode_item.base_item.name)
+      have_barcode_in_table = have_css(".td_barcode_name", exact_text: barcode_item.base_item.name)
+      expect(page).to have_barcode_in_table
 
       expect(
         accept_confirm do
@@ -36,7 +36,7 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
         end
       ).to include "Are you sure you want to delete"
 
-      expect(page).not_to have_css(".td_barcode_name", exact_text: barcode_item.base_item.name)
+      expect(page).not_to have_barcode_in_table
     end
 
     it "should view a barcode shows details about it"

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -37,8 +37,30 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
         end
       ).to include "Are you sure you want to delete"
 
-      options = page.all('option').map(&:text)
-      expect(options).not_to include(target_name)
+      test_deletion_using_have_content = -> do
+        expect(page).not_to have_content target_name, exact: true
+      end
+
+      test_deletion_using_options = -> do
+        options = page.all('option').map(&:text)
+        expect(options).not_to include(target_name)
+      end
+
+      test_deletion_using_css = -> do
+        expect page.all('#tbl_barcode_items_name').include?(target_name)
+      end
+
+      test_deletion_using_have_css = -> do
+        expect(page).not_to have_css("#tbl_barcode_items_name", text: target_name)
+      end
+
+      test_deletion_using_options.()
+      test_deletion_using_have_content.()
+      test_deletion_using_css.()
+      test_deletion_using_have_css.()
+      # require 'pry'; binding.pry
+
+
     end
 
     it "should view a barcode shows details about it"


### PR DESCRIPTION
### Description

This PR addresses an intermittent false positive problem when running the "should delete a global barcode" test in barcode_items_system_spec.rb.

This change will result in reporting a test error only if the search string is in the page as a full element text value (as opposed to a substring of one).

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

This test has been run several hundred times without failure. (In a previous test of the previous version that motivated the submission of this issue, I found that the error occurred approximately 4% of the time.)
