### PR TITLE
Switch to Mini Racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "simple_form"
 gem "skylight"
 gem "sprockets", "~> 3.7.2"
 gem "uglifier", ">= 1.3.0"
-gem "therubyracer", "~> 0.12", platforms: :ruby
+gem "mini_racer", "~> 0.2.8"
 gem "yajl-ruby"
 gem "toastr-rails"
 gem "webpacker", "> 4.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ GEM
     kaminari-core (1.1.1)
     launchy (2.4.3)
       addressable (~> 2.3)
-    libv8 (3.16.14.19)
+    libv8 (7.3.492.27.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -252,6 +252,8 @@ GEM
     mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
+    mini_racer (0.2.8)
+      libv8 (>= 6.9.411)
     minitest (5.12.2)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
@@ -350,7 +352,6 @@ GEM
       ffi (~> 1.0)
     rb-readline (0.5.5)
     redis (4.1.0)
-    ref (2.0.0)
     regexp_parser (1.3.0)
     responders (3.0.0)
       actionpack (>= 5.0)
@@ -454,9 +455,6 @@ GEM
     terminal-notifier-guard (1.7.0)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -542,6 +540,7 @@ DEPENDENCIES
   kaminari
   launchy
   listen (~> 3.1.5)
+  mini_racer (~> 0.2.8)
   momentjs-rails
   newrelic_rpm
   nokogiri (>= 1.10.4)
@@ -570,7 +569,6 @@ DEPENDENCIES
   sprockets (~> 3.7.2)
   terminal-notifier
   terminal-notifier-guard
-  therubyracer (~> 0.12)
   timecop
   toastr-rails
   uglifier (>= 1.3.0)


### PR DESCRIPTION
The last version of therubyracer was released in January 2017, and it depends on a *very* old version of libv8 (3.16). This version of libv8 also does not build on MacOS Catalina. Switching to mini_racer allows a much more recent libv8 (7.3) while still getting the asset build benefits of execjs

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->


### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

App boots up locally and serves pages without any obvious problems. Manually ran `bin/rails assets:precompile` to ensure they build successfully.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

```
$ bin/rails assets:precompile
W, [2019-11-28T18:39:02.581820 #92505]  WARN -- Skylight: [SKYLIGHT] [4.1.2] Running Skylight in development mode. No data will be reported until you deploy your app.
(To disable this message for all local apps, run `skylight disable_dev_warning`.)
2019-11-28T23:39:03.038Z 92505 TID-ovuy3a68t INFO: Loading Schedule
2019-11-28T23:39:03.038Z 92505 TID-ovuy3a68t INFO: Scheduling ReminderDeadlineJob {"cron"=>"0 0 0 * * *", "class"=>"ReminderDeadlineJob", "queue"=>"default"}
2019-11-28T23:39:03.041Z 92505 TID-ovuy3a68t INFO: Schedules Loaded
yarn install v1.19.1
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.47s.
I, [2019-11-28T18:39:07.451302 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/ionicons-a4803d7bdeb478a5b9238fe74d8aaa98dafe2e8e68fccbd0e3f4dced823f27f0.eot
I, [2019-11-28T18:39:07.452398 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/ionicons-a4803d7bdeb478a5b9238fe74d8aaa98dafe2e8e68fccbd0e3f4dced823f27f0.eot.gz
I, [2019-11-28T18:39:07.456513 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/ionicons-2ba7f20b1d8990e17a47fe3d88e4c766628aaa2baf1dd30fca0a0db59836f5f9.ttf
I, [2019-11-28T18:39:07.457407 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/ionicons-2ba7f20b1d8990e17a47fe3d88e4c766628aaa2baf1dd30fca0a0db59836f5f9.ttf.gz
I, [2019-11-28T18:39:07.461531 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/ionicons-a627d9068c1235d9b3c95c405eb6ecb64a290b159cf5e926c0d96d89b24cd5fc.svg
I, [2019-11-28T18:39:07.462460 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/ionicons-a627d9068c1235d9b3c95c405eb6ecb64a290b159cf5e926c0d96d89b24cd5fc.svg.gz
I, [2019-11-28T18:39:07.497950 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/ionicons-709f2789daaff440820ebb975d3ae409af45121bdec47e39e83523490b1bc0fc.woff
I, [2019-11-28T18:39:07.505647 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/open_sans/Apache License-283ea6cc2997a1a70da0049e09adf9317bb60ca1b51279b65196b83a69e1996b.txt
I, [2019-11-28T18:39:07.505776 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/open_sans/Apache License-283ea6cc2997a1a70da0049e09adf9317bb60ca1b51279b65196b83a69e1996b.txt.gz
I, [2019-11-28T18:39:07.509488 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/open_sans/OpenSans-Bold-5894a3649b213cf5b2d673b6e7a871815fd1d120fa68a463592f27db14eae323.ttf
I, [2019-11-28T18:39:07.510454 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/open_sans/OpenSans-Bold-5894a3649b213cf5b2d673b6e7a871815fd1d120fa68a463592f27db14eae323.ttf.gz
I, [2019-11-28T18:39:07.513447 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/open_sans/OpenSans-BoldItalic-3ca680f2444cc9e50447d057c006464566e92f2e77b0b6e26491e5bd757ed4e7.ttf
I, [2019-11-28T18:39:07.514087 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/open_sans/OpenSans-BoldItalic-3ca680f2444cc9e50447d057c006464566e92f2e77b0b6e26491e5bd757ed4e7.ttf.gz
I, [2019-11-28T18:39:07.517771 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/open_sans/OpenSans-Italic-a54dc8488f8193bf30c3820cf6f261f911f9d328d699e1a1b8042641554cec70.ttf
I, [2019-11-28T18:39:07.518937 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/open_sans/OpenSans-Italic-a54dc8488f8193bf30c3820cf6f261f911f9d328d699e1a1b8042641554cec70.ttf.gz
I, [2019-11-28T18:39:07.521883 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/open_sans/OpenSans-Regular-e64e508b2aa2880f907e470c4550980ec4c0694d103a43f36150ac3f93189bee.ttf
I, [2019-11-28T18:39:07.522593 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/open_sans/OpenSans-Regular-e64e508b2aa2880f907e470c4550980ec4c0694d103a43f36150ac3f93189bee.ttf.gz
I, [2019-11-28T18:39:07.524942 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/DiaperBase-Logo-5ba50dca131dd5a87889c324b095ba2da6a8c03075e83d3d96c9c02786cab708.png
I, [2019-11-28T18:39:07.527326 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/Just-Diaper-20b30c12d6e483040aa37e58fd9785dbac48ddfb341b7eac5d402fd5e3ebb54f.svg
I, [2019-11-28T18:39:07.527833 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/Just-Diaper-20b30c12d6e483040aa37e58fd9785dbac48ddfb341b7eac5d402fd5e3ebb54f.svg.gz
I, [2019-11-28T18:39:07.530332 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/blue@2x-c0ce7ecfbd5605a7a0d0239d83b736eda75dbc71ff183472e02c6d6cdfbcc888.png
I, [2019-11-28T18:39:07.533495 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/boxed-bg-5487391fa5db6155709522886beebc00fd7433ffb7ae5f63e585497cd5174ae5.jpg
I, [2019-11-28T18:39:07.536205 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/boxed-bg-9ed1309f8e468eda59c6742adcf195c8b305a5ea1b062cd6cc619ecc5acd6ecb.png
I, [2019-11-28T18:39:08.135611 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/application-3c7aebc1c00cd0e6d5d7eceee667900871c7aaa3c7d8203ff9185eb076f29d2b.js
I, [2019-11-28T18:39:08.135712 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/application-3c7aebc1c00cd0e6d5d7eceee667900871c7aaa3c7d8203ff9185eb076f29d2b.js.gz
I, [2019-11-28T18:39:08.140323 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/components/scale-5322f35ebea95b089e3933de3fc4bc815a9d54e0a33ca6a6b9f8c6b3b21c6fca.jsx
I, [2019-11-28T18:39:08.158582 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/application-8dbe496cd30a05ed1478a0040351dc6f641c7098b10818d6da810ead4802fe68.css
I, [2019-11-28T18:39:08.158670 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/application-8dbe496cd30a05ed1478a0040351dc6f641c7098b10818d6da810ead4802fe68.css.gz
I, [2019-11-28T18:39:08.159601 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/fontawesome-webfont-7bfcab6db99d5cfbf1705ca0536ddc78585432cc5fa41bbd7ad0f009033b2979.eot
I, [2019-11-28T18:39:08.160577 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/fontawesome-webfont-7bfcab6db99d5cfbf1705ca0536ddc78585432cc5fa41bbd7ad0f009033b2979.eot.gz
I, [2019-11-28T18:39:08.161375 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/fontawesome-webfont-2adefcbc041e7d18fcf2d417879dc5a09997aa64d675b7a3c4b6ce33da13f3fe.woff2
I, [2019-11-28T18:39:08.162985 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/fontawesome-webfont-ba0c59deb5450f5cb41b3f93609ee2d0d995415877ddfa223e8a8a7533474f07.woff
I, [2019-11-28T18:39:08.164416 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/fontawesome-webfont-aa58f33f239a0fb02f5c7a6c45c043d7a9ac9a093335806694ecd6d4edc0d6a8.ttf
I, [2019-11-28T18:39:08.165095 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/fontawesome-webfont-aa58f33f239a0fb02f5c7a6c45c043d7a9ac9a093335806694ecd6d4edc0d6a8.ttf.gz
I, [2019-11-28T18:39:08.165957 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/fontawesome-webfont-ad6157926c1622ba4e1d03d478f1541368524bfc46f51e42fe0d945f7ef323e4.svg
I, [2019-11-28T18:39:08.166902 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/fontawesome-webfont-ad6157926c1622ba4e1d03d478f1541368524bfc46f51e42fe0d945f7ef323e4.svg.gz
I, [2019-11-28T18:39:08.171068 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/bootstrap.min.css-b4a35d19793de445f4622f4d28db279c0242b60228ef304340aad833d012a77d.map
I, [2019-11-28T18:39:08.484946 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/actiontext/test/dummy/app/assets/stylesheets/application-10f688b3470d6691e2d22429d7192cc29e5bae1b60a176123f814f67abe99b9b.css
I, [2019-11-28T18:39:08.485072 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/actiontext/test/dummy/app/assets/stylesheets/application-10f688b3470d6691e2d22429d7192cc29e5bae1b60a176123f814f67abe99b9b.css.gz
I, [2019-11-28T18:39:08.489477 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/actiontext/test/dummy/app/javascript/packs/application-58cff65556692112ef75eee4baa2b14e243b0f01364352d6cbf4b66050f3ed3b.js
I, [2019-11-28T18:39:08.489702 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/actiontext/test/dummy/app/javascript/packs/application-58cff65556692112ef75eee4baa2b14e243b0f01364352d6cbf4b66050f3ed3b.js.gz
I, [2019-11-28T18:39:08.708877 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/express/lib/application-9232ebdb20ad39572e70fb9e29810e63dbb63b58f5f18617c7c2bc8bd28321b5.js
I, [2019-11-28T18:39:08.708988 #92505]  INFO -- : Writing /Users/bklang/src/rubyforgood/diaper/public/assets/express/lib/application-9232ebdb20ad39572e70fb9e29810e63dbb63b58f5f18617c7c2bc8bd28321b5.js.gz
Compiling…
Compiled all packs in /Users/bklang/src/rubyforgood/diaper/public/packs
```
