### PR TITLE
#1491 Add documentation of test coverage reporting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,6 @@ We try to stick with "Rails Way" philosophies as much as possible, and also keep
 
 ## Test Coverage
 
-This project uses the `simplecov` gem to generate a test coverage report. This report is generated when the tests are run (as previously mentioned, with `bundle exec rspec`).
+This project uses the `simplecov` gem to generate a test coverage report. This report is generated when the tests are run (as previously mentioned, with `bundle exec rspec`). The report can then be viewed by opening `coverage/index.html` in a browser.
 
-The report can then be viewed by opening `coverage/index.html` in a browser.
+To view the most recent test coverage statistics online, you can go to https://codeclimate.com/github/rubyforgood/diaper/code?sort=test_coverage for file-by-file statistics, and https://codeclimate.com/github/rubyforgood/diaper for the overall test coverage percentage (in addition to other information.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,3 +49,8 @@ We try to stick with "Rails Way" philosophies as much as possible, and also keep
  4. The PR description should describe what you're doing in it. If there's any noteworthy decisions you made or things you weren't expecting, note those in the description. We have a PR template, but you can free-form your description as long as it's thorough enough. The description should let us know what to focus on in the review.
  5. At this point you're waiting on us–we'll try to respond to your PR quickly. We may suggest some changes or improvements or alternatives.
 
+## Test Coverage
+
+This project uses the `simplecov` gem to generate a test coverage report. This report is generated when the tests are run (as previously mentioned, with `bundle exec rspec`).
+
+The report can then be viewed by opening `coverage/index.html` in a browser.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,9 @@ We try to stick with "Rails Way" philosophies as much as possible, and also keep
 
 This project uses the `simplecov` gem to generate a test coverage report. This report is generated when the tests are run (as previously mentioned, with `bundle exec rspec`). The report can then be viewed by opening `coverage/index.html` in a browser.
 
-To view the most recent test coverage statistics online, you can go to [https://codeclimate.com/github/rubyforgood/diaper/code?sort=test_coverage](https://codeclimate.com/github/rubyforgood/diaper/code?sort=test_coverage) for file-by-file statistics, and [https://codeclimate.com/github/rubyforgood/diaper](https://codeclimate.com/github/rubyforgood/diaper) for the overall test coverage percentage (in addition to other information).
+The most recent test coverage statistics are available online at the Code Climate web site:
 
+* [file-by-file](https://codeclimate.com/github/rubyforgood/diaper/code?sort=test_coverage)
+* [aggregate, including other kinds of information](https://codeclimate.com/github/rubyforgood/diaper)
 
-Of the two, the local page is better organized and has more test coverage information. Sample screenshots can be seen in the simplecov [readme](https://github.com/colszowka/simplecov#example-output).
+Of the two (local and cloud), the local page is better organized and has more test coverage information. Sample screenshots can be seen in the simplecov [readme](https://github.com/colszowka/simplecov#example-output).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ We try to stick with "Rails Way" philosophies as much as possible, and also keep
 
 This project uses the `simplecov` gem to generate a test coverage report. This report is generated when the tests are run (as previously mentioned, with `bundle exec rspec`). The report can then be viewed by opening `coverage/index.html` in a browser.
 
-To view the most recent test coverage statistics online, you can go to https://codeclimate.com/github/rubyforgood/diaper/code?sort=test_coverage for file-by-file statistics, and https://codeclimate.com/github/rubyforgood/diaper for the overall test coverage percentage (in addition to other information).
+To view the most recent test coverage statistics online, you can go to [https://codeclimate.com/github/rubyforgood/diaper/code?sort=test_coverage](https://codeclimate.com/github/rubyforgood/diaper/code?sort=test_coverage) for file-by-file statistics, and [https://codeclimate.com/github/rubyforgood/diaper](https://codeclimate.com/github/rubyforgood/diaper) for the overall test coverage percentage (in addition to other information).
 
 
 Of the two, the local page is better organized and has more test coverage information. Sample screenshots can be seen in the simplecov [readme](https://github.com/colszowka/simplecov#example-output).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,3 +54,6 @@ We try to stick with "Rails Way" philosophies as much as possible, and also keep
 This project uses the `simplecov` gem to generate a test coverage report. This report is generated when the tests are run (as previously mentioned, with `bundle exec rspec`). The report can then be viewed by opening `coverage/index.html` in a browser.
 
 To view the most recent test coverage statistics online, you can go to https://codeclimate.com/github/rubyforgood/diaper/code?sort=test_coverage for file-by-file statistics, and https://codeclimate.com/github/rubyforgood/diaper for the overall test coverage percentage (in addition to other information.
+
+
+Of the two, the local page is better organized and has more test coverage information. Sample screenshots can be seen in the simplecov [readme](https://github.com/colszowka/simplecov#example-output).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ We try to stick with "Rails Way" philosophies as much as possible, and also keep
 
 This project uses the `simplecov` gem to generate a test coverage report. This report is generated when the tests are run (as previously mentioned, with `bundle exec rspec`). The report can then be viewed by opening `coverage/index.html` in a browser.
 
-To view the most recent test coverage statistics online, you can go to https://codeclimate.com/github/rubyforgood/diaper/code?sort=test_coverage for file-by-file statistics, and https://codeclimate.com/github/rubyforgood/diaper for the overall test coverage percentage (in addition to other information.
+To view the most recent test coverage statistics online, you can go to https://codeclimate.com/github/rubyforgood/diaper/code?sort=test_coverage for file-by-file statistics, and https://codeclimate.com/github/rubyforgood/diaper for the overall test coverage percentage (in addition to other information).
 
 
 Of the two, the local page is better organized and has more test coverage information. Sample screenshots can be seen in the simplecov [readme](https://github.com/colszowka/simplecov#example-output).


### PR DESCRIPTION
Document test coverage in the contributor documentation.

Resolves #1491

### Description
   
This (first) commit adds some basic information, but is probably not sufficient.

I wanted to add similar information about test coverage report generation on the server (by Travis, or other) but don't know that information. If the report is only generated locally, I'd like to mention that.

### Type of change

* Documentation update
