### PR TITLE
Document how to run feature specs in headless mode or in the browser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ example:
   end
 ```
 
+##### Feature specs
+
+If you need to see a feature spec run in the browser, you can use the following env variable:
+
+```
+NOT_HEADLESS=true bundle exec rspec
+```
+
+Keep in mind that you need js to be enabled. For example:
+
+```
+describe "PickupSheet", type: :feature, js: true do
+```
+
 ### In-flight Pull Requests
 
 Sometimes we want to get a PR up there and going so that other people can review it or provide feedback, but maybe it's incomplete. This is OK, but if you do it, please tag your PR with `in-progress` label so that we know not to review / merge it.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,7 +47,9 @@ Capybara.ignore_hidden_elements = true
 
 # https://docs.travis-ci.com/user/chrome
 Capybara.register_driver :chrome do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu window-size=1680,1050])
+  args = %w[no-sandbox disable-gpu window-size=1680,1050]
+  args << "headless" unless ENV["NOT_HEADLESS"] == "true"
+  options = Selenium::WebDriver::Chrome::Options.new(args: args)
 
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end


### PR DESCRIPTION
Document how to run specs in the browser.

Same implementation as in partner for the sake of consistency.

https://github.com/rubyforgood/partner/pull/248