### PR TITLE
Unpend date range specs

### DIFF
--- a/app/helpers/date_range_helper.rb
+++ b/app/helpers/date_range_helper.rb
@@ -31,7 +31,7 @@ module DateRangeHelper
 
   def selected_range
     start_date, end_date = selected_interval
-    start_date..end_date
+    (start_date.beginning_of_day)..(end_date.end_of_day)
   end
 
   def selected_range_described

--- a/app/javascript/packs/sinon.js
+++ b/app/javascript/packs/sinon.js
@@ -1,0 +1,3 @@
+  // Sinon is used to fake the browser's time when used with Timecop
+  import sinon from "sinon/pkg/sinon"
+  window.sinon = sinon

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,12 +44,8 @@ class User < ApplicationRecord
 
   scope :alphabetized, -> { order(:name) }
 
-  def most_recent_sign_in
-    [current_sign_in_at.to_s, last_sign_in_at.to_s].max
-  end
-
   def invitation_status
-    return "joined" if most_recent_sign_in.present?
+    return "joined" if current_sign_in_at.present?
     return "accepted" if invitation_accepted_at.present?
     return "invited" if invitation_sent_at.present?
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,14 @@
   <%= javascript_include_tag 'application' %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <%= javascript_pack_tag 'application' %>
+
+  <% # This allows Timecop to control the Capybara browser's simulated time %>
+  <% if defined?(Timecop) && Timecop.top_stack_item %>
+    <%= javascript_pack_tag 'sinon' %>
+    <script>
+      window.sinon.useFakeTimers(<%= (Time.now.to_f * 1000.0).to_i %>);
+    </script>
+  <% end %>
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">

--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -2,7 +2,7 @@
   <td><%= user.name %></td>
   <td><%= user.email %></td>
   <td><%= user.kind %> </td>
-  <td><%= user.most_recent_sign_in %></td>
+  <td><%= user.current_sign_in_at %></td>
   <td><%= user.invitation_status %></td>
   <td><%= reinvite_user_link(user) %></td>
   <td><%= edit_button_to promote_to_org_admin_organization_path(user_id: user.id),

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,4 +44,9 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Tell Rails to use the system default timezone. This avoids issues where Timecop
+  # freezes to UTC and the fake browser is running under a local timezone
+  config.time_zone = 'America/Los_Angeles'
+  ENV['TZ'] = 'America/Los_Angeles' # Make Capybara aware of the current time zone
 end

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -2,4 +2,11 @@ process.env.NODE_ENV = process.env.NODE_ENV || 'development'
 
 const environment = require('./environment')
 
+// Workaround Sinon+Webpack issues as documented at https://gist.github.com/rrgayhart/cf5dcefdf3975598f491
+const sinonLoader = {
+  test: /sinon\.js$/, loader: "imports-loader?define=>false,require=>false"
+}
+
+environment.loaders.append('sinon', sinonLoader)
+
 module.exports = environment.toWebpackConfig()

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "webpack-cli": "^3.3.7"
   },
   "devDependencies": {
-    "webpack-dev-server": "^3.8.0"
+    "webpack-dev-server": "^3.8.0",
+    "imports-loader": "^0.8.0",
+    "sinon": "^7.5.0"
   }
 }

--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -16,7 +16,9 @@ RSpec.describe TransfersController, type: :controller do
 
         context 'when date parameters are supplied' do
           it 'only returns the correct obejects' do
-            get :index, params: { organization_id: @organization.short_name, dates: { date_from: 3.days.ago, date_to: Time.zone.today } }
+            start_date = 3.days.ago.strftime "%m/%d/%Y"
+            end_date = Time.zone.today.strftime "%m/%d/%Y"
+            get :index, params: { organization_id: @organization.short_name, filters: { date_range: "#{start_date} - #{end_date}" } }
             expect(assigns(:transfers)).to eq([new_transfer])
           end
         end

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -87,8 +87,12 @@ RSpec.describe Distribution, type: :model do
     it "initializes the issued_at field to default to created_at if it wasn't explicitly set" do
       yesterday = 1.day.ago
       today = Time.zone.today
-      expect(create(:distribution, created_at: yesterday, issued_at: today).issued_at).to eq(today)
-      expect(create(:distribution, created_at: yesterday).issued_at).to eq(yesterday)
+
+      distribution = create(:distribution, created_at: yesterday, issued_at: today)
+      expect(distribution.issued_at.to_date).to eq(today)
+
+      distribution = create(:distribution, created_at: yesterday)
+      expect(distribution.issued_at).to eq(distribution.created_at)
     end
   end
 
@@ -100,12 +104,12 @@ RSpec.describe Distribution, type: :model do
     describe "#distributed_at" do
       it "displays explicit issued_at date" do
         two_days_ago = 2.days.ago.midnight
