### PR TITLE
Refine barcode item test for more error information.

### DIFF
--- a/spec/models/barcode_item_spec.rb
+++ b/spec/models/barcode_item_spec.rb
@@ -136,8 +136,7 @@ RSpec.describe BarcodeItem, type: :model do
         barcode_item
         create(:barcode_item, organization: create(:organization))
         results = BarcodeItem.for_csv_export(barcode_item.organization)
-        expect(results.length).to eq(1)
-        expect(results.first).to eq(barcode_item)
+        expect(results).to eq([barcode_item])
       end
 
       it "#by_item_partner_key returns barcodes that match the partner key" do

--- a/spec/models/barcode_item_spec.rb
+++ b/spec/models/barcode_item_spec.rb
@@ -127,8 +127,7 @@ RSpec.describe BarcodeItem, type: :model do
         barcode_item
         create(:barcode_item)
         results = BarcodeItem.barcodeable_id(item.id)
-        expect(results.length).to eq(1)
-        expect(results.first).to eq(barcode_item)
+        expect(results).to eq([barcode_item])
       end
     end
 


### PR DESCRIPTION
We seem to be getting intermittent errors like this:

```
1) BarcodeItem Barcodes of BaseItems ('Global') filters > ->barcodeable_id shows only barcodes for a specific barcodeable_id
     Failure/Error: expect(results.length).to eq(1)
       expected: 1
            got: 2
       (compared using ==)
     # ./spec/models/barcode_item_spec.rb:61:in `block (4 levels) in <top (required)>'
```

It would be helpful to have the test output the content of the array so we can see the elements that differ and not just the different length. We can accomplish this, and also combine two tests into one, by using this test:

```
expect(results).to eq([barcode_item])
```

This PR does that, so that the next time this error occurs, we would see the array content.
