### PR TITLE
Expand spec coverage for user model

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -57,6 +57,20 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe "Scopes >" do
+    describe "->alphabetized" do
+      let!(:z_name_user) { create(:user, name: 'Zachary') }
+      let!(:a_name_user) { create(:user, name: 'Amanda') }
+
+      it "retrieves users in the correct order" do
+        alphabetized_list = described_class.alphabetized
+
+        expect(alphabetized_list.first).to eq(a_name_user)
+        expect(alphabetized_list.last).to eq(z_name_user)
+      end
+    end
+  end
+
   context "Methods >" do
     it "#most_recent_sign_in" do
       expect(build(:user, current_sign_in_at: Time.zone.parse("2018-10-23 00:00:00"), last_sign_in_at: Time.zone.parse("2018-10-20 00:00:00 UTC")).most_recent_sign_in).to eq("2018-10-23 00:00:00 UTC")


### PR DESCRIPTION
### Description

Ref EPIC [#1024](https://github.com/rubyforgood/diaper/issues/1024)

Completes the spec coverage for the user model. Warning: it looks like this test db automatically seeds default users with every spec run; that means that querying for all users in the spec will return more than the two explicitly created here. It also means that changing the seed file to include more users could potentially impact this spec :( if there's a different way I should do this, please let me know.

### Type of change

* spec coverage (non-breaking change)

### How Has This Been Tested?

Locally and through CI

### Screenshots

Spec Coverage Before:
<img width="1188" alt="Screen Shot 2019-10-28 at 9 17 11 PM" src="https://user-images.githubusercontent.com/16630021/67729833-08a0a800-f9c9-11e9-8baa-92827c9073b7.png">

Spec Coverage After: 
<img width="1174" alt="Screen Shot 2019-10-28 at 9 17 20 PM" src="https://user-images.githubusercontent.com/16630021/67729837-0f2f1f80-f9c9-11e9-892d-192d6cc663ac.png">