-        distribution.issued_at = Time.zone.parse("2014-03-01 14:30:00 UTC")
+        distribution.issued_at = Time.zone.parse("2014-03-01 14:30:00")
         expect(create(:distribution, issued_at: two_days_ago).distributed_at).to eq(two_days_ago.to_s(:distribution_date))
       end
 
       it "shows the hour and minutes if it has been provided" do
-        distribution.issued_at = Time.zone.parse("2014-03-01 14:30:00 UTC")
+        distribution.issued_at = Time.zone.parse("2014-03-01 14:30:00")
         expect(distribution.distributed_at).to eq("March 1 2014 2:30pm")
       end
     end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -57,8 +57,12 @@ RSpec.describe Donation, type: :model do
     it "inititalizes the issued_at field to default to created_at if it wasn't explicitly set" do
       yesterday = 1.day.ago
       today = Time.zone.today
-      expect(create(:donation, created_at: yesterday, issued_at: today).issued_at).to eq(today)
-      expect(create(:donation, created_at: yesterday).issued_at).to eq(yesterday)
+
+      donation = create(:donation, created_at: yesterday, issued_at: today)
+      expect(donation.issued_at.to_date).to eq(today)
+
+      donation = create(:donation, created_at: yesterday)
+      expect(donation.issued_at).to eq(donation.created_at)
     end
 
     it "automatically combines duplicate line_item records when they're created" do

--- a/spec/models/purchase_spec.rb
+++ b/spec/models/purchase_spec.rb
@@ -35,8 +35,12 @@ RSpec.describe Purchase, type: :model do
     it "inititalizes the issued_at field to default to created_at if it wasn't explicitly set" do
       yesterday = 1.day.ago
       today = Time.zone.today
-      expect(create(:purchase, created_at: yesterday, issued_at: today).issued_at).to eq(today)
-      expect(create(:purchase, created_at: yesterday).issued_at).to eq(yesterday)
+
+      purchase = create(:purchase, created_at: yesterday, issued_at: today)
+      expect(purchase.issued_at.to_date).to eq(today)
+
+      purchase = create(:purchase, created_at: yesterday)
+      expect(purchase.issued_at).to eq(purchase.created_at)
     end
 
     it "automatically combines duplicate line_item records when they're created" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe User, type: :model do
       expect(build(:user).kind).to eq("normal")
     end
 
-    it "#reinvatable?" do
+    it "#reinvitable?" do
       expect(build(:user, invitation_sent_at: Time.current - 7.days).reinvitable?).to be true
       expect(build(:user, invitation_sent_at: Time.current - 6.days).reinvitable?).to be false
       expect(build(:user, invitation_sent_at: Time.current - 7.days, invitation_accepted_at: Time.current - 7.days).reinvitable?).to be false

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,12 +58,6 @@ RSpec.describe User, type: :model do
   end
 
   context "Methods >" do
-    it "#most_recent_sign_in" do
-      expect(build(:user, current_sign_in_at: Time.zone.parse("2018-10-23 00:00:00"), last_sign_in_at: Time.zone.parse("2018-10-20 00:00:00 UTC")).most_recent_sign_in).to eq("2018-10-23 00:00:00 UTC")
-      expect(build(:user, current_sign_in_at: Time.zone.parse("2018-10-24 00:00:00"), last_sign_in_at: nil).most_recent_sign_in).to eq("2018-10-24 00:00:00 UTC")
-      expect(build(:user).most_recent_sign_in).to eq("")
-    end
-
     it "#invitation_status" do
       expect(build(:user, invitation_sent_at: Time.zone.parse("2018-10-10 00:00:00")).invitation_status).to eq("invited")
       expect(build(:user, invitation_sent_at: Time.zone.parse("2018-10-10 00:00:00"), invitation_accepted_at: Time.zone.parse("2018-10-11 00:00:00")).invitation_status).to eq("accepted")

--- a/spec/support/date_range_picker_shared_example.rb
+++ b/spec/support/date_range_picker_shared_example.rb
@@ -13,6 +13,9 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
   before :each do
     date_field ||= "created_at"
     travel_to 1.month.ago.end_of_month
+    # In case the described class/parent spec has already created instances in a `before` block
+    # I'm looking at you, spec/system/request_system_spec.rb:4
+    described_class.destroy_all
   end
 
   after do

--- a/spec/support/date_range_picker_shared_example.rb
+++ b/spec/support/date_range_picker_shared_example.rb
@@ -47,16 +47,9 @@ RSpec.shared_examples_for "Date Range Picker" do |described_class, date_field|
   context "when choosing a date range that only includes the previous week" do
     it "shows only 1 record" do
       visit subject
