### PR TITLE
Add query parameters to DiaperPartnerClient#get

### DIFF
--- a/app/services/diaper_partner_client.rb
+++ b/app/services/diaper_partner_client.rb
@@ -29,6 +29,7 @@ module DiaperPartnerClient
   def self.get(attributes)
     id = attributes[:id]
     uri = URI(ENV["PARTNER_REGISTER_URL"] + "/#{id}")
+    uri.query = URI.encode_www_form(attributes[:query_params]) unless attributes[:query_params].blank?
     req = Net::HTTP::Get.new(uri, "Content-Type" => "application/json")
 
     req["Content-Type"] = "application/json"

--- a/app/services/diaper_partner_client.rb
+++ b/app/services/diaper_partner_client.rb
@@ -26,10 +26,10 @@ module DiaperPartnerClient
     response.body
   end
 
-  def self.get(attributes)
+  def self.get(attributes, query_params: {})
     id = attributes[:id]
     uri = URI(ENV["PARTNER_REGISTER_URL"] + "/#{id}")
-    uri.query = URI.encode_www_form(attributes[:query_params]) unless attributes[:query_params].blank?
+    uri.query = URI.encode_www_form(query_params) if query_params.present?
     req = Net::HTTP::Get.new(uri, "Content-Type" => "application/json")
 
     req["Content-Type"] = "application/json"

--- a/spec/services/diaper_partner_client_spec.rb
+++ b/spec/services/diaper_partner_client_spec.rb
@@ -29,6 +29,26 @@ RSpec.describe DiaperPartnerClient, type: :service do
       result = DiaperPartnerClient.get(id: 123)
       expect(result).to eq 'success'
     end
+
+    context 'with query_params' do
+      let(:query_params) { { additional_details: true } }
+
+      it 'performs a GET request' do
+        stub_partner_request(:get, 'https://partner-register.com/123?additional_details=true')
+        result = DiaperPartnerClient.get(id: 123, query_params: query_params)
+        expect(result).to eq 'success'
+      end
+    end
+
+    context 'with random params' do
+      let(:random_params) { { something: 'weird' } }
+
+      it 'performs a GET request' do
+        stub_partner_request(:get, 'https://partner-register.com/123')
+        result = DiaperPartnerClient.get(id: 123, random_params: random_params)
+        expect(result).to eq 'success'
+      end
+    end
   end
 
   describe '::put' do

--- a/spec/services/diaper_partner_client_spec.rb
+++ b/spec/services/diaper_partner_client_spec.rb
@@ -24,9 +24,11 @@ RSpec.describe DiaperPartnerClient, type: :service do
   end
 
   describe '::get' do
+    let(:fake_random_id) { Faker::Number.number }
+
     it 'performs a GET request' do
-      stub_partner_request(:get, 'https://partner-register.com/123')
-      result = DiaperPartnerClient.get(id: 123)
+      stub_partner_request(:get, "https://partner-register.com/#{fake_random_id}")
+      result = DiaperPartnerClient.get(id: fake_random_id)
       expect(result).to eq 'success'
     end
 
@@ -34,18 +36,8 @@ RSpec.describe DiaperPartnerClient, type: :service do
       let(:query_params) { { additional_details: true } }
 
       it 'performs a GET request' do
-        stub_partner_request(:get, 'https://partner-register.com/123?additional_details=true')
-        result = DiaperPartnerClient.get(id: 123, query_params: query_params)
-        expect(result).to eq 'success'
-      end
-    end
-
-    context 'with random params' do
-      let(:random_params) { { something: 'weird' } }
-
-      it 'performs a GET request' do
-        stub_partner_request(:get, 'https://partner-register.com/123')
-        result = DiaperPartnerClient.get(id: 123, random_params: random_params)
+        stub_partner_request(:get, "https://partner-register.com/#{fake_random_id}?additional_details=true")
+        result = DiaperPartnerClient.get({ id: fake_random_id }, query_params: query_params)
         expect(result).to eq 'success'
       end
     end


### PR DESCRIPTION
Co-authored-by: Alicia Barrett <Aliciawyse@users.noreply.github.com>

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1605

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

New RSpec unit tests in `spec/services/diaper_partner_client_spec.rb`
Plus local testing of the `approve_partner` button and endpoint
