### PR TITLE
Enable Users to delete Transfers

### DIFF
--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -55,11 +55,11 @@ class TransfersController < ApplicationController
 
     if results.success?
       flash[:notice] = "Succesfully deleted Transfer ##{params[:id]}!"
-      redirect_to transfers_path
     else
       flash[:error] = results.error.message
-      redirect_to transfers_path
     end
+
+    redirect_to transfers_path
   end
 
   private

--- a/app/controllers/transfers_controller.rb
+++ b/app/controllers/transfers_controller.rb
@@ -49,6 +49,19 @@ class TransfersController < ApplicationController
     @line_items = @transfer.line_items.sorted
   end
 
+  def destroy
+    transfer_destroy_service = TransferDestroyService.new(transfer_id: params[:id])
+    results = transfer_destroy_service.call
+
+    if results.success?
+      flash[:notice] = "Succesfully deleted Transfer ##{params[:id]}!"
+      redirect_to transfers_path
+    else
+      flash[:error] = results.error.message
+      redirect_to transfers_path
+    end
+  end
+
   private
 
   def load_form_collections

--- a/app/services/transfer_destroy_service.rb
+++ b/app/services/transfer_destroy_service.rb
@@ -1,5 +1,4 @@
 class TransferDestroyService
-
   def initialize(transfer_id:)
     @transfer_id = transfer_id
   end
@@ -27,5 +26,4 @@ class TransferDestroyService
     transfer.to.decrease_inventory(transfer)
     transfer.from.increase_inventory(transfer)
   end
-
 end

--- a/app/services/transfer_destroy_service.rb
+++ b/app/services/transfer_destroy_service.rb
@@ -1,0 +1,31 @@
+class TransferDestroyService
+
+  def initialize(transfer_id:)
+    @transfer_id = transfer_id
+  end
+
+  def call
+    transfer.transaction do
+      revert_inventory_transfer!
+      transfer.destroy!
+    end
+
+    OpenStruct.new(success?: true)
+  rescue StandardError => e
+    OpenStruct.new(success?: false, error: e)
+  end
+
+  private
+
+  attr_reader :transfer_id
+
+  def transfer
+    @transfer ||= Transfer.find(transfer_id)
+  end
+
+  def revert_inventory_transfer!
+    transfer.to.decrease_inventory(transfer)
+    transfer.from.increase_inventory(transfer)
+  end
+
+end

--- a/app/views/transfers/_transfer_row.html.erb
+++ b/app/views/transfers/_transfer_row.html.erb
@@ -5,6 +5,7 @@
   <td><%= transfer_row.comment || "none" %></td>
   <td class="numeric"><%= transfer_row.line_items.total %></td>
   <td class="text-right">
+    <%= delete_button_to transfer_path(transfer_row.id), { confirm: "Are you sure you want to permanently remove this transfer?" } %>
     <%= view_button_to transfer_row %>
   </td>
 </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
     resources :audits do
       post :finalize
     end
-    resources :transfers, only: %i(index create new show)
+    resources :transfers, only: %i(index create new show destroy)
     resources :storage_locations do
       collection do
         post :import_csv

--- a/spec/services/transfer_destroy_service_spec.rb
+++ b/spec/services/transfer_destroy_service_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require_relative '../support/env_helper'
 
 RSpec.describe TransferDestroyService, type: :service do
-
   describe '#call' do
     subject { described_class.new(transfer_id: transfer_id).call }
     let(:transfer_id) { transfer.id }
@@ -11,8 +10,8 @@ RSpec.describe TransferDestroyService, type: :service do
     # Create a double StorageLocation that behaves like how we want to use
     # it within the service object. The benefit is that we aren't testing
     # ActiveRecord and the database.
-    let(:fake_from) { instance_double(StorageLocation, increase_inventory: ->{}) }
-    let(:fake_to) { instance_double(StorageLocation, decrease_inventory: ->{}) }
+    let(:fake_from) { instance_double(StorageLocation, increase_inventory: -> {}) }
+    let(:fake_to) { instance_double(StorageLocation, decrease_inventory: -> {}) }
 
     before do
       # Stub the outputs of these method calls to avoid testing
