### PR TITLE
1325 Only show the donation edit select fields if they have a selected value.

### DIFF
--- a/app/assets/javascripts/donations.js.erb
+++ b/app/assets/javascripts/donations.js.erb
@@ -102,8 +102,9 @@ $(function() {
 
 function hide_fields_with_no_value(field_selectors){
   $.each( field_selectors, function(index, selector){
-      if($(selector + " select").prop('selectedIndex') == 0){
-        $(selector).hide();
-      }
+    let selected_value_text = $(selector + " select option").filter(":selected").text()
+    if(selected_value_text == "" || selected_value_text == "Choose one..." ){
+      $(selector).hide();
+    }
   });
 }

--- a/app/assets/javascripts/donations.js.erb
+++ b/app/assets/javascripts/donations.js.erb
@@ -15,12 +15,16 @@ $(function() {
   const manufacturer_text = "<%= Donation::SOURCES[:manufacturer] %>";
   const donation_site_text = "<%= Donation::SOURCES[:donation_site] %>";
 
-  $(diaper_drive_participant_container_id).hide();
-  $(manufacturer_container_id).hide();
-  $(donation_site_container_id).hide();
-
   const create_new_diaper_drive_text = "---Create new diaper drive---";
   const create_new_manufacturer_text = "---Create new Manufacturer---";
+
+  const fields_to_hide = [
+    diaper_drive_participant_container_id,
+    manufacturer_container_id,
+    donation_site_container_id
+  ]
+
+  hide_fields_with_no_value(fields_to_hide);
 
   $(diaper_drive_participant_id).append(
     `<option value="">${create_new_diaper_drive_text}</option>`
@@ -95,3 +99,11 @@ $(function() {
     })
   );
 });
+
+function hide_fields_with_no_value(field_selectors){
+  $.each( field_selectors, function(index, selector){
+      if($(selector + " select").prop('selectedIndex') == 0){
+        $(selector).hide();
+      }
+  });
+}


### PR DESCRIPTION
Resolves #1325 

### Description
This PR adds a JS function that will hide select fields on the donation edit page if they do not already have a value. It is only run at page load time. Only the participant, manufacturer, and donation site select fields are effected.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Using the seeded data.
Go to the edit page of a donation that has
1. no manufacturer
2. no participant
3. no donation site

The respective select fields should not show if they have no value.

diaper_bank/donations/40/edit - Has only a donation site
diaper_bank/donations/39/edit - Has only a manufacturer
diaper_bank/donations/27/edit - Has only a participant