### PR TITLE
Includes organization email in data sent to Partnerbase from UpdateDiaperPartnerJob

### DIFF
--- a/app/jobs/update_diaper_partner_job.rb
+++ b/app/jobs/update_diaper_partner_job.rb
@@ -10,6 +10,8 @@ class UpdateDiaperPartnerJob
     @partner.invited!
   end
 
+  private
+
   def partner_attributes(partner)
     partner.attributes.merge({ organization_email: partner.organization.email }).with_indifferent_access
   end

--- a/app/jobs/update_diaper_partner_job.rb
+++ b/app/jobs/update_diaper_partner_job.rb
@@ -6,11 +6,11 @@ class UpdateDiaperPartnerJob
   def perform(partner_id)
     @partner = Partner.find(partner_id)
     @invitation_message = @partner.organization.invitation_text
-    @response = DiaperPartnerClient.post(partner_attributes, @invitation_message) if Flipper.enabled?(:email_active)
+    @response = DiaperPartnerClient.post(partner_attributes(@partner), @invitation_message) if Flipper.enabled?(:email_active)
     @partner.invited!
   end
 
-  def partner_attributes
-    @partner.attributes
+  def partner_attributes(partner)
+    partner.attributes
   end
 end

--- a/app/jobs/update_diaper_partner_job.rb
+++ b/app/jobs/update_diaper_partner_job.rb
@@ -6,7 +6,11 @@ class UpdateDiaperPartnerJob
   def perform(partner_id)
     @partner = Partner.find(partner_id)
     @invitation_message = @partner.organization.invitation_text
-    @response = DiaperPartnerClient.post(@partner.attributes, @invitation_message) if Flipper.enabled?(:email_active)
+    @response = DiaperPartnerClient.post(partner_attributes, @invitation_message) if Flipper.enabled?(:email_active)
     @partner.invited!
+  end
+
+  def partner_attributes
+    @partner.attributes
   end
 end

--- a/app/jobs/update_diaper_partner_job.rb
+++ b/app/jobs/update_diaper_partner_job.rb
@@ -11,6 +11,6 @@ class UpdateDiaperPartnerJob
   end
 
   def partner_attributes(partner)
-    partner.attributes
+    partner.attributes.merge({ organization_email: partner.organization.email }).with_indifferent_access
   end
 end

--- a/spec/jobs/update_diaper_partner_job_spec.rb
+++ b/spec/jobs/update_diaper_partner_job_spec.rb
@@ -58,7 +58,8 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
     it "includes the organization_email in the output" do
       @partner = create(:partner)
       organization_email = @partner.organization.email
-      expect(UpdateDiaperPartnerJob.new.partner_attributes(@partner)).to have_value(organization_email)
+      update_partner_job = UpdateDiaperPartnerJob.new
+      expect(update_partner_job.partner_attributes(@partner)).to have_value(organization_email)
     end
   end
 end

--- a/spec/jobs/update_diaper_partner_job_spec.rb
+++ b/spec/jobs/update_diaper_partner_job_spec.rb
@@ -1,4 +1,42 @@
 RSpec.describe UpdateDiaperPartnerJob, job: true do
+  describe '#perform(partner_id)' do
+    subject { described_class.new.perform(partner_id) }
+    let(:partner_id) { Faker::Number.number }
+
+    context 'when the email feature is active' do
+      # I'am only going handle the branch of logic when it email is active
+      let(:fake_partner) { instance_double(Partner, attributes: { fake: 'data' }) }
+
+      before do
+        # Force email to be enabled
+        allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
+
+        allow(Partner).to receive(:find).with(partner_id).and_return(fake_partner)
+
+        # Pre-program all interactions with the fake partner. This is to
+        # remove any dependencies on what Partner actually does.
+        fake_invitation_text = Faker::Lorem.sentences
+        fake_organization_email = Faker::Internet.email
+
+        allow(fake_partner).to receive_message_chain(:organization, :invitation_text).and_return(fake_invitation_text)
+        allow(fake_partner).to receive_message_chain(:organization, :email).and_return(fake_organization_email)
+
+        # The below will fail the test if `.with(...)` doesn't
+        # match what is actually happening.
+        allow(DiaperPartnerClient).to receive(:post)
+          .with(fake_partner.attributes.merge({ organization_email: fake_organization_email }), fake_invitation_text)
+          .and_return({})
+
+        allow(fake_partner).to receive(:invited!)
+      end
+
+      it 'should have called invited! on the partner' do
+        subject
+        expect(fake_partner).to have_received(:invited!)
+      end
+    end
+  end
+
   describe "Responses >" do
     context "with a successful POST response" do
       before do
@@ -51,15 +89,6 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
           end
         end
       end
-    end
-  end
-
-  describe ".partner_attributes" do
-    it "includes the organization_email in the output" do
-      @partner = create(:partner)
-      organization_email = @partner.organization.email
-      update_partner_job = UpdateDiaperPartnerJob.new
-      expect(update_partner_job.partner_attributes(@partner)).to have_value(organization_email)
     end
   end
 end

--- a/spec/jobs/update_diaper_partner_job_spec.rb
+++ b/spec/jobs/update_diaper_partner_job_spec.rb
@@ -53,4 +53,12 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
       end
     end
   end
+
+  describe ".partner_attributes" do
+    it "includes the organization_email in the output" do
+      @partner = create(:partner)
+      organization_email = @partner.organization.email
+      expect(UpdateDiaperPartnerJob.new.partner_attributes(@partner)).to have_value(organization_email)
+    end
+  end
 end

--- a/spec/jobs/update_diaper_partner_job_spec.rb
+++ b/spec/jobs/update_diaper_partner_job_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
     let(:partner_id) { Faker::Number.number }
 
     context 'when the email feature is active' do
-      # I'am only going handle the branch of logic when it email is active
       let(:fake_partner) { instance_double(Partner, attributes: { fake: 'data' }) }
 
       before do


### PR DESCRIPTION
Fixes #1597 

Paired with @coderpaz 

### Description
We want the Partners to use organization email addresses in their email notifications. For that to happen, they have to know the organization email for their diaper bank. 

This includes that email address when the post request is fired off.

**IMPORTANT** - PartnerBase still needs to integrate this new data into its operation.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
We wrote a test to verify the method includes the email.