### PR TITLE
1356 diaper drive filters

### DIFF
--- a/app/controllers/diaper_drives_controller.rb
+++ b/app/controllers/diaper_drives_controller.rb
@@ -6,8 +6,8 @@ class DiaperDrivesController < ApplicationController
   def index
     setup_date_range_picker
     @diaper_drives = DiaperDrive.class_filter(filter_params)
-    @diaper_drives = @diaper_drives.within_date_rage(@selected_date_range)
-    @diaper_drives = @diaper_drives.order(created_at: :desc)
+                      .within_date_rage(@selected_date_range)
+                      .order(created_at: :desc)
     @selected_name_filter = filter_params[:by_name]
   end
 

--- a/app/controllers/diaper_drives_controller.rb
+++ b/app/controllers/diaper_drives_controller.rb
@@ -6,8 +6,8 @@ class DiaperDrivesController < ApplicationController
   def index
     setup_date_range_picker
     @diaper_drives = DiaperDrive.class_filter(filter_params)
-                                .within_date_rage(date_range_filter)
-                                .order(created_at: :desc)
+    @diaper_drives = @diaper_drives.within_date_rage(@selected_date_range)
+    @diaper_drives = @diaper_drives.order(created_at: :desc)
     @selected_name_filter = filter_params[:by_name]
   end
 

--- a/app/controllers/diaper_drives_controller.rb
+++ b/app/controllers/diaper_drives_controller.rb
@@ -5,7 +5,10 @@ class DiaperDrivesController < ApplicationController
   # GET /diaper_drives.json
   def index
     setup_date_range_picker
-    @diaper_drives = DiaperDrive.all
+    @diaper_drives = DiaperDrive.class_filter(filter_params)
+                                .within_date_rage(date_range_filter)
+                                .order(created_at: :desc)
+    @selected_name_filter = filter_params[:by_name]
   end
 
   # GET /diaper_drives/1
@@ -70,5 +73,16 @@ class DiaperDrivesController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def diaper_drive_params
     params.require(:diaper_drive).permit(:name, :start_date, :end_date)
+  end
+
+  def date_range_filter
+    return '' unless params.key?(:filters)
+    params.require(:filters)[:date_range]
+  end
+
+  def filter_params
+    return {} unless params.key?(:filters)
+
+    params.require(:filters).slice(:by_name)
   end
 end

--- a/app/controllers/diaper_drives_controller.rb
+++ b/app/controllers/diaper_drives_controller.rb
@@ -77,6 +77,7 @@ class DiaperDrivesController < ApplicationController
 
   def date_range_filter
     return '' unless params.key?(:filters)
+
     params.require(:filters)[:date_range]
   end
 

--- a/app/controllers/diaper_drives_controller.rb
+++ b/app/controllers/diaper_drives_controller.rb
@@ -4,6 +4,7 @@ class DiaperDrivesController < ApplicationController
   # GET /diaper_drives
   # GET /diaper_drives.json
   def index
+    setup_date_range_picker
     @diaper_drives = DiaperDrive.all
   end
 

--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -11,9 +11,27 @@
 #
 
 class DiaperDrive < ApplicationRecord
+  include Filterable
+
+  scope :by_name, -> (name_filter) { where(name: name_filter) }
+
+  scope :within_date_rage, -> (search_range) {
+    search_dates = search_date_range(search_range)
+    where('end_date >= ? AND start_date <= ?', search_dates[:start_date], search_dates[:end_date])
+  }
+
+
   has_many :donations, dependent: :nullify
   validates :name, presence:
     { message: "A name must be chosen." }
   validates :start_date, presence:
     { message: "Please enter a start date." }
+
+
+  private
+
+  def self.search_date_range(dates)
+    dates = dates.split(" - ")
+    @search_date_range = {start_date: dates[0], end_date: dates[1]}
+  end
 end

--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -13,13 +13,12 @@
 class DiaperDrive < ApplicationRecord
   include Filterable
 
-  scope :by_name, -> (name_filter) { where(name: name_filter) }
+  scope :by_name, ->(name_filter) { where(name: name_filter) }
 
