### PR TITLE
[1402] Add organization to diaper drives

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -147,7 +147,8 @@ end
 [
   {
     name: 'Pamper the Poopsies',
-    start_date: Time.current
+    start_date: Time.current,
+    organization: pdx_org
   }
 ].each { |drive| DiaperDrive.create! drive }
 
@@ -174,15 +175,18 @@ end
 [
   { name:        "First Diaper Drive",
     start_date:  3.years.ago,
-    end_date:    3.years.ago
+    end_date:    3.years.ago,
+    organization: sf_org
   },
   { name:        "Best Diaper Drive",
     start_date:  3.weeks.ago,
-    end_date:    2.week.ago
+    end_date:    2.week.ago,
+    organization: sf_org
   },
   { name:        "Second Best Diaper Drive",
     start_date:  2.weeks.ago,
-    end_date:    1.week.ago
+    end_date:    1.week.ago,
+    organization: pdx_org
   }
 ].each { |diaper_drive| DiaperDrive.find_or_create_by! diaper_drive }
 


### PR DESCRIPTION
Resolves #1402 

### Description
Add organization relationship to diaper drives in seed data, so that drives show up on the index page.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Dev qa


