### PR TITLE
fix link of the organization at Recently Added Organizations

### DIFF
--- a/app/views/admin/dashboard.html.erb
+++ b/app/views/admin/dashboard.html.erb
@@ -114,7 +114,7 @@
             <li>
               <%#= image_tag(org&.logo)
               %>
-              <%= link_to org.name, admin_organization_path(org), class: "users-list-name" %>
+              <%= link_to org.name, admin_organization_path(org.id), class: "users-list-name" %>
               <span class="users-list-date"><%= time_ago_in_words(org.created_at) %></span>
             </li>
             <% end %>


### PR DESCRIPTION
Resolves #1367  <!--fill issue number-->

### Description

```
I believe that at /admin/dashboard? in Recently Added Organizations the organiztions would must redirect to your page, right?
Now when the user clicks on organization link he is redirect to 404 page.
```
### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
Where user click
![Screenshot_20191101_153618](https://user-images.githubusercontent.com/20587352/68050317-a47d2d00-fcc3-11e9-9426-649ab0ee1834.png)

what happened
![antes_diaper](https://user-images.githubusercontent.com/20587352/68050294-96c7a780-fcc3-11e9-8979-2d1940627142.png)

what happen now
![agora_diaper](https://user-images.githubusercontent.com/20587352/68050299-992a0180-fcc3-11e9-8546-6e6057874bd9.png)