@@ -49,7 +48,6 @@ RSpec.describe TransferDestroyService, type: :service do
     end
 
     context 'when an issue occurs in transaction' do
-
       context 'because the transfer_id does not match any Transfer' do
         before do
           allow(Transfer).to receive(:find).with(transfer_id).and_raise(ActiveRecord::RecordNotFound)
@@ -102,7 +100,5 @@ RSpec.describe TransferDestroyService, type: :service do
         end
       end
     end
-
   end
-
 end

--- a/spec/services/transfer_destroy_service_spec.rb
+++ b/spec/services/transfer_destroy_service_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+require_relative '../support/env_helper'
+
+RSpec.describe TransferDestroyService, type: :service do
+
+  describe '#call' do
+    subject { described_class.new(transfer_id: transfer_id).call }
+    let(:transfer_id) { transfer.id }
+    let(:transfer) { create(:transfer, organization: organization) }
+    let(:organization) { create(:organization) }
+    # Create a double StorageLocation that behaves like how we want to use
+    # it within the service object. The benefit is that we aren't testing
+    # ActiveRecord and the database.
+    let(:fake_from) { instance_double(StorageLocation, increase_inventory: ->{}) }
+    let(:fake_to) { instance_double(StorageLocation, decrease_inventory: ->{}) }
+
+    before do
+      # Stub the outputs of these method calls to avoid testing
+      # beyond this service objects responsiblity. That is we,
+      # aren't interested in testing the implementation details
+      # such as the database.
+      allow(Transfer).to receive(:find).with(transfer_id).and_return(transfer)
+      allow(transfer).to receive(:from).and_return(fake_from)
+      allow(transfer).to receive(:to).and_return(fake_to)
+      allow(transfer).to receive(:destroy!)
+
+      # Now that that the `transfer.from` and `transfer.to` is stubbed
+      # to return the doubles of StorageLocation, we must program them
+      # to expect the `increase_inventory` and `decrease_inventory`
+      allow(fake_from).to receive(:increase_inventory).with(transfer)
+      allow(fake_to).to receive(:decrease_inventory).with(transfer)
+    end
+
+    context 'when there are no issues' do
+      it 'should return an OpenStruct with succes? set to true' do
+        expect(subject).to be_a_kind_of(OpenStruct)
+        expect(subject.success?).to eq(true)
+      end
+
+      it 'should execute the expected methods' do
+        # Invoke the subject aka call the service object call method
+        subject
+
+        # Assert that the service object calls the expected method.
+        expect(fake_from).to have_received(:increase_inventory).with(transfer)
+        expect(fake_to).to have_received(:decrease_inventory).with(transfer)
+        expect(transfer).to have_received(:destroy!)
+      end
+    end
+
+    context 'when an issue occurs in transaction' do
+
+      context 'because the transfer_id does not match any Transfer' do
+        before do
+          allow(Transfer).to receive(:find).with(transfer_id).and_raise(ActiveRecord::RecordNotFound)
+        end
+
+        it 'should return a OpenStruct with an ActiveRecord::RecordNotFound error' do
+          expect(subject).to be_a_kind_of(OpenStruct)
+          expect(subject.success?).to eq(false)
+          expect(subject.error).to be_a_kind_of(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context 'because undoing the transfer inventory changes by increasing the inventory of `from` failed' do
+        let(:fake_error) { Errors::InsufficientAllotment.new('msg') }
+
+        before do
+          allow(fake_from).to receive(:increase_inventory).with(transfer).and_raise(fake_error)
+        end
+
+        it 'should return a OpenStruct with the raised error' do
+          expect(subject).to be_a_kind_of(OpenStruct)
+          expect(subject.success?).to eq(false)
+          expect(subject.error).to eq(fake_error)
+        end
+      end
+
+      context 'because undoing the transfer inventory changes by decreasing the inventory of `to` failed' do
+        let(:fake_error) { Errors::InsufficientAllotment.new('random-error') }
+        before do
+          allow(fake_to).to receive(:decrease_inventory).with(transfer).and_raise(fake_error)
+        end
+
+        it 'should return a OpenStruct with the raised error' do
+          expect(subject).to be_a_kind_of(OpenStruct)
+          expect(subject.success?).to eq(false)
+          expect(subject.error).to eq(fake_error)
+        end
+      end
+
+      context 'because the transfer destroy raised an error' do
+        let(:fake_error) { StandardError.new('random-error') }
+        before do
+          allow(transfer).to receive(:destroy!).and_raise(fake_error)
+        end
+
+        it 'should return a OpenStruct with the raised error' do
+          expect(subject).to be_a_kind_of(OpenStruct)
+          expect(subject.success?).to eq(false)
+          expect(subject.error).to eq(fake_error)
+        end
+      end
+    end
+
+  end
+
+end

--- a/spec/system/transfer_system_spec.rb
+++ b/spec/system/transfer_system_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Transfer management", type: :system do
 
     create_transfer(transfer_amount.to_s, from_storage_location.name, to_storage_location.name)
 
-    expect(from_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).not_to eq(original_from_storage_item_count)
+    expect(from_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).to eq(original_from_storage_item_count-transfer_amount)
     expect(to_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).to eq(transfer_amount)
 
     allow_any_instance_of(StorageLocation).to receive(:decrease_inventory).and_raise(
@@ -93,7 +93,7 @@ RSpec.describe "Transfer management", type: :system do
 
     # Assert that the inventory did not change in response
     # to the raised error.
-    expect(from_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).to eq(original_from_storage_item_count)
+    expect(from_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).to eq(original_from_storage_item_count-transfer_amount)
     expect(to_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).to eq(transfer_amount)
   end
 

--- a/spec/system/transfer_system_spec.rb
+++ b/spec/system/transfer_system_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Transfer management", type: :system do
 
     create_transfer(transfer_amount.to_s, from_storage_location.name, to_storage_location.name)
 
-    expect(from_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).to eq(original_from_storage_item_count-transfer_amount)
+    expect(from_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).to eq(original_from_storage_item_count - transfer_amount)
     expect(to_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).to eq(transfer_amount)
 
     allow_any_instance_of(StorageLocation).to receive(:decrease_inventory).and_raise(
@@ -93,7 +93,7 @@ RSpec.describe "Transfer management", type: :system do
 
     # Assert that the inventory did not change in response
     # to the raised error.
-    expect(from_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).to eq(original_from_storage_item_count-transfer_amount)
+    expect(from_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).to eq(original_from_storage_item_count - transfer_amount)
     expect(to_storage_location.reload.inventory_items.find_by(item_id: item.id).quantity).to eq(transfer_amount)
   end
 


### PR DESCRIPTION
Relates to #1418 

### Description
This PR gives users the ability to delete Transfers that contain errors. This should enable users to more easily correct an incorrect entry (as mentioned in [issue](https://github.com/rubyforgood/diaper/issues/1418)). Upon deletion of a `Transfer` it will restore the values of the inventory before the `Transfer` was created.

- Add `TransferDestroyService` to encapsulate the logic related to deleting the transfer and undoing it's inventory changes
- Added system test and unit tests to validate each addition has test coverage. Utilizes a mocking/stubbing approach to isolate the responsibilities. Let me know if this needs more clarification or comments.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
1. Login as a user
2. Access the transfers index page at http://localhost:3000/diaper_bank/transfers
3. Create a Transfer
4. On the index page, click and confirm the deletion of the newly created Transfer.
5. The transfer should be removed and the inventory amounts should be restored before the transfer was created.

### Screenshots
<img width="1192" alt="Screen Shot 2020-01-19 at 9 08 40 PM" src="https://user-images.githubusercontent.com/11335191/72699167-f5573180-3b0c-11ea-9e1c-8a49b77c3e32.png">
<img width="551" alt="Screen Shot 2020-01-19 at 9 08 45 PM" src="https://user-images.githubusercontent.com/11335191/72699170-f5efc800-3b0c-11ea-88bb-45198e3b7dfb.png">
<img width="1203" alt="Screen Shot 2020-01-19 at 9 08 50 PM" src="https://user-images.githubusercontent.com/11335191/72699171-f6885e80-3b0c-11ea-945d-4966fe9d6dc2.png">
