### PR TITLE
Validate that "From" and "To" transfer storage locations are different && test

### DIFF
--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -49,6 +49,20 @@ RSpec.describe TransfersController, type: :controller do
         expect(response).to render_template("new")
         expect(response).to have_error(/error/i)
       end
+
+      it "renders to #new when from_id and to_id match" do
+        sl = create(:storage_location, organization: @organization)
+        attributes = attributes_for(
+          :transfer,
+          organization_id: @organization.id,
+          to_id: sl.id,
+          from_id: sl.id
+        )
+        post :create, params: { organization_id: @organization.id, transfer: attributes }
+        expect(response).to be_successful # Will render :new
+        expect(response).to render_template("new")
+        expect(response).to have_error(/error/i)
+      end
     end
 
     describe "GET #new" do


### PR DESCRIPTION
Resolves #1347

### Description
Validates that From and To storage locations are different for a transfer.

I was _not_ able to replicate the other issue in #1347, which was a new storage location not showing up in the To dropdown. I created one and it showed up in both.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Added additional controller test to verify redirect to New with error if storage locations are same.

### Screenshots
![Screen Shot 2019-11-01 at 11 12 26 AM](https://user-images.githubusercontent.com/43351221/68034699-90700600-fc98-11e9-9620-ae4fd46fb15b.png)