### PR TITLE
[WIP] In seeds.rb, support the creation of multiple org's with standard data sets.

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -22,7 +22,7 @@ class Partner < ApplicationRecord
   has_many :requests, dependent: :destroy
 
   validates :organization, presence: true
-  validates :name, :email, presence: true
+  validates :name, :email, presence: true, uniqueness: { scope: :organization }
   validates :email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, on: :create }
 
   scope :for_csv_export, ->(organization) {

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -22,7 +22,7 @@ class Partner < ApplicationRecord
   has_many :requests, dependent: :destroy
 
   validates :organization, presence: true
-  validates :name, :email, presence: true, uniqueness: true
+  validates :name, :email, presence: true
   validates :email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, on: :create }
 
   scope :for_csv_export, ->(organization) {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -73,10 +73,12 @@ dc_org = Organization.find_or_create_by!(short_name: "dc_bank") do |organization
 end
 Organization.seed_items(dc_org)
 
-ORGS_TO_SEED = [pdx_org, dc_org]
+# This array contains organizations _other than_ sf_org that need to be seeded.
+# If you add an organization, remember to create some users for that organization too.
+STANDARD_ORGS_TO_SEED = [pdx_org, dc_org]
 
 # Assign a value to some organization items to verify totals are working
-ORGS_TO_SEED.each do |org|
+STANDARD_ORGS_TO_SEED.each do |org|
   org.items.where(value_in_cents: 0).limit(10).update_all(value_in_cents: 100)
 end
 
@@ -131,7 +133,7 @@ def create_donation_sites(organization)
   end
 end
 
-ORGS_TO_SEED.each { |org| create_donation_sites(org) }
+STANDARD_ORGS_TO_SEED.each { |org| create_donation_sites(org) }
 
 
 # ----------------------------------------------------------------------------
@@ -152,7 +154,7 @@ def create_partners(organization)
   end
 end
 
-ORGS_TO_SEED.each { |org| create_partners(org) }
+STANDARD_ORGS_TO_SEED.each { |org| create_partners(org) }
 
 
 # ----------------------------------------------------------------------------
@@ -177,7 +179,7 @@ def create_storage_locations(organization)
   @storage_locations[organization] = { arbor: inv_arbor, pdxdb: inv_pdxdb }
 end
 
-ORGS_TO_SEED.each { |org| create_storage_locations(org) }
+STANDARD_ORGS_TO_SEED.each { |org| create_storage_locations(org) }
 
 
 # ----------------------------------------------------------------------------
@@ -197,7 +199,7 @@ def create_participants(organization)
   ].each { |participant| DiaperDriveParticipant.create! participant }
 end
 
-ORGS_TO_SEED.each { |org| create_participants(org) }
+STANDARD_ORGS_TO_SEED.each { |org| create_participants(org) }
 
 
 
@@ -212,7 +214,7 @@ def create_manufacturers(organization)
   ].each { |search_values| Manufacturer.find_or_create_by! search_values }
 end
 
-ORGS_TO_SEED.each { |org| create_manufacturers(org) }
+STANDARD_ORGS_TO_SEED.each { |org| create_manufacturers(org) }
 
 
 # ----------------------------------------------------------------------------
@@ -247,7 +249,7 @@ def seed_item_quantities(organization)
   end
 end
 
-  ORGS_TO_SEED.each { |org| seed_item_quantities(org) }
+  STANDARD_ORGS_TO_SEED.each { |org| seed_item_quantities(org) }
 
 
 # ----------------------------------------------------------------------------
@@ -279,7 +281,7 @@ def create_barcode_items(organization)
   end
 end
 
-ORGS_TO_SEED.each { |org| create_barcode_items(org) }
+STANDARD_ORGS_TO_SEED.each { |org| create_barcode_items(org) }
 
 
 
@@ -316,7 +318,7 @@ def create_donations(organization)
   donation.storage_location.increase_inventory(donation)
 end
 
-ORGS_TO_SEED.each do |organization|
+STANDARD_ORGS_TO_SEED.each do |organization|
   20.times.each { create_donations(organization) }
 end
 
@@ -345,7 +347,7 @@ def create_distributions(organization)
   end
 end
 
-ORGS_TO_SEED.each { |org| create_distributions(org) }
+STANDARD_ORGS_TO_SEED.each { |org| create_distributions(org) }
 
 
 # ----------------------------------------------------------------------------
