### PR TITLE
Optimize computation of manufacturer donation volume.

### DIFF
--- a/app/models/manufacturer.rb
+++ b/app/models/manufacturer.rb
@@ -22,7 +22,7 @@ class Manufacturer < ApplicationRecord
 
   def volume
     # returns 0 instead of nil when Manufacturer exists without any donations
-    donations.map { |d| d.line_items.total }.reduce(:+) || 0
+    donations.joins(:line_items).sum(:quantity)
   end
 
   def self.by_donation_count(count = 10)

--- a/spec/models/manufacturer_spec.rb
+++ b/spec/models/manufacturer_spec.rb
@@ -31,6 +31,21 @@ RSpec.describe Manufacturer, type: :model do
         create(:donation, :with_items, item_quantity: 15, source: Donation::SOURCES[:manufacturer], manufacturer: mfg)
         expect(mfg.volume).to eq(15)
       end
+
+      it "retrieves the amount of product that has been donated by manufacturer from multiple donations" do
+        mfg = create(:manufacturer)
+        create(:donation, :with_items, item_quantity: 15, source: Donation::SOURCES[:manufacturer], manufacturer: mfg)
+        create(:donation, :with_items, item_quantity: 10, source: Donation::SOURCES[:manufacturer], manufacturer: mfg)
+        expect(mfg.volume).to eq(25)
+      end
+
+      it "ignores the amount of product from other manufacturers" do
+        mfg = create(:manufacturer)
+        mfg2 = create(:manufacturer)
+        create(:donation, :with_items, item_quantity: 5, source: Donation::SOURCES[:manufacturer], manufacturer: mfg)
+        create(:donation, :with_items, item_quantity: 10, source: Donation::SOURCES[:manufacturer], manufacturer: mfg2)
+        expect(mfg.volume).to eq(5)
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request addresses https://github.com/rubyforgood/diaper/issues/1308.

Optimize computation of manufacturer donation volume by using ActiveRecord instead of Ruby Enumerables, as per @armahillo's recommendation.

### Type of change

* Performance optimization

### How Has This Been Tested?

Unit tests all passed.