-  scope :within_date_rage, -> (search_range) {
+  scope :within_date_rage, ->(search_range) {
     search_dates = search_date_range(search_range)
     where('end_date >= ? AND start_date <= ?', search_dates[:start_date], search_dates[:end_date])
   }
-
 
   has_many :donations, dependent: :nullify
   validates :name, presence:
@@ -27,11 +26,8 @@ class DiaperDrive < ApplicationRecord
   validates :start_date, presence:
     { message: "Please enter a start date." }
 
-
-  private
-
   def self.search_date_range(dates)
     dates = dates.split(" - ")
-    @search_date_range = {start_date: dates[0], end_date: dates[1]}
+    @search_date_range = { start_date: dates[0], end_date: dates[1] }
   end
 end

--- a/app/views/diaper_drives/index.html.erb
+++ b/app/views/diaper_drives/index.html.erb
@@ -10,7 +10,7 @@
         <div class="row">
           <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
             <%= label_tag "by name" %>
-            <%= collection_select(:filters, :name, @diaper_drives || {}, :id, :name, { include_blank: true }, class: "form-control") %>
+            <%= collection_select(:filters, :by_name, @diaper_drives || {}, :name, :name, { include_blank: true, selected: @selected_name_filter }, class: "form-control") %>
           </div>
           <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
             <%= label_tag "Date Range" %>

--- a/app/views/diaper_drives/index.html.erb
+++ b/app/views/diaper_drives/index.html.erb
@@ -30,32 +30,38 @@
         <% end %>
       </section>
     </div>
+    <div class="box-body">
+      <div class="row">
+        <div class="col-xs-12">
+          <div class="box-body table-responsive no-padding">
+            <table class="table table-hover striped records">
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Start date</th>
+                <th>End date</th>
+                <th colspan="3"></th>
+              </tr>
+            </thead>
+
+            <tbody>
+              <% @diaper_drives.each do |diaper_drive| %>
+                <tr>
+                  <td><%= diaper_drive.name %></td>
+                  <td><%= diaper_drive.start_date %></td>
+                  <td><%= diaper_drive.end_date %></td>
+                  <td><%= link_to 'Show', diaper_drive %></td>
+                  <td><%= link_to 'Edit', edit_diaper_drive_path(diaper_drive) %></td>
+                  <td><%= link_to 'Destroy', diaper_drive, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
   </div>
 </section>
-
-<table>
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Start date</th>
-      <th>End date</th>
-      <th colspan="3"></th>
-    </tr>
-  </thead>
-
-  <tbody>
-    <% @diaper_drives.each do |diaper_drive| %>
-      <tr>
-        <td><%= diaper_drive.name %></td>
-        <td><%= diaper_drive.start_date %></td>
-        <td><%= diaper_drive.end_date %></td>
-        <td><%= link_to 'Show', diaper_drive %></td>
-        <td><%= link_to 'Edit', edit_diaper_drive_path(diaper_drive) %></td>
-        <td><%= link_to 'Destroy', diaper_drive, method: :delete, data: { confirm: 'Are you sure?' } %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
 
 <br>
 

--- a/app/views/diaper_drives/index.html.erb
+++ b/app/views/diaper_drives/index.html.erb
@@ -2,6 +2,37 @@
 
 <h1>Diaper Drives</h1>
 
+<section class="content">
+  <div class="box">
+    <div class="box-header with-border bg-gray">
+      <section id="filters">
+        <%= form_tag(diaper_drives_path, method: :get, organization_id: @organization.id) do |f| %>
+        <div class="row">
+          <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
+            <%= label_tag "by name" %>
+            <%= collection_select(:filters, :name, @diaper_drives || {}, :id, :name, { include_blank: true }, class: "form-control") %>
+          </div>
+          <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
+            <%= label_tag "Date Range" %>
+            <%= render partial: "shared/date_range_picker", locals: { css_class: "form-control" } %>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-xs-12">
+            <%= filter_button %>
+            <%= cancel_button_to donations_path, { text: "Clear Filters" } %>
+
+            <div class="pull-right">
+              <%= new_button_to new_diaper_drive_path(organization_id: current_organization), { text: "New Diaper Drive" } %>
+            </div>
+          </div>
+        </div>
+        <% end %>
+      </section>
+    </div>
+  </div>
+</section>
+
 <table>
   <thead>
     <tr>

--- a/app/views/diaper_drives/index.html.erb
+++ b/app/views/diaper_drives/index.html.erb
@@ -62,7 +62,3 @@
     </div>
   </div>
 </section>
-
-<br>
-
-<%= link_to 'New Diaper drive', new_diaper_drive_path %>

--- a/app/views/diaper_drives/index.html.erb
+++ b/app/views/diaper_drives/index.html.erb
@@ -20,7 +20,7 @@
         <div class="row">
           <div class="col-xs-12">
             <%= filter_button %>
-            <%= cancel_button_to donations_path, { text: "Clear Filters" } %>
+            <%= cancel_button_to diaper_drives_path, { text: "Clear Filters" } %>
 
             <div class="pull-right">
               <%= new_button_to new_diaper_drive_path(organization_id: current_organization), { text: "New Diaper Drive" } %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -161,6 +161,10 @@ end
 # ----------------------------------------------------------------------------
 
 [
+  { name:        "First Diaper Drive",
+    start_date:  3.years.ago,
+    end_date:    3.years.ago
+  },
   { name:        "Best Diaper Drive",
     start_date:  3.weeks.ago,
     end_date:    2.week.ago

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -156,6 +156,21 @@ end
     organization:  pdx_org }
 ].each { |participant| DiaperDriveParticipant.create! participant }
 
+# ----------------------------------------------------------------------------
+# Diaper Drives
+# ----------------------------------------------------------------------------
+
+[
+  { name:        "Best Diaper Drive",
+    start_date:  3.weeks.ago,
+    end_date:    2.week.ago
+  },
+  { name:        "Second Best Diaper Drive",
+    start_date:  2.weeks.ago,
+    end_date:    1.week.ago
+  }
+].each { |diaper_drive| DiaperDrive.find_or_create_by! diaper_drive }
+
 
 # ----------------------------------------------------------------------------
 # Manufacturers

--- a/spec/system/diaper_drive_system_spec.rb
+++ b/spec/system/diaper_drive_system_spec.rb
@@ -1,11 +1,32 @@
 RSpec.describe "Diaper Drives", type: :system, js: true do
+  include DateRangeHelper
+
   before do
     sign_in @user
-    @url_prefix = "/#{@organization.short_name}"
+    @url_prefix = "/#{@organization.id}"
   end
-  context "When visiting the index page" do
+
+  context "When visiting the index page without parameters" do
+    subject { @url_prefix + "/diaper_drives" }
+
     before(:each) do
-      create(:diaper_drive)
+      @diaper_drives = [
+        create(:diaper_drive, name: "Test name 1", start_date: 3.weeks.ago, end_date: 2.weeks.ago),
+        create(:diaper_drive, name: "Test name 2", start_date: 2.weeks.ago, end_date: 1.weeks.ago)
+      ]
+      visit subject
+    end
+
+    it "Shows the expected filters with the expected values" do
+      expect(page.has_select?('filters_by_name', with_options: @diaper_drives.map(&:name))).to be true
+      expect(page.has_field?('filters_date_range', with: this_year))
+    end
+
+    it "shows the expected diaper drives" do
+      @diaper_drives.each do |d|
+        expect(page).to have_xpath('//table/tbody/tr/td', text: d.name)
+        expect(page).to have_xpath('//table/tbody/tr/td', text: d.name)
+      end
     end
   end
 end

--- a/spec/system/diaper_drive_system_spec.rb
+++ b/spec/system/diaper_drive_system_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Diaper Drives", type: :system, js: true do
     before(:each) do
       @diaper_drives = [
         create(:diaper_drive, name: "Test name 1", start_date: 3.weeks.ago, end_date: 2.weeks.ago),
-        create(:diaper_drive, name: "Test name 2", start_date: 2.weeks.ago, end_date: 1.weeks.ago)
+        create(:diaper_drive, name: "Test name 2", start_date: 2.weeks.ago, end_date: 1.week.ago)
       ]
       visit subject
     end


### PR DESCRIPTION
Resolves #1356 

### Description
This PR adds the name a date filters for the new diaper drives index page.
The date rage picker is intended to make it easy for the user to find a diaper drive. If they had to put in the exact start or end date, that might be tedious. Using the existing date range picker means that the user only has to know roughly when it happened. And diaper drive that is overlapped (even partially) by the selected date range will be returned.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Using seed data

1. Go to /1/diaper_drives You should see the three seeded diaper drives.
2. Select on of the names and click filter. You should see only that diaper drive.
3. Select a date range of this year. You should see only the two diaper drives that happened this year according to their start and end dates.
4. Click the clear filters button. The filters should be cleared.
5. Click the new diaper drive button. It should take you to the new diaper drive form page (not a finished page. Out of scope for this PR).
