### PR TITLE
Only enforce partner name uniqueness within an org instead of across all orgs #1408

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -22,8 +22,11 @@ class Partner < ApplicationRecord
   has_many :requests, dependent: :destroy
 
   validates :organization, presence: true
-  validates :name, :email, presence: true, uniqueness: true
-  validates :email, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, on: :create }
+  validates :name, presence: true, uniqueness: { scope: :organization }
+
+  validates :email, presence: true,
+                    uniqueness: true,
+                    format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, on: :create }
 
   scope :for_csv_export, ->(organization) {
     where(organization: organization)

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -17,11 +17,23 @@ RSpec.describe Partner, type: :model do
     it "must belong to an organization" do
       expect(build(:partner, organization_id: nil)).not_to be_valid
     end
-    it "requires a unique name" do
+
+    it "requires a unique name within an organization" do
       expect(build(:partner, name: nil)).not_to be_valid
       create(:partner, name: "Foo")
       expect(build(:partner, name: "Foo")).not_to be_valid
     end
+
+    it "does not require a unique name between organizations" do
+      create(:partner, name: "Foo")
+      expect(build(:partner, name: "Foo", organization: build(:organization))).to be_valid
+    end
+
+    it "still requires a unique email between organizations" do
+      create(:partner, name: "Foo", email: "foo@example.com")
+      expect(build(:partner, name: "Foo", email: "foo@example.com", organization: build(:organization))).to_not be_valid
+    end
+
     it "requires a unique email that is formatted correctly" do
       expect(build(:partner, email: nil)).not_to be_valid
       create(:partner, email: "foo@bar.com")


### PR DESCRIPTION
Resolves #1408 

This PR removes app-wide enforcement of partner name uniqueness and replaces it with an `Organization` wide enforcement.

This will fix a lot of annoying errors we're seeing in prod where two organizations work with partners with duplicate names.