@@ -366,7 +368,7 @@ def create_requests(organization)
   end
 end
 
-ORGS_TO_SEED.each { |org| create_requests(org) }
+STANDARD_ORGS_TO_SEED.each { |org| create_requests(org) }
 
 
 # ----------------------------------------------------------------------------
@@ -392,7 +394,7 @@ def create_vendors(organization)
   end
 end
 
-ORGS_TO_SEED.each { |org| create_vendors(org) }
+STANDARD_ORGS_TO_SEED.each { |org| create_vendors(org) }
 
 
 # ----------------------------------------------------------------------------
@@ -423,7 +425,7 @@ def create_purchases(organization)
   end
 end
 
-ORGS_TO_SEED.each { |org| create_purchases(org) }
+STANDARD_ORGS_TO_SEED.each { |org| create_purchases(org) }
 
 
 # ----------------------------------------------------------------------------

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,7 +71,7 @@ Organization.seed_items(sf_org)
 STANDARD_ORGS_TO_SEED = [pdx_org]
 
 # Assign a value to some organization items to verify totals are working
-STANDARD_ORGS_TO_SEED.each do |org|
+Organization.all.each do |org|
   org.items.where(value_in_cents: 0).limit(10).update_all(value_in_cents: 100)
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -40,9 +40,7 @@ base_items = File.read(Rails.root.join("db", "base_items.json"))
 end
 
 
-# Only pdx_org and dc_org will be seeded with data.
-# sf_org will get only a minimal amount with which to start populating manually
-
+# pdx_org will be populated with a minimal but complete set of data
 pdx_org = Organization.find_or_create_by!(short_name: "diaper_bank") do |organization|
   organization.name    = "Pawnee Diaper Bank"
   organization.street  = "P.O. Box 22613"
@@ -53,6 +51,7 @@ pdx_org = Organization.find_or_create_by!(short_name: "diaper_bank") do |organiz
 end
 Organization.seed_items(pdx_org)
 
+# sf_org will get only a minimal amount with which to start populating manually
 sf_org = Organization.find_or_create_by!(short_name: "sf_bank") do |organization|
   organization.name    = "SF Diaper Bank"
   organization.street  = "P.O. Box 12345"
@@ -63,19 +62,13 @@ sf_org = Organization.find_or_create_by!(short_name: "sf_bank") do |organization
 end
 Organization.seed_items(sf_org)
 
-dc_org = Organization.find_or_create_by!(short_name: "dc_bank") do |organization|
-  organization.name    = "DC Diaper Bank"
-  organization.street  = "P.O. Box 12345"
-  organization.city    = "Washington"
-  organization.state   = "DC"
-  organization.zipcode = "20003"
-  organization.email   = "info@dcdiaperbank.org"
-end
-Organization.seed_items(dc_org)
 
-# This array contains organizations _other than_ sf_org that need to be seeded.
-# If you add an organization, remember to create some users for that organization too.
-STANDARD_ORGS_TO_SEED = [pdx_org, dc_org]
+# This array contains organizations _other than_ sf_org that need to be seeded
+# with minimal but complete sets of data. It default to only pdx but you can add others.
+# If you add an organization, to this array, you will need to:
+#   1) create it
+#   2) add users to it in the Users section below
+STANDARD_ORGS_TO_SEED = [pdx_org]
 
 # Assign a value to some organization items to verify totals are working
 STANDARD_ORGS_TO_SEED.each do |org|
@@ -92,16 +85,12 @@ end
 
     { email: 'org_admin1@example.com', organization_admin: true,  organization: pdx_org },
     { email: 'org_admin2@example.com', organization_admin: true,  organization: sf_org },
-    { email: 'org_admin3@example.com', organization_admin: true,  organization: dc_org },
 
     { email: 'user_1@example.com',     organization_admin: false, organization: pdx_org },
     { email: 'user_2@example.com',     organization_admin: false, organization: sf_org },
-    { email: 'user_3@example.com',     organization_admin: false, organization: dc_org },
 
     { email: 'test@example.com',       organization_admin: false, organization: pdx_org, super_admin: true },
     { email: 'test2@example.com',      organization_admin: true,  organization: pdx_org },
