### PR TITLE
Expand test coverage for line items

### DIFF
--- a/spec/models/line_item_spec.rb
+++ b/spec/models/line_item_spec.rb
@@ -12,6 +12,8 @@
 #
 
 RSpec.describe LineItem, type: :model do
+  let(:line_item) { build :line_item }
+
   context "Validations >" do
     it "requires an item" do
       expect(build(:line_item, item: nil)).not_to be_valid
@@ -58,6 +60,67 @@ RSpec.describe LineItem, type: :model do
 
       it "retrieves only those with active status" do
         expect(described_class.active.size).to eq(1)
+      end
+    end
+  end
+
+  describe 'Methods >' do
+    context '#value_per_line_item' do
+      subject { line_item.value_per_line_item }
+
+      describe 'item has no value' do
+        it { is_expected.to eq(0) }
+      end
+
+      describe 'item has value and quantity' do
+        let(:value) { 5 }
+        let(:quantity) { 5 }
+
+        before do
+          line_item.item = create(:item, value_in_cents: value)
+          line_item.quantity = quantity
+        end
+
+        it { is_expected.to eq(value * quantity) }
+      end
+    end
+
+    context 'item packages' do
+      let(:package_size) { 5 }
+      let(:quantity) { 5 }
+
+      context '#has_packages' do
+        subject { line_item.has_packages }
+
+        describe 'item has no package size' do
+          it { is_expected.to be_falsy }
+        end
+
+        describe 'item has package size' do
+          before do
+            line_item.item = create(:item, package_size: package_size)
+            line_item.quantity = quantity
+          end
+
+          it { is_expected.to be_truthy }
+        end
+      end
+
+      context '#package_count' do
+        subject { line_item.package_count }
+
+        describe 'has packages' do
+          before do
+            line_item.item = create(:item, package_size: package_size)
+            line_item.quantity = quantity
+          end
+
+          it { is_expected.to eq((quantity / package_size).to_s) }
+        end
+
+        describe 'does not have packages' do
+          it { is_expected.to be_falsy }
+        end
       end
     end
   end


### PR DESCRIPTION
# Checklist:

Ref [#1024](https://github.com/rubyforgood/diaper/issues/1024)

### Description

Added spec coverage for the line items class. I felt a little torn about this PR, because I wasn't sure how to write these specs without re-implementing the methods themselves. If this is unhelpful, feel free to close :) 

### Type of change

* additional spec coverage (non-breaking change)

### How Has This Been Tested?

locally and through CI

### Screenshots

Before
<img width="1102" alt="Screen Shot 2019-10-28 at 8 55 14 PM" src="https://user-images.githubusercontent.com/16630021/67728888-54515280-f9c5-11e9-8e09-69f467631549.png">

After
<img width="1168" alt="Screen Shot 2019-10-28 at 8 55 27 PM" src="https://user-images.githubusercontent.com/16630021/67728892-57e4d980-f9c5-11e9-9678-806832e17761.png">

