### PR TITLE
WIP: added modal to add users to partners

### DIFF
--- a/app/views/partners/_add_user_modal.html.erb
+++ b/app/views/partners/_add_user_modal.html.erb
@@ -1,0 +1,27 @@
+<div id="addUserModal_<%= partner.id%>" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">Invite a new user to <%= partner.name %> </h4>
+      </div>
+      <div class="modal-body">
+        <div class="box-body">
+          <%= form_tag do %>
+            <div class="input-group">
+              <span class="input-group-addon" id="spn_usr_fa_icon"><%= fa_icon "user" %></span>
+              <input type="text" name="name" class="form-control" placeholder="Name" aria-describedby="spn_usr_fa_icon">
+            </div>
+            <br>
+            <div class="input-group">
+              <span class="input-group-addon" id="spn_env_fa_icon"><%= fa_icon "envelope" %></span>
+              <input type="email" name="email" class="form-control" placeholder="Email" aria-describedby="spn_env_fa_icon">
+            </div>
+            <%= hidden_field_tag :partner , partner %><br>
+            <%= submit_button({ text: "Invite User", icon: "envelope" }) %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/partners/_partner_row.html.erb
+++ b/app/views/partners/_partner_row.html.erb
@@ -1,4 +1,5 @@
 <% status = partner_row.status%>
+<%= render partial: "add_user_modal", locals: { partner: partner_row } %>
 <tr>
   <td><%= link_to partner_row.name, partner_path(partner_row) %></td>
   <td><%= link_to partner_row.email, "mailto:#{partner_row.email}" %></td>
@@ -8,7 +9,6 @@
       <button class="btn btn-xs bg-teal">Uninvited</button>
     <% when "invited" %>
       <%= view_button_to "#", { text: "#{status.humanize}", icon: "check" } %>
-
     <% when "awaiting_review" %>
       <%= view_button_to "#", { text: "#{status.humanize}", icon: "check", type: "warning" } %>
     <% when "approved" %>
@@ -34,5 +34,8 @@
     <% else %>
       &nbsp;
     <% end %>
+  </td>
+  <td>
+    <%= modal_button_to("#addUserModal_#{partner_row.id}", { text: "Add User", icon: "plus", size: "xs" }) %>
   </td>
 </tr>

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe "Partner management", type: :system, js: true do
       expect(page.find(:xpath, "//table/tbody/tr[3]/td[4]")).to have_no_content('Invite')
     end
 
+    it "shows add user modal for partners" do
+      expect(page.find(:xpath, "//table/tbody/tr[1]/td[5]")).to have_content('Add User')
+      expect(page.find(:xpath, "//table/tbody/tr[2]/td[5]")).to have_content('Add User')
+      expect(page.find(:xpath, "//table/tbody/tr[3]/td[5]")).to have_content('Add User')
+      expect(page.find(:xpath, "//table/tbody/tr[4]/td[5]")).to have_content('Add User')
+    end
+
     context "when filtering" do
       it "allows the user to click on one of the statuses at the top to filter the results" do
         approved_count = Partner.approved.count


### PR DESCRIPTION
Resolves #1282 

### Description
Added a modal button for partner rows to add new users. Added WIP because wasn't really sure how to get it connected to the partner app but as far as ui standpoint it works.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
added test in spec for partner to see if the button appears

### Screenshots
![image](https://user-images.githubusercontent.com/54120546/67639847-4a4b2900-f8cb-11e9-97e4-bad2b30a0bdb.png)
![image](https://user-images.githubusercontent.com/54120546/67639848-4d461980-f8cb-11e9-9c1b-3934f5c046f5.png)


