### PR TITLE
Donation money raised currency form field

### DIFF
--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -62,6 +62,7 @@ class Donation < ApplicationRecord
                            if: :from_manufacturer?
   validates :source, presence: true, inclusion: { in: SOURCES.values,
                                                   message: "Must be a valid source." }
+  validates :money_raised, format: { with: /\A\d+(?:\.\d{0,2})?\z/ }, numericality: { greater_than: 0 }, allow_nil: true
 
   include IssuedAt
 

--- a/db/migrate/20191025230639_change_donation_money_raised_type_to_float.rb
+++ b/db/migrate/20191025230639_change_donation_money_raised_type_to_float.rb
@@ -1,5 +1,13 @@
 class ChangeDonationMoneyRaisedTypeToFloat < ActiveRecord::Migration[6.0]
   def change
-    change_column :donations, :money_raised, :float
+    reversible do |change|
+      change.up do
+        change_column :donations, :money_raised, :decimal, scale: 2
+      end
+
+      change.down do
+        change_column :donations, :money_raised, :integer
+      end
+    end
   end
 end

--- a/db/migrate/20191025230639_change_donation_money_raised_type_to_float.rb
+++ b/db/migrate/20191025230639_change_donation_money_raised_type_to_float.rb
@@ -1,0 +1,5 @@
+class ChangeDonationMoneyRaisedTypeToFloat < ActiveRecord::Migration[6.0]
+  def change
+    change_column :donations, :money_raised, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_20_165853) do
+ActiveRecord::Schema.define(version: 2019_10_25_230639) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -156,7 +156,7 @@ ActiveRecord::Schema.define(version: 2019_10_20_165853) do
     t.integer "organization_id"
     t.integer "diaper_drive_participant_id"
     t.datetime "issued_at"
-    t.integer "money_raised"
+    t.float "money_raised"
     t.bigint "manufacturer_id"
     t.bigint "diaper_drive_id"
     t.index ["diaper_drive_id"], name: "index_donations_on_diaper_drive_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,7 +95,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.string "partner_key"
   end
 
-  create_table "diaper_drive_participants", force: :cascade do |t|
+  create_table "diaper_drive_participants", id: :serial, force: :cascade do |t|
     t.string "contact_name"
     t.string "email"
     t.string "phone"
@@ -118,12 +118,12 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "distributions", force: :cascade do |t|
+  create_table "distributions", id: :serial, force: :cascade do |t|
     t.text "comment"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "storage_location_id"
-    t.bigint "partner_id"
+    t.integer "storage_location_id"
+    t.integer "partner_id"
     t.integer "organization_id"
     t.datetime "issued_at"
     t.string "agency_rep"
@@ -134,7 +134,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.index ["storage_location_id"], name: "index_distributions_on_storage_location_id"
   end
 
-  create_table "donation_sites", force: :cascade do |t|
+  create_table "donation_sites", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "address"
     t.datetime "created_at", null: false
@@ -146,12 +146,12 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.index ["organization_id"], name: "index_donation_sites_on_organization_id"
   end
 
-  create_table "donations", force: :cascade do |t|
+  create_table "donations", id: :serial, force: :cascade do |t|
     t.string "source"
-    t.bigint "donation_site_id"
+    t.integer "donation_site_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "storage_location_id"
+    t.integer "storage_location_id"
     t.text "comment"
     t.integer "organization_id"
     t.integer "diaper_drive_participant_id"
@@ -192,7 +192,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
-  create_table "inventory_items", force: :cascade do |t|
+  create_table "inventory_items", id: :serial, force: :cascade do |t|
     t.integer "storage_location_id"
     t.integer "item_id"
     t.integer "quantity", default: 0
@@ -200,7 +200,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "items", force: :cascade do |t|
+  create_table "items", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "category"
     t.datetime "created_at", null: false
@@ -218,7 +218,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.index ["partner_key"], name: "index_items_on_partner_key"
   end
 
-  create_table "line_items", force: :cascade do |t|
+  create_table "line_items", id: :serial, force: :cascade do |t|
     t.integer "quantity"
     t.integer "item_id"
     t.integer "itemizable_id"