-    { email: 'test_dc@example.com',    organization_admin: false, organization: dc_org, super_admin: true },
-    { email: 'test_dc2@example.com',   organization_admin: true,  organization: dc_org },
 ].each do |user|
   User.create(
       email:                 user[:email],

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,14 +26,14 @@ end
 
 # Initial starting qty for our test organizations
 base_items = File.read(Rails.root.join("db", "base_items.json"))
-items_by_category = JSON.parse(base_items)
+@items_by_category = JSON.parse(base_items)
 
 
 # ----------------------------------------------------------------------------
 # Base Items
 # ----------------------------------------------------------------------------
 
-items_by_category.each do |category, entries|
+@items_by_category.each do |category, entries|
   entries.each do |entry|
     BaseItem.find_or_create_by!(name: entry["name"], category: category, partner_key: entry["key"])
   end
@@ -44,7 +44,7 @@ end
 # Organizations
 # ----------------------------------------------------------------------------
 
-pdx_org = Organization.find_or_create_by!(short_name: "diaper_bank") do |organization|
+@pdx_org = Organization.find_or_create_by!(short_name: "diaper_bank") do |organization|
   organization.name    = "Pawnee Diaper Bank"
   organization.street  = "P.O. Box 22613"
   organization.city    = "Pawnee"
@@ -52,9 +52,8 @@ pdx_org = Organization.find_or_create_by!(short_name: "diaper_bank") do |organiz
   organization.zipcode = "12345"
   organization.email   = "info@pawneediaper.org"
 end
-Organization.seed_items(pdx_org)
 
-sf_org = Organization.find_or_create_by!(short_name: "sf_bank") do |organization|
+@sf_org = Organization.find_or_create_by!(short_name: "sf_bank") do |organization|
   organization.name    = "SF Diaper Bank"
   organization.street  = "P.O. Box 12345"
   organization.city    = "San Francisco"
@@ -62,10 +61,11 @@ sf_org = Organization.find_or_create_by!(short_name: "sf_bank") do |organization
   organization.zipcode = "90210"
   organization.email   = "info@sfdiaperbank.org"
 end
-Organization.seed_items(sf_org)
+
 
 # Assign a value to some organization items to verify totals are working
 Organization.all.each do |org|
+  Organization.seed_items(org)
   org.items.where(value_in_cents: 0).limit(10).update_all(value_in_cents: 100)
 end
 
@@ -76,12 +76,12 @@ end
 
 [
   { email: 'superadmin@example.com', organization_admin: false,                        super_admin: true },
-  { email: 'org_admin1@example.com', organization_admin: true,  organization: pdx_org },
-  { email: 'org_admin2@example.com', organization_admin: true,  organization: sf_org },
-  { email: 'user_1@example.com',     organization_admin: false, organization: pdx_org },
-  { email: 'user_2@example.com',     organization_admin: false, organization: sf_org },
-  { email: 'test@example.com',       organization_admin: false, organization: pdx_org, super_admin: true },
-  { email: 'test2@example.com',      organization_admin: true,  organization: pdx_org }
+  { email: 'org_admin1@example.com', organization_admin: true,  organization: @pdx_org },
+  { email: 'org_admin2@example.com', organization_admin: true,  organization: @sf_org },
+  { email: 'user_1@example.com',     organization_admin: false, organization: @pdx_org },
+  { email: 'user_2@example.com',     organization_admin: false, organization: @sf_org },
+  { email: 'test@example.com',       organization_admin: false, organization: @pdx_org, super_admin: true },
+  { email: 'test2@example.com',      organization_admin: true,  organization: @pdx_org }
 ].each do |user|
   User.create(
     email:                 user[:email],
@@ -98,73 +98,103 @@ end
 # Donation Sites
 # ----------------------------------------------------------------------------
 
-[
-  { name: "Pawnee Hardware",       address: "1234 SE Some Ave., Pawnee, OR 12345" },
-  { name: "Parks Department",      address: "2345 NE Some St., Pawnee, OR 12345" },
-  { name: "Waffle House",          address: "3456 Some Bay., Pawnee, OR 12345" },
-  { name: "Eagleton Country Club", address: "4567 Some Blvd., Eagleton, OR 12345" }
-].each do |donation_option|
-  DonationSite.find_or_create_by!(name: donation_option[:name]) do |donation|
-    donation.address = donation_option[:address]
-    donation.organization = pdx_org
+def create_donation_sites(organization)
+  [
+    { name: "Pawnee Hardware",       address: "1234 SE Some Ave., Pawnee, OR 12345" },
+    { name: "Parks Department",      address: "2345 NE Some St., Pawnee, OR 12345" },
+    { name: "Waffle House",          address: "3456 Some Bay., Pawnee, OR 12345" },
+    { name: "Eagleton Country Club", address: "4567 Some Blvd., Eagleton, OR 12345" }
+  ].each do |donation_option|
+    search_values = { name: donation_option[:name], organization: organization }
+    DonationSite.find_or_create_by!(search_values) do |donation_site|
+      donation_site.address = donation_option[:address]
+      donation_site.organization = organization
+    end
   end
 end
+
+Organization.all.each { |org| create_donation_sites(org) }
 
 
 # ----------------------------------------------------------------------------
 # Partners
 # ----------------------------------------------------------------------------
 
-[
-  { name: "Pawnee Parent Service",         email: "someone@pawneeparent.org",      status: :approved },
-  { name: "Pawnee Homeless Shelter",       email: "anyone@pawneehomelss.com",      status: :invited },
-  { name: "Pawnee Pregnancy Center",       email: "contactus@pawneepregnancy.com", status: :invited },
-  { name: "Pawnee Senior Citizens Center", email: "help@pscc.org",                 status: :recertification_required }
-].each do |partner_option|
-  Partner.find_or_create_by!(partner_option) do |partner|
-    partner.organization = pdx_org
+def create_partners(organization)
+  [
+    { name: "Pawnee Parent Service",         email: "someone@pawneeparent.org",      status: :approved },
+    { name: "Pawnee Homeless Shelter",       email: "anyone@pawneehomelss.com",      status: :invited },
+    { name: "Pawnee Pregnancy Center",       email: "contactus@pawneepregnancy.com", status: :invited },
+    { name: "Pawnee Senior Citizens Center", email: "help@pscc.org",                 status: :recertification_required }
+  ].each do |search_values|
+    search_values[:organization] = organization
+    Partner.find_or_create_by!(search_values) do |partner|
+      partner.organization = organization
+    end
   end
 end
+
+Organization.all.each { |org| create_partners(org) }
 
 
 # ----------------------------------------------------------------------------
 # Storage Locations
 # ----------------------------------------------------------------------------
 
-inv_arbor = StorageLocation.find_or_create_by!(name: "Bulk Storage Location") do |inventory|
-  inventory.address = "Unknown"
-  inventory.organization = pdx_org
+def create_storage_locations(organization)
+  @storage_locations ||= {}
+
+  search_values = { name: "Bulk Storage Location", organization: organization }
+  inv_arbor = StorageLocation.find_or_create_by!(search_values) do |inventory|
+    inventory.address = "Unknown"
+    inventory.organization = organization
+  end
+
+  search_values = { name: "Pawnee Main Bank (Office)", organization: organization }
+  inv_pdxdb = StorageLocation.find_or_create_by!(search_values) do |inventory|
+    inventory.address = "Unknown"
+    inventory.organization = organization
+  end
+
+  @storage_locations[organization] = { arbor: inv_arbor, pdxdb: inv_pdxdb }
 end
-inv_pdxdb = StorageLocation.find_or_create_by!(name: "Pawnee Main Bank (Office)") do |inventory|
-  inventory.address = "Unknown"
-  inventory.organization = pdx_org
-end
+
+Organization.all.each { |org| create_storage_locations(org) }
 
 
 # ----------------------------------------------------------------------------
 # Diaper Drive Participants
 # ----------------------------------------------------------------------------
 
-[
-  { business_name: "A Good Place to Collect Diapers",
-    contact_name:  "fred",
-    email:         "good@place.is",
-    organization:  pdx_org },
-  { business_name: "A Mediocre Place to Collect Diapers",
-    contact_name:  "wilma",
-    email:         "ok@place.is",
-    organization:  pdx_org }
-].each { |participant| DiaperDriveParticipant.create! participant }
+def create_participants(organization)
+  [
+    { business_name: "A Good Place to Collect Diapers",
+      contact_name:  "fred",
+      email:         "good@place.is",
+      organization:  organization },
+    { business_name: "A Mediocre Place to Collect Diapers",
+      contact_name:  "wilma",
+      email:         "ok@place.is",
+      organization:  organization }
+  ].each { |participant| DiaperDriveParticipant.create! participant }
+end
+
+Organization.all.each { |org| create_participants(org) }
+
 
 
 # ----------------------------------------------------------------------------
 # Manufacturers
 # ----------------------------------------------------------------------------
 
-[
-  { name: "Manufacturer 1", organization: pdx_org },
-  { name: "Manufacturer 2", organization: pdx_org }
-].each { |manu| Manufacturer.find_or_create_by! manu }
+def create_manufacturers(organization)
+  [
+    { name: "Manufacturer 1", organization: organization },
+    { name: "Manufacturer 2", organization: organization }
+  ].each { |search_values| Manufacturer.find_or_create_by! search_values }
+end
+
+Organization.all.each { |org| create_manufacturers(org) }
 
 
 # ----------------------------------------------------------------------------
@@ -190,80 +220,86 @@ def seed_quantity(item_name, organization, storage_location, quantity)
   adjustment.storage_location.decrease_inventory decreasing_adjustment
 end
 
-items_by_category.each do |_category, entries|
-  entries.each do |entry|
-    seed_quantity(entry['name'], pdx_org, inv_arbor, entry['qty']['arbor'])
-    seed_quantity(entry['name'], pdx_org, inv_pdxdb, entry['qty']['pdxdb'])
+def seed_item_quantities(organization)
+  @items_by_category.each do |_category, entries|
+    entries.each do |entry|
+      seed_quantity(entry['name'], organization, @storage_locations[organization][:pdxdb], entry['qty']['pdxdb'])
+      seed_quantity(entry['name'], organization, @storage_locations[organization][:arbor], entry['qty']['arbor'])
+    end
   end
 end
+
+  Organization.all.each { |org| seed_item_quantities(org) }
 
 
 # ----------------------------------------------------------------------------
 # Barcode Items
 # ----------------------------------------------------------------------------
 
-[
-  { value: "10037867880046", name: "Kids (Size 5)",         quantity: 108 },
-  { value: "10037867880053", name: "Kids (Size 6)",         quantity: 92 },
-  { value: "10037867880039", name: "Kids (Size 4)",         quantity: 124 },
-  { value: "803516626364",   name: "Kids (Size 1)",         quantity: 40 },
-  { value: "036000406535",   name: "Kids (Size 1)",         quantity: 44 },
-  { value: "037000863427",   name: "Kids (Size 1)",         quantity: 35 },
-  { value: "041260379000",   name: "Kids (Size 3)",         quantity: 160 },
-  { value: "074887711700",   name: "Wipes (Baby)",          quantity: 8 },
-  { value: "036000451306",   name: "Kids Pull-Ups (4T-5T)", quantity: 56 },
-  { value: "037000862246",   name: "Kids (Size 4)",         quantity: 92 },
-  { value: "041260370236",   name: "Kids (Size 4)",         quantity: 68 },
-  { value: "036000407679",   name: "Kids (Size 4)",         quantity: 24 },
-  { value: "311917152226",   name: "Kids (Size 4)",         quantity: 82 },
-].each do |item|
-  BarcodeItem.find_or_create_by!(value: item[:value]) do |barcode|
-    barcode.item = Item.find_by(name: item[:name])
-    barcode.quantity = item[:quantity]
-    barcode.organization = pdx_org
+def create_barcode_items(organization)
+  [
+    { value: "10037867880046", name: "Kids (Size 5)",         quantity: 108 },
+    { value: "10037867880053", name: "Kids (Size 6)",         quantity: 92 },
+    { value: "10037867880039", name: "Kids (Size 4)",         quantity: 124 },
+    { value: "803516626364",   name: "Kids (Size 1)",         quantity: 40 },
+    { value: "036000406535",   name: "Kids (Size 1)",         quantity: 44 },
+    { value: "037000863427",   name: "Kids (Size 1)",         quantity: 35 },
+    { value: "041260379000",   name: "Kids (Size 3)",         quantity: 160 },
+    { value: "074887711700",   name: "Wipes (Baby)",          quantity: 8 },
+    { value: "036000451306",   name: "Kids Pull-Ups (4T-5T)", quantity: 56 },
+    { value: "037000862246",   name: "Kids (Size 4)",         quantity: 92 },
+    { value: "041260370236",   name: "Kids (Size 4)",         quantity: 68 },
+    { value: "036000407679",   name: "Kids (Size 4)",         quantity: 24 },
+    { value: "311917152226",   name: "Kids (Size 4)",         quantity: 82 },
+  ].each do |item|
+    search_values = { value: item[:value], organization: organization}
+    BarcodeItem.find_or_create_by!(search_values) do |barcode|
+      barcode.item = Item.find_by(name: item[:name])
+      barcode.quantity = item[:quantity]
+      barcode.organization = organization
+    end
   end
 end
+
+Organization.all.each { |org| create_barcode_items(org) }
+
 
 
 # ----------------------------------------------------------------------------
 # Donations
 # ----------------------------------------------------------------------------
 
-# Make some donations of all sorts
-20.times.each do
+def create_donations(organization)
   source = Donation::SOURCES.values.sample
+
+  attrs = {
+      source:                   source,
+      storage_location:         random_record_for_org(organization, StorageLocation),
+      organization:             organization,
+      issued_at:                Time.zone.now,
+  }
+
   # Depending on which source it uses, additional data may need to be provided.
-  donation = case source
-             when Donation::SOURCES[:diaper_drive]
-               Donation.create! source:                   source,
-                                diaper_drive_participant: random_record_for_org(pdx_org, DiaperDriveParticipant),
-                                storage_location:         random_record_for_org(pdx_org, StorageLocation),
-                                organization:             pdx_org,
-                                issued_at:                Time.zone.now
-             when Donation::SOURCES[:donation_site]
-               Donation.create! source:           source,
-                                donation_site:    random_record_for_org(pdx_org, DonationSite),
-                                storage_location: random_record_for_org(pdx_org, StorageLocation),
-                                organization:     pdx_org,
-                                issued_at:        Time.zone.now
-             when Donation::SOURCES[:manufacturer]
-               Donation.create! source:           source,
-                                manufacturer:     random_record_for_org(pdx_org, Manufacturer),
-                                storage_location: random_record_for_org(pdx_org, StorageLocation),
-                                organization:     pdx_org,
-                                issued_at:        Time.zone.now
-             else
-               Donation.create! source:           source,
-                                storage_location: random_record_for_org(pdx_org, StorageLocation),
-                                organization:     pdx_org,
-                                issued_at:        Time.zone.now
-             end
+  case source
+  when Donation::SOURCES[:diaper_drive]
+    attrs[:diaper_drive_participant] = random_record_for_org(organization, DiaperDriveParticipant)
+  when Donation::SOURCES[:donation_site]
+    attrs[:donation_site] = random_record_for_org(organization, DonationSite)
+  when Donation::SOURCES[:manufacturer]
+    attrs[:manufacturer] = random_record_for_org(organization, Manufacturer)
+  end
+
+  donation = Donation.create! attrs
 
   rand(1..5).times.each do
-    LineItem.create! quantity: rand(250..500), item: random_record_for_org(pdx_org, Item), itemizable: donation
+    LineItem.create! quantity: rand(250..500), item: random_record_for_org(organization, Item), itemizable: donation
   end
   donation.reload
   donation.storage_location.increase_inventory(donation)
+end
+
+Organization.all.each do |organization|
+  20.times.each { create_donations(organization) }
 end
 
 
@@ -271,92 +307,111 @@ end
 # Distributions
 # ----------------------------------------------------------------------------
 
+def create_distributions(organization)
 # Make some distributions, but don't use up all the inventory
-20.times.each do
-  storage_location = random_record_for_org(pdx_org, StorageLocation)
-  stored_inventory_items_sample = storage_location.inventory_items.sample(20)
+  20.times.each do
+    storage_location = random_record_for_org(organization, StorageLocation)
+    stored_inventory_items_sample = storage_location.inventory_items.sample(20)
 
-  distribution = Distribution.create!(storage_location: storage_location,
-                                      partner:          random_record_for_org(pdx_org, Partner),
-                                      organization:     pdx_org,
-                                      issued_at:        Faker::Date.between(from: 4.days.ago, to: Time.zone.today))
+    distribution = Distribution.create!(storage_location: storage_location,
+                                        partner:          random_record_for_org(organization, Partner),
+                                        organization:     organization,
+                                        issued_at:        Faker::Date.between(from: 4.days.ago, to: Time.zone.today))
 
-  stored_inventory_items_sample.each do |stored_inventory_item|
-    distribution_qty = rand(stored_inventory_item.quantity / 2)
-    LineItem.create! quantity: distribution_qty, item: stored_inventory_item.item, itemizable: distribution if distribution_qty >= 1
+    stored_inventory_items_sample.each do |stored_inventory_item|
+      distribution_qty = rand(stored_inventory_item.quantity / 2)
+      LineItem.create! quantity: distribution_qty, item: stored_inventory_item.item, itemizable: distribution if distribution_qty >= 1
+    end
+    distribution.reload
+    distribution.storage_location.decrease_inventory(distribution)
   end
-  distribution.reload
-  distribution.storage_location.decrease_inventory(distribution)
 end
+
+Organization.all.each { |org| create_distributions(org) }
 
 
 # ----------------------------------------------------------------------------
 # Requests
 # ----------------------------------------------------------------------------
 
-20.times.each do |count|
-  status = count > 15 ? 'fulfilled' : 'pending'
-  Request.create(
-    partner: random_record_for_org(pdx_org, Partner),
-    organization: pdx_org,
-    request_items: [{ "item_id" => Item.all.pluck(:id).sample, "quantity" => 3 },
-                    { "item_id" => Item.all.pluck(:id).sample, "quantity" => 2 }],
-    comments: "Urgent",
-    status: status
-  )
+def create_requests(organization)
+  20.times.each do |count|
+    status = count > 15 ? 'fulfilled' : 'pending'
+    Request.create(
+      partner: random_record_for_org(organization, Partner),
+      organization: organization,
+      request_items: [{ "item_id" => Item.all.pluck(:id).sample, "quantity" => 3 },
+                      { "item_id" => Item.all.pluck(:id).sample, "quantity" => 2 }],
+      comments: "Urgent",
+      status: status
+    )
+  end
 end
+
+Organization.all.each { |org| create_requests(org) }
 
 
 # ----------------------------------------------------------------------------
 # Vendors
 # ----------------------------------------------------------------------------
 
-# Create some Vendors so Purchases can have vendor_ids
-5.times do
-  Vendor.create(
-    contact_name:    Faker::FunnyName.two_word_name,
-    email:           Faker::Internet.email,
-    phone:           Faker::PhoneNumber.cell_phone,
-    comment:         Faker::Lorem.paragraph(sentence_count: 2),
-    organization_id: Organization.all.pluck(:id).sample,
-    address:         "#{Faker::Address.street_address} #{Faker::Address.city}, #{Faker::Address.state_abbr} #{Faker::Address.zip_code}",
-    business_name:   Faker::Company.name,
-    latitude:        rand(-90.000000000...90.000000000),
-    longitude:       rand(-180.000000000...180.000000000),
-    created_at:      (Date.today - rand(15).days),
-    updated_at:      (Date.today - rand(15).days),
-  )
+def create_vendors(organization)
+  # Create some Vendors so Purchases can have vendor_ids
+  3.times do
+    Vendor.create(
+      contact_name:    Faker::FunnyName.two_word_name,
+      email:           Faker::Internet.email,
+      phone:           Faker::PhoneNumber.cell_phone,
+      comment:         Faker::Lorem.paragraph(sentence_count: 2),
+      organization_id: organization.id,
+      address:         "#{Faker::Address.street_address} #{Faker::Address.city}, #{Faker::Address.state_abbr} #{Faker::Address.zip_code}",
+      business_name:   Faker::Company.name,
+      latitude:        rand(-90.000000000...90.000000000),
+      longitude:       rand(-180.000000000...180.000000000),
+      created_at:      (Date.today - rand(15).days),
+      updated_at:      (Date.today - rand(15).days),
+    )
+  end
 end
+
+Organization.all.each { |org| create_vendors(org) }
 
 
 # ----------------------------------------------------------------------------
 # Purchases
 # ----------------------------------------------------------------------------
 
-suppliers = ["Target", "Wegmans", "Walmart", "Walgreens"]
-comments = [
-  "Maecenas ante lectus, vestibulum pellentesque arcu sed, eleifend lacinia elit. Cras accumsan varius nisl, a commodo ligula consequat nec. Aliquam tincidunt diam id placerat rutrum.",
-  "Integer a molestie tortor. Duis pretium urna eget congue porta. Fusce aliquet dolor quis viverra volutpat.",
-  "Nullam dictum ac lectus at scelerisque. Phasellus volutpat, sem at eleifend tristique, massa mi cursus dui, eget pharetra ligula arcu sit amet nunc."]
+def create_purchases(organization)
+  suppliers = ["Target", "Wegmans", "Walmart", "Walgreens"]
+  comments = [
+    "Maecenas ante lectus, vestibulum pellentesque arcu sed, eleifend lacinia elit. Cras accumsan varius nisl, a commodo ligula consequat nec. Aliquam tincidunt diam id placerat rutrum.",
+    "Integer a molestie tortor. Duis pretium urna eget congue porta. Fusce aliquet dolor quis viverra volutpat.",
+    "Nullam dictum ac lectus at scelerisque. Phasellus volutpat, sem at eleifend tristique, massa mi cursus dui, eget pharetra ligula arcu sit amet nunc."]
 
-20.times do
-  storage_location = random_record_for_org(pdx_org, StorageLocation)
-  vendor = random_record_for_org(pdx_org, Vendor)
-  Purchase.create(
-    purchased_from:        suppliers.sample,
-    comment:               comments.sample,
-    organization_id:       pdx_org.id,
-    storage_location_id:   storage_location.id,
-    amount_spent_in_cents: rand(200..10000),
-    issued_at:             (Date.today - rand(15).days),
-    created_at:            (Date.today - rand(15).days),
-    updated_at:            (Date.today - rand(15).days),
-    vendor_id:             vendor.id
-  )
+  20.times do
+    storage_location = random_record_for_org(organization, StorageLocation)
+    vendor = random_record_for_org(organization, Vendor)
+    Purchase.create(
+      purchased_from:        suppliers.sample,
+      comment:               comments.sample,
+      organization_id:       organization.id,
+      storage_location_id:   storage_location.id,
+      amount_spent_in_cents: rand(200..10000),
+      issued_at:             (Date.today - rand(15).days),
+      created_at:            (Date.today - rand(15).days),
+      updated_at:            (Date.today - rand(15).days),
+      vendor_id:             vendor.id
+    )
+  end
 end
+
+Organization.all.each { |org| create_purchases(org) }
+
 
 # ----------------------------------------------------------------------------
 # Flipper
 # ----------------------------------------------------------------------------
 
 Flipper::Adapters::ActiveRecord::Feature.find_or_create_by(key: "new_logo")
+
+

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -17,15 +17,20 @@ RSpec.describe Partner, type: :model do
     it "must belong to an organization" do
       expect(build(:partner, organization_id: nil)).not_to be_valid
     end
+
     it "requires a unique name" do
+      pending('a way to test this scoped to the organization')
       expect(build(:partner, name: nil)).not_to be_valid
       create(:partner, name: "Foo")
       expect(build(:partner, name: "Foo")).not_to be_valid
     end
-    it "requires a unique email that is formatted correctly" do
+    it "requires a unique email" do
+      pending('a way to test this scoped to the organization')
       expect(build(:partner, email: nil)).not_to be_valid
       create(:partner, email: "foo@bar.com")
       expect(build(:partner, email: "foo@bar.com")).not_to be_valid
+    end
+    it "requires an email address to be formatted correctly" do
       expect(build(:partner, email: "boooooooooo")).not_to be_valid
     end
   end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -18,14 +18,12 @@ RSpec.describe Partner, type: :model do
       expect(build(:partner, organization_id: nil)).not_to be_valid
     end
 
-    it "requires a unique name" do
-      pending('a way to test this scoped to the organization')
+    it "requires a unique name", focus: true do
       expect(build(:partner, name: nil)).not_to be_valid
       create(:partner, name: "Foo")
       expect(build(:partner, name: "Foo")).not_to be_valid
     end
-    it "requires a unique email" do
-      pending('a way to test this scoped to the organization')
+    it "requires a unique email", focus: true do
       expect(build(:partner, email: nil)).not_to be_valid
       create(:partner, email: "foo@bar.com")
       expect(build(:partner, email: "foo@bar.com")).not_to be_valid


### PR DESCRIPTION
Resolves #1322

### Description

The attached source code creates comparable data sets for each of the 2 sample organizations.

In order for this to work I needed to remove the uniqueness constraint on name and email in the `Partner` model, and disable the tests that test that. Is there a way to reinstate that constraint, but scoped only to the organization? 

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

The unit tests have been run successfully (after making the modifications to the tests described above).

### To See the Changes in the App

...you can log in as any of the users in the `sf_org`, which at the time of this writing are: 

```
  { email: 'org_admin2@example.com', organization_admin: true,  organization: @sf_org },
  { email: 'user_2@example.com',     organization_admin: false, organization: @sf_org },
```
