### PR TITLE
Reformat some BarcodeItem code to aid the reader

### DIFF
--- a/app/models/barcode_item.rb
+++ b/app/models/barcode_item.rb
@@ -27,10 +27,20 @@ class BarcodeItem < ApplicationRecord
   default_scope { order("barcodeable_type DESC, created_at ASC") }
 
   scope :barcodeable_id, ->(barcodeable_id) { where(barcodeable_id: barcodeable_id) }
+
   # Because it's a polymorphic association, we have to do this join manually.
-  scope :by_item_partner_key, ->(partner_key) { joins("INNER JOIN items ON items.id = barcode_items.barcodeable_id").where(barcodeable_type: "Item", items: { partner_key: partner_key }) }
-  scope :by_base_item_partner_key, ->(partner_key) { joins("INNER JOIN base_items ON base_items.id = barcode_items.barcodeable_id").where(barcodeable_type: "BaseItem", base_items: { partner_key: partner_key }) }
+  scope :by_item_partner_key, ->(partner_key) do
+    joins("INNER JOIN items ON items.id = barcode_items.barcodeable_id") \
+      .where(barcodeable_type: "Item", items: { partner_key: partner_key })
+  end
+
+  scope :by_base_item_partner_key, ->(partner_key) do
+    joins("INNER JOIN base_items ON base_items.id = barcode_items.barcodeable_id") \
+      .where(barcodeable_type: "BaseItem", base_items: { partner_key: partner_key })
+  end
+
   scope :by_value, ->(value) { where(value: value) }
+
   scope :for_csv_export, ->(organization) {
     where(organization: organization)
       .includes(:barcodeable)
@@ -68,8 +78,8 @@ class BarcodeItem < ApplicationRecord
   private
 
   def unique_barcode_value
-    if (global? && BarcodeItem.where.not(id: id).find_by(value: value, barcodeable_type: "BaseItem")) ||
-       (!global? && BarcodeItem.where.not(id: id).find_by(value: value, organization: organization))
+    if (global?  && BarcodeItem.where.not(id: id).find_by(value: value, barcodeable_type: "BaseItem")) ||
+       (!global? && BarcodeItem.where.not(id: id).find_by(value: value, organization:     organization))
       errors.add(:value, "That barcode value already exists")
     end
   end


### PR DESCRIPTION
I was looking over the `BarcodeItem` class and noticed that much of my effort to understand it could be eliminated by a more strategic use of horizontal and vertical whitespace. This PR includes the changes I made that I think would be helpful.

I also wanted to left align the hash values in `to_h`, but Rubocop would not permit it.

RSpec and Rubocop tests are still successful after this change.