@@ -236,7 +236,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.index ["organization_id"], name: "index_manufacturers_on_organization_id"
   end
 
-  create_table "organizations", force: :cascade do |t|
+  create_table "organizations", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "short_name"
     t.string "email"
@@ -257,7 +257,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.index ["short_name"], name: "index_organizations_on_short_name"
   end
 
-  create_table "partners", force: :cascade do |t|
+  create_table "partners", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.datetime "created_at", null: false
@@ -296,7 +296,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.index ["status"], name: "index_requests_on_status"
   end
 
-  create_table "storage_locations", force: :cascade do |t|
+  create_table "storage_locations", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "address"
     t.datetime "created_at", null: false
@@ -308,7 +308,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.index ["organization_id"], name: "index_storage_locations_on_organization_id"
   end
 
-  create_table "transfers", force: :cascade do |t|
+  create_table "transfers", id: :serial, force: :cascade do |t|
     t.integer "from_id"
     t.integer "to_id"
     t.string "comment"
@@ -318,7 +318,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.index ["organization_id"], name: "index_transfers_on_organization_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :serial, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -338,7 +338,7 @@ ActiveRecord::Schema.define(version: 2019_10_25_230639) do
     t.datetime "invitation_accepted_at"
     t.integer "invitation_limit"
     t.string "invited_by_type"
-    t.bigint "invited_by_id"
+    t.integer "invited_by_id"
     t.integer "invitations_count", default: 0
     t.boolean "organization_admin"
     t.string "name", default: "CHANGEME", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -239,13 +239,15 @@ end
                                 diaper_drive_participant: random_record_for_org(pdx_org, DiaperDriveParticipant),
                                 storage_location:         random_record_for_org(pdx_org, StorageLocation),
                                 organization:             pdx_org,
-                                issued_at:                Time.zone.now
+                                issued_at:                Time.zone.now,
+                                money_raised:             (rand * 100).round(2)
              when Donation::SOURCES[:donation_site]
                Donation.create! source:           source,
                                 donation_site:    random_record_for_org(pdx_org, DonationSite),
                                 storage_location: random_record_for_org(pdx_org, StorageLocation),
                                 organization:     pdx_org,
-                                issued_at:        Time.zone.now
+                                issued_at:        Time.zone.now,
+                                money_raised:     (rand * 100).round(2)
              when Donation::SOURCES[:manufacturer]
                Donation.create! source:           source,
                                 manufacturer:     random_record_for_org(pdx_org, Manufacturer),

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -61,6 +61,11 @@ RSpec.describe Donation, type: :model do
       d.money_raised = 1.12
       expect(d).to be_valid
     end
+    it "is valid when money raised is a whole number" do
+      d = build(:donation)
+      d.money_raised = 2
+      expect(d).to be_valid
+    end
   end
 
   context "Callbacks >" do

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -51,6 +51,16 @@ RSpec.describe Donation, type: :model do
       d.line_items << build(:line_item, quantity: nil)
       expect(d).not_to be_valid
     end
+    it "is invalid when money raised has more than 2 decimal places" do
+      d = build(:donation)
+      d.money_raised = 1.123
+      expect(d).not_to be_valid
+    end
+    it "is valid when money raised has not more than 2 decimal places" do
+      d = build(:donation)
+      d.money_raised = 1.12
+      expect(d).to be_valid
+    end
   end
 
   context "Callbacks >" do


### PR DESCRIPTION
Resolves #1352

### Description
I created the issue and this PR because I found that users are unable to enter decimal amounts for money_raised. I assume users will not always raise exact whole dollar amounts. Therefore, this PR changes donation.money_raised to a decimal. I have added a validation, database constraints, seed data, and a test. However, the validation messages seem to be broken. Invalid data seems to trigger a bug elsewhere in the code that I did not track down. I did not include a fix for this issue as it seemed outside the scope of this issue.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

1. Go to the donation edit page.
2. Enter a decimal amount up to 2 decimal places.
3. The data should save successfully. Use rails console to confirm.

Do the same test with more than 2 decimal places. It should fail to save.
