### PR TITLE
Documentation Change: `ubuntu-installation` renamed to `installation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This project took what we built for the [Portland Diaper Bank in 2016](https://g
 
 ### Installation Instructions
 
-The `ubuntu_installation.md` file ([https://github.com/rubyforgood/diaper/blob/master/ubuntu-installation.md](https://github.com/rubyforgood/diaper/blob/master/ubuntu-installation.md)) has detailed instructions for installation and configuration of an Ubuntu host to run this software. Although there is not a document for Mac OS, it may be helpful for that as well.
+The `installation.md` file ([https://github.com/rubyforgood/diaper/blob/master/installation.md](https://github.com/rubyforgood/diaper/blob/master/installation.md)) has detailed instructions for installation and configuration of an Ubuntu host to run this software. Although there is not a document for Mac OS, it may be helpful for that as well.
 
 ### Ruby Version
 This app uses Ruby version 2.6.4, indicated in `/.ruby-version` and `Gemfile`, which will be auto-selected if you use a Ruby versioning manager like `rvm`, `rbenv`, or `asdf`.


### PR DESCRIPTION
### Description 

Was working through installation and noticed the `installation` link didn't work; it looks like the file was recently renamed. This PR simply updates the documentation to make the link go to the correct place again :)

### Type of change

* Documentation update

### How Has This Been Tested?

With a clickable, working link.
