### PR TITLE
Move fakeredis gem to test group to avoid sidekiq error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,9 +90,9 @@ group :test do
   gem "fakeredis", require: "fakeredis/rspec"
   gem "launchy"
   gem "rails-controller-testing"
-  gem "webmock", "~> 3.8"
   gem 'simplecov'
   gem 'webdrivers', '~> 4.2'
+  gem "webmock", "~> 3.8"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,6 @@ gem 'bootstrap-daterangepicker-rails'
 
 group :development, :test do
   gem "awesome_print"
-  gem "fakeredis", require: "fakeredis/rspec"
   gem "guard-rspec"
   gem "pry-rails"
   gem "pry-remote"
@@ -88,6 +87,7 @@ group :test do
   gem "capybara-screenshot"
   gem "database_cleaner"
   gem "factory_bot_rails"
+  gem "fakeredis", require: "fakeredis/rspec"
   gem "launchy"
   gem "rails-controller-testing"
   gem "webmock", "~> 3.8"


### PR DESCRIPTION
# Description
I discovered when trying to run `bundle exec sidekiq` to run enqueued jobs -- I get this error:
```
You are using Redis v2.6.16, Sidekiq requires Redis v2.8.0 or greater
```

This seems to be linked to the use of `fakeredis` in development according to this [issue](https://github.com/mperham/sidekiq/issues/4085)

Once I moved this to the `test` group, the error stopped.

### Screenshots
If you run `bundle exec sidekiq` to start running jobs on the queue you might get an error stating that the version of redis is not correct.
<img width="911" alt="Screen Shot 2020-03-28 at 11 46 22 AM" src="https://user-images.githubusercontent.com/11335191/77828653-c5b73d80-70ea-11ea-855f-c052b6491044.png">