-      page.find("#filters_date_range").click
-      within ".ranges" do
-        page.find('li[data-range-key="Custom Range"]').click
-      end
-      within ".drp-calendar.left .calendar-table", match: :first do
-        8.times { page.find('th.next span').click }
-        page.find('td', text: '11', match: :first, exact_text: true).click
-        page.all('td', text: '27').last.click
-      end
-      click_on "Filter"
+      date_range = "#{1.week.ago.beginning_of_week.strftime("%m/%d/%Y")} - #{1.week.ago.end_of_week.strftime("%m/%d/%Y")}"
+      fill_in "filters_date_range", with: date_range
+      find(:id, 'filters_date_range').native.send_keys(:enter)
       expect(page).to have_css("table.records tbody tr", count: 1)
     end
   end

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -546,7 +546,7 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
             it "has a widget displaying the Diaper drive totals from yesterday, only using donations from yesterday" do
               within "#diaper_drives" do
-                expect(page).to have_content(/2 diaper drive/i)
+                expect(page).to have_content(/1 diaper drive participant/i)
                 expect(page).to have_content(total_inventory)
               end
             end

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -897,7 +897,6 @@ RSpec.describe "Dashboard", type: :system, js: true do
         end
 
         context "When Date Filtering >" do
-
           context "with year-to-date selected" do
             before do
               date_range_picker_select_range "This Year"

--- a/spec/system/dashboard_system_spec.rb
+++ b/spec/system/dashboard_system_spec.rb
@@ -149,7 +149,6 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "when constrained to date range" do
           before do
