### PR TITLE
Feature/validate dates diaper drive

### DIFF
--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -34,7 +34,7 @@ class DiaperDrive < ApplicationRecord
     return if start_date.nil? || end_date.nil?
 
     if end_date < start_date
-      errors.add(:end_date, 'needs to be bigger of start date')
+      errors.add(:end_date, 'needs to be after of start date')
     end
   end
 

--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -28,6 +28,16 @@ class DiaperDrive < ApplicationRecord
     { message: "Please enter a start date." }
   scope :alphabetized, -> { order(:name) }
 
+  validate :end_date_is_bigger_of_end_date
+
+  def end_date_is_bigger_of_end_date
+    return if start_date.nil? || end_date.nil?
+
+    if end_date < start_date
+      errors.add(:end_date, 'needs to be bigger of start date')
+    end
+  end
+
   def donation_quantity
     donations.joins(:line_items).sum('line_items.quantity')
   end

--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -34,7 +34,7 @@ class DiaperDrive < ApplicationRecord
     return if start_date.nil? || end_date.nil?
 
     if end_date < start_date
-      errors.add(:end_date, 'needs to be after of start date')
+      errors.add(:end_date, 'End date must be after the start date')
     end
   end
 

--- a/spec/models/diaper_drive_spec.rb
+++ b/spec/models/diaper_drive_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe DiaperDrive, type: :model do
   describe 'validations' do
     it { expect(build(:diaper_drive, name: nil)).not_to be_valid }
     it { expect(build(:diaper_drive, start_date: nil)).not_to be_valid }
+    it { expect(build(:diaper_drive, start_date: '2020-12-17', end_date: '2019-12-19')).not_to be_valid }
   end
 
   describe 'associations' do


### PR DESCRIPTION
Resolves #1404 

 - [x] A user is not allowed to create or update a diaper drive if the start date is not before or the same as the end date
 - [x] When a user attempts to create or update a diaper drive with an invalid start/end date combination, they are shown an error message explaining what the issue is

### Screenshots
![Peek 2020-01-08 16-51](https://user-images.githubusercontent.com/49662698/72011210-1fb90d00-3238-11ea-8cdb-70d4dce42451.gif)

