### PR TITLE
[1419] Move controller specs to request specs

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -111,6 +111,7 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :helper
   config.include Devise::Test::IntegrationHelpers, type: :feature
   config.include Devise::Test::IntegrationHelpers, type: :system
+  config.include Devise::Test::IntegrationHelpers, type: :request
 
   config.include ActiveSupport::Testing::TimeHelpers, type: :system
   config.include ActiveSupport::Testing::TimeHelpers, type: :feature

--- a/spec/requests/dashobard_requests_spec.rb
+++ b/spec/requests/dashobard_requests_spec.rb
@@ -1,4 +1,6 @@
-RSpec.describe DashboardController, type: :controller do
+require 'rails_helper'
+
+RSpec.describe "Dashboard", type: :request do
   let(:default_params) do
     { organization_id: @organization.to_param }
   end
@@ -10,14 +12,14 @@ RSpec.describe DashboardController, type: :controller do
 
     describe "GET #show" do
       it "returns http success" do
-        get :index, params: default_params
+        get dashboard_path(default_params)
         expect(response).to be_successful
       end
 
       context "for another org" do
         it "requires authorization" do
           # nother org
-          get :index, params: { organization_id: create(:organization).to_param }
+          get dashboard_path(organization_id: create(:organization).to_param)
           expect(response).to be_redirect
         end
       end
@@ -26,7 +28,7 @@ RSpec.describe DashboardController, type: :controller do
 
   context "While not signed in" do
     it "redirects for authentication" do
-      get :index, params: { organization_id: create(:organization).to_param }
+      get dashboard_path(organization_id: create(:organization).to_param)
       expect(response).to be_redirect
     end
   end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolve partially #1419   <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
I moved `barcode_items_controller_spec` and `dashboard_controller_spec` to `barcode_items_requests_spec` and `dashboard_requests_spec` respectively, with the necessary changes.

### Type of change

<!-- Please delete options that are not relevant. -->

- Improvement 

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

All tests were green.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