-            skip "FIXME: These are currently failing but they work when done manually. Marking pending so we can get this feature out at NBDN"
             @organization.donations.destroy_all
 
             @this_years_donations = {
@@ -323,7 +322,6 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "when constrained to date range" do
           before do
-            skip "FIXME: These are currently failing but they work when done manually. Marking pending so we can get this feature out at NBDN"
             @organization.purchases.destroy_all
             storage_location = create(:storage_location, :with_items, item_quantity: 0, organization: @organization)
             @this_years_purchases = {
@@ -478,7 +476,6 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "when constrained to date range" do
           before do
-            skip "FIXME: These are currently failing but they work when done manually. Marking pending so we can get this feature out at NBDN"
             @organization.donations.destroy_all
             storage_location = create(:storage_location, :with_items, item_quantity: 0, organization: @organization)
             diaper_drive1 = create(:diaper_drive_participant, business_name: "First Diaper Drive", organization: @organization)
@@ -683,7 +680,6 @@ RSpec.describe "Dashboard", type: :system, js: true do
 
         context "when constrained to date range" do
           before do
-            skip "FIXME: These are currently failing but they work when done manually. Marking pending so we can get this feature out at NBDN"
             @organization.donations.destroy_all
             storage_location = create(:storage_location, :with_items, item_quantity: 0, organization: @organization)
             manufacturer1 = create(:manufacturer, name: "ABC Corp", organization: @organization)
@@ -901,9 +897,6 @@ RSpec.describe "Dashboard", type: :system, js: true do
         end
 
         context "When Date Filtering >" do
-          before do
-            skip "FIXME: These are currently failing but they work when done manually. Marking pending so we can get this feature out at NBDN"
-          end
 
           context "with year-to-date selected" do
             before do

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "Donations", type: :system, js: true do
             click_button "Save"
           end.to change { Donation.count }.by(1)
 
-          expect(Donation.last.issued_at).to eq("01/01/2001")
+          expect(Donation.last.issued_at).to eq(Time.zone.parse("2001-01-01"))
         end
 
         it "Accepts and combines multiple line items for the same item type" do

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe "Purchases", type: :system, js: true do
           click_button "Save"
         end.to change { Purchase.count }.by(1)
 
-        expect(Purchase.last.issued_at).to eq(Date.parse("01/01/2001"))
+        expect(Purchase.last.issued_at).to eq(Time.zone.parse("2001-01-01"))
       end
 
       it "Does not include inactive items in the line item fields" do

--- a/yarn.lock
+++ b/yarn.lock
@@ -724,6 +724,35 @@
     webpack-cli "^3.3.2"
     webpack-sources "^1.3.0"
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.4.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.6.0.tgz#ec7670432ae9c8eb710400d112c201a362d83393"
+  integrity sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/formatio@^3.2.1":
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-3.2.2.tgz#771c60dfa75ea7f2d68e3b94c7e888a78781372c"
+  integrity sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^3.1.0"
+
+"@sinonjs/samsam@^3.1.0", "@sinonjs/samsam@^3.3.3":
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-3.3.3.tgz#46682efd9967b259b81136b9f120fd54585feb4a"
+  integrity sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==
+  dependencies:
+    "@sinonjs/commons" "^1.3.0"
+    array-from "^2.1.1"
+    lodash "^4.17.15"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@types/events@*":
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
@@ -1080,6 +1109,11 @@ array-flatten@^2.1.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
+
+array-from@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/array-from/-/array-from-2.1.1.tgz#cfe9d8c26628b9dc5aecc62a9f5d8f1f352c1195"
+  integrity sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=
 
 array-union@^1.0.1:
   version "1.0.2"
@@ -2930,6 +2964,11 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
   integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
 
+diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+  integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
 diffie-hellman@^5.0.0:
   version "5.0.3"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.3.tgz#40e8ee98f55a2149607146921c63e1ae5f3d2875"
@@ -4009,6 +4048,14 @@ import-local@2.0.0, import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
+imports-loader@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/imports-loader/-/imports-loader-0.8.0.tgz#030ea51b8ca05977c40a3abfd9b4088fe0be9a69"
+  integrity sha512-kXWL7Scp8KQ4552ZcdVTeaQCZSLW+e6nJfp3cwUMB673T7Hr98Xjx5JK+ql7ADlJUvj1JS5O01RLbKoutN5QDQ==
+  dependencies:
+    loader-utils "^1.0.2"
+    source-map "^0.6.1"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -4414,6 +4461,11 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -4542,6 +4594,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+just-extend@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
+  integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
 
 killable@^1.0.1:
   version "1.0.1"
@@ -4681,6 +4738,11 @@ loglevel@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.3.tgz#77f2eb64be55a404c9fd04ad16d57c1d6d6b1280"
   integrity sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==
+
+lolex@^4.1.0, lolex@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-4.2.0.tgz#ddbd7f6213ca1ea5826901ab1222b65d714b3cd7"
+  integrity sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -5081,6 +5143,17 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+
+nise@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.5.2.tgz#b6d29af10e48b321b307e10e065199338eeb2652"
+  integrity sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==
+  dependencies:
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    lolex "^4.1.0"
+    path-to-regexp "^1.7.0"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -5620,6 +5693,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
+  integrity sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -7067,6 +7147,19 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+sinon@^7.5.0:
+  version "7.5.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-7.5.0.tgz#e9488ea466070ea908fd44a3d6478fd4923c67ec"
+  integrity sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==
+  dependencies:
+    "@sinonjs/commons" "^1.4.0"
+    "@sinonjs/formatio" "^3.2.1"
+    "@sinonjs/samsam" "^3.3.3"
+    diff "^3.5.0"
+    lolex "^4.2.0"
+    nise "^1.5.2"
+    supports-color "^5.5.0"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -7446,7 +7539,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -7649,6 +7742,11 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-detect@4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-is@~1.6.17, type-is@~1.6.18:
   version "1.6.18"


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

This PR removes the "pending" exclusion from 4 places (approximately 58 pended examples), all of which are related to date range filters.

In the process of unpending these specs, a legitimate bug was found: if a date range was selected by the user where the start date and end date were the same, then zero results would be returned. This is because the dates were not time-sensitive. Thus for the given date range of `start_date: "1/1/1990", end_date: "1/1/1990"` would result in a query of `start_date: "1990-01-01 00:00:00, end_date: "1990-01-01 00:00:00"`. This is a zero-width range of time. The user almost certainly meant to find all records created on that date between midnight and 11:59:59pm. This PR also addresses this bug, so now the date range would convert to `start_date: "1990-01-01 00:00:00, end_date: "1990-01-01 23:59:59"`

The primary reason these specs were failing in the first place was because Rails and the browser inside of Capybara disagreed on the current date. Rails uses Timecop to move the "current" date around to make the specs reliable, regardless of the actual current date. Unfortunately, Capybara knows nothing about this, so when the UI tests would run, the date filter would jump to dates that are the *actual* current time. The fix was to add [Sinon](https://sinonjs.org/) to the Capybara browser, and have Timecop feed the simulated "current" time to Sinon in the Capybara browser. Now they both have a consistent view of "now". Care was taken to ensure that Sinon is only present in `test` mode, not in development or production.

In the process of fixing this bug, we found that the `User#most_recent_sign_in` method was difficult to test because of its reliance on strings instead of date objects. Since it was only used in one place in the UI, we removed that method entirely. The behavior was irrelevant anyway, since Devise always keeps the most recent sign in datestamp in the `current_sign_in_at` attribute.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix

### How Has This Been Tested?

Tested in the UI manually, and the test suite has been run locally. Almost all of the code changes are in spec files. The only functional change is in the date range helper, which simply adds `beginning_of_day` and `end_of_day` to the date objects.

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
