### PR TITLE
Refactor barcode_items_system_spec to prevent failure for certain base_items

### DIFF
--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -26,13 +26,13 @@ RSpec.describe "Barcode Items Admin", type: :system, js: true do
     it "should delete a global barcode" do
       visit admin_barcode_items_path
       page.refresh
-      expect(page).to have_content barcode_item.base_item.name
+      expect(page).to have_content "\n#{barcode_item.base_item.name}"
       expect(
         accept_confirm do
           click_on "Delete"
         end
       ).to include "Are you sure you want to delete"
-      expect(page).to have_no_content barcode_item.base_item.name
+      expect(page).to have_no_content "\n#{barcode_item.base_item.name}"
     end
 
     it "should view a barcode shows details about it"


### PR DESCRIPTION
Resolves #1514 

### Description
This change refactors the barcode_items_system_spec to include the newline character when looking for base_item names. Without this character, the base_items with name "Swimmers" and "Pads" were leading to false positives because they are contained inside of other base_item names, e.g. "Cloth Swimmers (Kids)".

If the newline character makes the test too dependent on the page formatting in your opinion, I can refactor the test in a different way to ensure the base_item isn't named "Swimmers" or "Pads". 

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Locally, I ran the test for all BaseItems to make sure it worked for any given base_item. For test speed reasons, I removed the `BaseItem.all.each` when pushing up, but it did pass in this form.

```
    it "should delete a global barcode" do
      BaseItem.all.each do |base_item|
        barcode_item = create(:global_barcode_item, barcodeable: base_item)
        visit admin_barcode_items_path
        page.refresh
        expect(page).to have_content "\n#{barcode_item.base_item.name}"
        expect(
          accept_confirm do
            click_on "Delete"
          end
        ).to include "Are you sure you want to delete"
        expect(page).to have_no_content "\n#{barcode_item.base_item.name}"
      end
    end
```