### PR TITLE
[1485] Fix missing newly created inventory item from dropdown

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,6 +26,11 @@ class ItemsController < ApplicationController
       redirect_to items_path, notice: "#{result.item.name} added!"
     else
       @base_items = BaseItem.alphabetized
+      # Define a @item to be used in the `new` action to be rendered with
+      # the provided parameters. This is required to render the page again
+      # with the error + the invalid parameters
+      @item = current_organization.items.new(item_params)
+
       flash[:error] = "Something didn't work quite right -- try again?"
       render action: :new
     end
@@ -94,9 +99,14 @@ class ItemsController < ApplicationController
   end
 
   def item_params
+    # Memoize the value of this to prevent trying to
+    # clean the values again which would result in an
+    # error.
+    return @item_params if @item_params
+
     clean_item_value_in_cents
     clean_item_value_in_dollars
-    params.require(:item).permit(
+    @item_params = params.require(:item).permit(
       :name,
       :partner_key,
       :value_in_cents,

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,9 +19,11 @@ class ItemsController < ApplicationController
   end
 
   def create
-    @item = current_organization.items.new(item_params)
-    if @item.save
-      redirect_to items_path, notice: "#{@item.name} added!"
+    create = ItemCreateService.new(organization_id: current_organization.id, item_params: item_params)
+    result = create.call
+
+    if result.success?
+      redirect_to items_path, notice: "#{result.item.name} added!"
     else
       @base_items = BaseItem.alphabetized
       flash[:error] = "Something didn't work quite right -- try again?"

--- a/app/services/item_create_service.rb
+++ b/app/services/item_create_service.rb
@@ -6,8 +6,9 @@ class ItemCreateService
   end
 
   def call
+    new_item = organization.items.new(item_params)
+
     organization.transaction do
-      new_item = organization.items.new(item_params)
       new_item.save!
 
       organization.storage_locations.each do |sl|
@@ -19,7 +20,7 @@ class ItemCreateService
       end
     end
 
-    OpenStruct.new(success?: true)
+    OpenStruct.new(success?: true, item: new_item)
   rescue StandardError => e
     OpenStruct.new(success?: false, error: e)
   end

--- a/app/services/item_create_service.rb
+++ b/app/services/item_create_service.rb
@@ -1,5 +1,4 @@
 class ItemCreateService
-
   def initialize(organization_id:, item_params:)
     @organization_id = organization_id
     @item_params = item_params
@@ -12,11 +11,11 @@ class ItemCreateService
       new_item.save!
 
       organization.storage_locations.each do |sl|
-        InventoryItem.create!({
+        InventoryItem.create!(
           storage_location_id: sl.id,
           item_id: new_item.id,
           quantity: 0
-        })
+        )
       end
     end
 
@@ -32,5 +31,4 @@ class ItemCreateService
   def organization
     @organization ||= Organization.find(organization_id)
   end
-
 end

--- a/app/services/item_create_service.rb
+++ b/app/services/item_create_service.rb
@@ -1,0 +1,35 @@
+class ItemCreateService
+
+  def initialize(organization_id:, item_params:)
+    @organization_id = organization_id
+    @item_params = item_params
+  end
+
+  def call
+    organization.transaction do
+      new_item = organization.items.new(item_params)
+      new_item.save!
+
+      organization.storage_locations.each do |sl|
+        InventoryItem.create!({
+          storage_location_id: sl.id,
+          item_id: new_item.id,
+          quantity: 0
+        })
+      end
+    end
+
+    OpenStruct.new(success?: true)
+  rescue StandardError => e
+    OpenStruct.new(success?: false, error: e)
+  end
+
+  private
+
+  attr_reader :organization_id, :item_params
+
+  def organization
+    @organization ||= Organization.find(organization_id)
+  end
+
+end

--- a/spec/services/item_create_service_spec.rb
+++ b/spec/services/item_create_service_spec.rb
@@ -1,0 +1,106 @@
+require 'spec_helper'
+require_relative '../support/env_helper'
+
+RSpec.describe ItemCreateService, type: :service do
+
+  describe '#call' do
+    subject { described_class.new(organization_id: organization_id, item_params: item_params).call }
+    let(:organization_id) { organization.id }
+    let(:item_params) { { fake: 'param' } }
+    let(:organization) { create(:organization) }
+    let(:fake_organization_items) { instance_double('organization.items') }
+    let(:fake_organization_item) { instance_double(Item, id: 99999, save!: ->{}) }
+    let(:fake_organization_storage_locations) do
+      [
+        instance_double(StorageLocation, id: 'fake-id-1'),
+        instance_double(StorageLocation, id: 'fake-id-2')
+      ]
+    end
+
+    before do
+      # Utilize mocks to isolate the tests to prevent accessing
+      # the database. And prevent testing ActiveRecord or the
+      # actual database.
+      #
+      # By doing it this way, we remove extra dependencies on the
+      # database.
+      allow(Organization).to receive(:find).with(organization_id).and_return(organization)
+      allow(organization).to receive(:items).and_return(fake_organization_items)
+      allow(fake_organization_items).to receive(:new).with(item_params).and_return(fake_organization_item)
+      allow(organization).to receive(:storage_locations).and_return(fake_organization_storage_locations)
+
+      # Add a spy on InventoryItem to ensure this method is being
+      # called in our specs and service object.
+      allow(InventoryItem).to receive(:create!)
+    end
+
+    context 'when there are no issues' do
+      it 'should return an OpenStruct with success? set to true' do
+        expect(subject).to be_a_kind_of(OpenStruct)
+        expect(subject.success?).to eq(true)
+      end
+
+      it 'should execute the expected methods' do
+        # Invoke the subject aka call the service object call method
+        subject
+
+        # Assert that the service object calls the expected method.
+        expect(fake_organization_item).to have_received(:save!)
+        fake_organization_storage_locations.each do |sl|
+          expect(InventoryItem).to have_received(:create!).with({
+            storage_location_id: sl.id,
+            item_id: fake_organization_item.id,
+            quantity: 0
+          })
+        end
+      end
+    end
+
+    context 'when an issue occurs in transaction' do
+      context 'because the organization_id does not match any Organization' do
+        before do
+          allow(Organization).to receive(:find).with(organization_id).and_raise(ActiveRecord::RecordNotFound)
+        end
+
+        it 'should return a OpenStruct with an ActiveRecord::RecordNotFound error' do
+          expect(subject).to be_a_kind_of(OpenStruct)
+          expect(subject.success?).to eq(false)
+          expect(subject.error).to be_a_kind_of(ActiveRecord::RecordNotFound)
+        end
+      end
+
+      context 'because the item create raised an error' do
+        let(:fake_error) { StandardError.new('random-error') }
+
+        before do
+          allow(fake_organization_item).to receive(:save!).and_raise(fake_error)
+        end
+
+        it 'should return a OpenStruct with the raised error' do
+          expect(subject).to be_a_kind_of(OpenStruct)
+          expect(subject.success?).to eq(false)
+          expect(subject.error).to eq(fake_error)
+        end
+      end
+
+      context 'because a inventory item creation failed and raised an error' do
+        let(:fake_error) { StandardError.new('random-error') }
+
+        before do
+          allow(InventoryItem).to receive(:create!).with({
+            storage_location_id: fake_organization_storage_locations.first.id,
+            item_id: fake_organization_item.id,
+            quantity: 0
+          }).and_raise(fake_error)
+        end
+
+        it 'should return a OpenStruct with the raised error' do
+          expect(subject).to be_a_kind_of(OpenStruct)
+          expect(subject.success?).to eq(false)
+          expect(subject.error).to eq(fake_error)
+        end
+
+      end
+    end
+  end
+end

--- a/spec/services/item_create_service_spec.rb
+++ b/spec/services/item_create_service_spec.rb
@@ -35,9 +35,10 @@ RSpec.describe ItemCreateService, type: :service do
     end
 
     context 'when there are no issues' do
-      it 'should return an OpenStruct with success? set to true' do
+      it 'should return an OpenStruct with success? set to true and the item' do
         expect(subject).to be_a_kind_of(OpenStruct)
         expect(subject.success?).to eq(true)
+        expect(subject.item).to eq(fake_organization_item)
       end
 
       it 'should execute the expected methods' do

--- a/spec/services/item_create_service_spec.rb
+++ b/spec/services/item_create_service_spec.rb
@@ -2,14 +2,13 @@ require 'spec_helper'
 require_relative '../support/env_helper'
 
 RSpec.describe ItemCreateService, type: :service do
-
   describe '#call' do
     subject { described_class.new(organization_id: organization_id, item_params: item_params).call }
     let(:organization_id) { organization.id }
     let(:item_params) { { fake: 'param' } }
     let(:organization) { create(:organization) }
     let(:fake_organization_items) { instance_double('organization.items') }
-    let(:fake_organization_item) { instance_double(Item, id: 99999, save!: ->{}) }
+    let(:fake_organization_item) { instance_double(Item, id: 99_999, save!: -> {}) }
     let(:fake_organization_storage_locations) do
       [
         instance_double(StorageLocation, id: 'fake-id-1'),
@@ -48,11 +47,11 @@ RSpec.describe ItemCreateService, type: :service do
         # Assert that the service object calls the expected method.
         expect(fake_organization_item).to have_received(:save!)
         fake_organization_storage_locations.each do |sl|
-          expect(InventoryItem).to have_received(:create!).with({
+          expect(InventoryItem).to have_received(:create!).with(
             storage_location_id: sl.id,
             item_id: fake_organization_item.id,
             quantity: 0
-          })
+          )
         end
       end
     end
@@ -88,11 +87,11 @@ RSpec.describe ItemCreateService, type: :service do
         let(:fake_error) { StandardError.new('random-error') }
 
         before do
-          allow(InventoryItem).to receive(:create!).with({
+          allow(InventoryItem).to receive(:create!).with(
             storage_location_id: fake_organization_storage_locations.first.id,
             item_id: fake_organization_item.id,
             quantity: 0
-          }).and_raise(fake_error)
+          ).and_raise(fake_error)
         end
 
         it 'should return a OpenStruct with the raised error' do
@@ -100,7 +99,6 @@ RSpec.describe ItemCreateService, type: :service do
           expect(subject.success?).to eq(false)
           expect(subject.error).to eq(fake_error)
         end
-
       end
     end
   end


### PR DESCRIPTION
Resolves #1485 

### Description

- Add a new service object `ItemCreateService` that handles the creation of `InventoryItem` on the organization's associated storage_locations
- Apply and utilize the `ItemCreateService ` to the items#create endpoint

### How Has This Been Tested?
1. Create a new item via the Item & Inventory page
2. Attempt to create a Transfer and see that the dropdown includes the newly created item with a quantity of 0.
