### PR TITLE
Correct the assertion description of POST #create from transfers controller spec

### DIFF
--- a/spec/controllers/transfers_controller_spec.rb
+++ b/spec/controllers/transfers_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe TransfersController, type: :controller do
     end
 
     describe "POST #create" do
-      it "redirects to #show when successful" do
+      it "redirects to #index when successful" do
         attributes = attributes_for(
           :transfer,
           organization_id: @organization.id,


### PR DESCRIPTION
While working on https://github.com/rubyforgood/diaper/issues/1418 I noticed that one of the specs had a description that did not match the assertion.

The description was stating that after a `transfers#create` succeeds it would take the user to `transfers#show`. However, the actual behavior is that the user after `transfers#create` is taken to `transfers#index`. If the mismatch is the other way, perhaps this is a bug?

This is a very minor fix in the description that caused a tiny bit confusing.