### PR TITLE
Fixes various ActiveJob issues, including specs and a couple bugfixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,6 +89,7 @@ group :test do
   gem "fakeredis", require: "fakeredis/rspec"
   gem "launchy"
   gem "rails-controller-testing"
+  gem "rspec-sidekiq"
   gem 'simplecov'
   gem 'webdrivers', '~> 4.2'
   gem "webmock", "~> 3.8"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -367,6 +367,9 @@ GEM
       rspec-expectations (~> 3.9)
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
+    rspec-sidekiq (3.0.3)
+      rspec-core (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
     rspec-support (3.9.2)
     rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
@@ -547,6 +550,7 @@ DEPENDENCIES
   rails-erd
   rb-readline (~> 0.5.3)
   rspec-rails (~> 4.0.0)
+  rspec-sidekiq
   rubocop
   rubocop-rails
   sass-rails

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -150,11 +150,11 @@ class DistributionsController < ApplicationController
   end
 
   def send_notification(org, dist, subject: 'Your Distribution')
-    PartnerMailerJob.perform_async(org, dist, subject) if Flipper.enabled?(:email_active)
+    PartnerMailerJob.perform_now(org, dist, subject) if Flipper.enabled?(:email_active)
   end
 
   def schedule_reminder_email(dist)
-    DistributionReminderJob.perform_async(dist)
+    DistributionReminderJob.perform_now(dist)
   end
 
   def distribution_params

--- a/app/jobs/add_diaper_partner_job.rb
+++ b/app/jobs/add_diaper_partner_job.rb
@@ -1,5 +1,4 @@
-class AddDiaperPartnerJob
-  include Sidekiq::Worker
+class AddDiaperPartnerJob < ApplicationJob
   include DiaperPartnerClient
 
   def perform(partner_id, options = {})

--- a/app/jobs/distribution_reminder_job.rb
+++ b/app/jobs/distribution_reminder_job.rb
@@ -1,9 +1,10 @@
 # This job notifies a Partner that they have a distribution scheduled to be sent in 24 hours
-class DistributionReminderJob
-  include Sidekiq::Worker
-
+class DistributionReminderJob < ApplicationJob
   def perform(dist_id)
     distribution = Distribution.find(dist_id)
+
+    # NOTE: This is being also checked in the DistributionMailer itself
+    return if distribution.past? || !distribution.partner.send_reminders
     DistributionMailer.delay_until(distribution.issued_at - 1.day).reminder_email(distribution)
   end
 end

--- a/app/jobs/distribution_reminder_job.rb
+++ b/app/jobs/distribution_reminder_job.rb
@@ -5,6 +5,7 @@ class DistributionReminderJob < ApplicationJob
 
     # NOTE: This is being also checked in the DistributionMailer itself
     return if distribution.past? || !distribution.partner.send_reminders
+
     DistributionMailer.delay_until(distribution.issued_at - 1.day).reminder_email(distribution)
   end
 end

--- a/app/jobs/partner_mailer_job.rb
+++ b/app/jobs/partner_mailer_job.rb
@@ -1,7 +1,5 @@
 # This job notifies a Partner that they have a pending distribution
-class PartnerMailerJob
-  include Sidekiq::Worker
-
+class PartnerMailerJob < ApplicationJob
   def perform(org_id, dist_id, subject)
     current_organization = Organization.find(org_id)
     distribution = Distribution.find(dist_id)

--- a/app/jobs/reminder_deadline_job.rb
+++ b/app/jobs/reminder_deadline_job.rb
@@ -1,6 +1,7 @@
 class ReminderDeadlineJob < ApplicationJob
   def perform
     if Flipper.enabled?(:reminders_active)
+      # TODO: This query can probably be improved
       organizations = Organization.where('reminder_day = ? and deadline_day is not null', Date.current.day)
       organizations.each do |organization|
         organization.partners.where(send_reminders: true).each do |partner|

--- a/app/jobs/reminder_deadline_job.rb
+++ b/app/jobs/reminder_deadline_job.rb
@@ -1,6 +1,4 @@
-class ReminderDeadlineJob
-  include Sidekiq::Worker
-
+class ReminderDeadlineJob < ApplicationJob
   def perform
     if Flipper.enabled?(:reminders_active)
       organizations = Organization.where('reminder_day = ? and deadline_day is not null', Date.current.day)

--- a/app/jobs/update_diaper_partner_job.rb
+++ b/app/jobs/update_diaper_partner_job.rb
@@ -1,11 +1,13 @@
 # Creates a job for indicating that a Partner has been invited, and notifies the PartnerBase system about them
 class UpdateDiaperPartnerJob < ApplicationJob
-  include DiaperPartnerClient
-
   def perform(partner_id)
     @partner = Partner.find(partner_id)
     @invitation_message = @partner.organization.invitation_text
     @response = DiaperPartnerClient.post(@partner.attributes, @invitation_message) if Flipper.enabled?(:email_active)
-    @partner.invited!
+    if @response == Net::HTTPSuccess
+      @partner.invited!
+    else
+      @partner.error!
+    end
   end
 end

--- a/app/jobs/update_diaper_partner_job.rb
+++ b/app/jobs/update_diaper_partner_job.rb
@@ -1,6 +1,5 @@
 # Creates a job for indicating that a Partner has been invited, and notifies the PartnerBase system about them
-class UpdateDiaperPartnerJob
-  include Sidekiq::Worker
+class UpdateDiaperPartnerJob < ApplicationJob
   include DiaperPartnerClient
 
   def perform(partner_id)

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -59,11 +59,11 @@ class Partner < ApplicationRecord
   end
 
   def register_on_partnerbase
-    UpdateDiaperPartnerJob.perform_async(id)
+    UpdateDiaperPartnerJob.perform_now(id)
   end
 
   def add_user_on_partnerbase(options = {})
-    AddDiaperPartnerJob.perform_async(id, options)
+    AddDiaperPartnerJob.perform_now(id, options)
   end
 
   def quantity_year_to_date

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -15,7 +15,7 @@ class DistributionCreateService
       @distribution.storage_location.decrease_inventory @distribution
       @distribution.reload
       @request&.update!(distribution_id: @distribution.id, status: 'fulfilled')
-      PartnerMailerJob.perform_async(@organization.id, @distribution.id, 'Your Distribution') if Flipper.enabled?(:email_active)
+      PartnerMailerJob.perform_now(@organization.id, @distribution.id, 'Your Distribution') if Flipper.enabled?(:email_active)
     end
   rescue Errors::InsufficientAllotment => e
     @distribution.line_items.assign_insufficiency_errors(e.insufficient_items)

--- a/spec/jobs/distribution_reminder_mailer_job_spec.rb
+++ b/spec/jobs/distribution_reminder_mailer_job_spec.rb
@@ -14,22 +14,22 @@ RSpec.describe DistributionReminderJob, type: :job do
 
     it "does not send mail for past distributions" do
       DistributionReminderJob.perform_now(past_distribution.id)
-      expect(DistributionMailer.method :reminder_email).not_to be_delayed(past_distribution)
+      expect(DistributionMailer.method(:reminder_email)).not_to be_delayed(past_distribution)
     end
 
     it "sends mail for future distributions" do
       DistributionReminderJob.perform_now(future_distribution.id)
-      expect(DistributionMailer.method :reminder_email).to be_delayed(future_distribution).until future_distribution.issued_at - 1.day 
+      expect(DistributionMailer.method(:reminder_email)).to be_delayed(future_distribution).until future_distribution.issued_at - 1.day
     end
 
     it "does not send mail for future distributions if the partner wants no reminders" do
       DistributionReminderJob.perform_now(distribution_without_reminder.id)
-      expect(DistributionMailer.method :reminder_email).not_to be_delayed(distribution_without_reminder)
+      expect(DistributionMailer.method(:reminder_email)).not_to be_delayed(distribution_without_reminder)
     end
 
     it "sends mail for future distributions where the partner wants reminders" do
       DistributionReminderJob.perform_now(distribution_with_reminder.id)
-      expect(DistributionMailer.method :reminder_email).to be_delayed(distribution_with_reminder).until distribution_with_reminder.issued_at - 1.day       
+      expect(DistributionMailer.method(:reminder_email)).to be_delayed(distribution_with_reminder).until distribution_with_reminder.issued_at - 1.day
     end
   end
 end

--- a/spec/jobs/distribution_reminder_mailer_job_spec.rb
+++ b/spec/jobs/distribution_reminder_mailer_job_spec.rb
@@ -1,19 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe DistributionReminderJob, type: :job do
-  describe '#perform' do
-    let(:organization) { create :organization }
-    let(:distribution) { create :distribution }
-
-    it 'sends an email' do
-      Sidekiq::Testing.inline! do
-        expect do
-          DistributionReminderJob.perform_later(distribution.id)
-        end .to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
-    end
-  end
-
   describe "conditionally sending the emails" do
     let(:organization) { create :organization }
 

--- a/spec/jobs/distribution_reminder_mailer_job_spec.rb
+++ b/spec/jobs/distribution_reminder_mailer_job_spec.rb
@@ -5,18 +5,10 @@ RSpec.describe DistributionReminderJob, type: :job do
     let(:organization) { create :organization }
     let(:distribution) { create :distribution }
 
-    it 'adds job to the queue' do
-      Sidekiq::Testing.fake! do
-        expect do
-          DistributionReminderJob.perform_async(distribution.id)
-        end.to change(DistributionReminderJob.jobs, :size).by(1)
-      end
-    end
-
     it 'sends an email' do
       Sidekiq::Testing.inline! do
         expect do
-          DistributionReminderJob.perform_async(distribution.id)
+          DistributionReminderJob.perform_later(distribution.id)
         end .to change { ActionMailer::Base.deliveries.count }.by(1)
       end
     end
@@ -34,35 +26,23 @@ RSpec.describe DistributionReminderJob, type: :job do
     let(:distribution_with_reminder) { create(:distribution, partner: partner_with_reminders) }
 
     it "does not send mail for past distributions" do
-      Sidekiq::Testing.inline! do
-        expect do
-          DistributionReminderJob.perform_async(past_distribution.id)
-        end.to_not change { ActionMailer::Base.deliveries.count }
-      end
+      DistributionReminderJob.perform_now(past_distribution.id)
+      expect(DistributionMailer.method :reminder_email).not_to be_delayed(past_distribution)
     end
 
     it "sends mail for future distributions" do
-      Sidekiq::Testing.inline! do
-        expect do
-          DistributionReminderJob.perform_async(future_distribution.id)
-        end.to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
+      DistributionReminderJob.perform_now(future_distribution.id)
+      expect(DistributionMailer.method :reminder_email).to be_delayed(future_distribution).until future_distribution.issued_at - 1.day 
     end
 
     it "does not send mail for future distributions if the partner wants no reminders" do
-      Sidekiq::Testing.inline! do
-        expect do
-          DistributionReminderJob.perform_async(distribution_without_reminder.id)
-        end.to_not change { ActionMailer::Base.deliveries.count }
-      end
+      DistributionReminderJob.perform_now(distribution_without_reminder.id)
+      expect(DistributionMailer.method :reminder_email).not_to be_delayed(distribution_without_reminder)
     end
 
     it "sends mail for future distributions where the partner wants reminders" do
-      Sidekiq::Testing.inline! do
-        expect do
-          DistributionReminderJob.perform_async(distribution_with_reminder.id)
-        end.to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
+      DistributionReminderJob.perform_now(distribution_with_reminder.id)
+      expect(DistributionMailer.method :reminder_email).to be_delayed(distribution_with_reminder).until distribution_with_reminder.issued_at - 1.day       
     end
   end
 end

--- a/spec/jobs/partner_mailer_job_spec.rb
+++ b/spec/jobs/partner_mailer_job_spec.rb
@@ -1,28 +1,4 @@
-require 'spec_helper'
-
 RSpec.describe PartnerMailerJob, type: :job do
-  describe '#perform' do
-    let(:organization) { create :organization }
-    let(:distribution) { create :distribution }
-    let(:mailer_subject) { 'PartnerMailerJob subject' }
-
-    it 'adds job to the queue' do
-      Sidekiq::Testing.fake! do
-        expect do
-          PartnerMailerJob.perform_async(organization.id, distribution.id, mailer_subject)
-        end.to change(PartnerMailerJob.jobs, :size).by(1)
-      end
-    end
-
-    it 'sends an email' do
-      Sidekiq::Testing.inline! do
-        expect do
-          PartnerMailerJob.perform_async(organization.id, distribution.id, mailer_subject)
-        end .to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
-    end
-  end
-
   describe "conditionally sending the emails" do
     let(:organization) { create :organization }
     let(:mailer_subject) { 'PartnerMailerJob subject' }
@@ -32,19 +8,15 @@ RSpec.describe PartnerMailerJob, type: :job do
     let(:future_distribution) { create(:distribution, issued_at: Time.zone.now + 1.week) }
 
     it "does not send mail for past distributions" do
-      Sidekiq::Testing.inline! do
-        expect do
-          PartnerMailerJob.perform_async(organization.id, past_distribution.id, mailer_subject)
-        end.to_not change { ActionMailer::Base.deliveries.count }
-      end
+      expect do
+        PartnerMailerJob.perform_now(organization.id, past_distribution.id, mailer_subject)
+      end.not_to change { ActionMailer::Base.deliveries.count }
     end
 
-    it "sends mail for future distributions" do
-      Sidekiq::Testing.inline! do
-        expect do
-          PartnerMailerJob.perform_async(organization.id, distribution.id, mailer_subject)
-        end.to change { ActionMailer::Base.deliveries.count }.by(1)
-      end
+    it "sends mail for future distributions immediately" do
+      expect do
+        PartnerMailerJob.perform_now(organization.id, future_distribution.id, mailer_subject)
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
   end
 end

--- a/spec/jobs/reminder_deadline_job_spec.rb
+++ b/spec/jobs/reminder_deadline_job_spec.rb
@@ -1,85 +1,86 @@
 require 'spec_helper'
 
 RSpec.describe ReminderDeadlineJob, type: :job do
+  let(:todays_day) { 10 }
+  let(:not_today) { 11 }
+  let(:deadline_day) { 20 }
+
   describe '#perform' do
-    let(:organization) { create :organization, reminder_day: Date.current.day, deadline_day: Date.current.day + 10 }
+    let(:complete_organization) { create :organization, reminder_day: todays_day, deadline_day: deadline_day }
 
     before do
-      travel_to Date.new(2019, 6, 10)
+      Organization.destroy_all
+      Partner.destroy_all
+      travel_to Date.new(2019, 6, todays_day)
     end
 
     after do
       travel_back
     end
 
-    it 'adds job to the queue' do
-      Sidekiq::Testing.fake! do
-        expect do
-          ReminderDeadlineJob.perform_async
-        end.to change(ReminderDeadlineJob.jobs, :size).by(1)
-      end
-    end
+    context 'partner with send reminders active, a reminder day set to today, and a deadline day set' do
+      let!(:partner) { create :partner, organization: complete_organization, send_reminders: true }
 
-    it 'sends an email' do
-      with_features reminders_active: true do
-        Sidekiq::Testing.inline! do
+      it "sends Reminder deadline e-mail to the organization's partner" do
+        with_features reminders_active: true do
           expect do
-            ReminderDeadlineJob.perform_async
+            ReminderDeadlineJob.perform_now
           end.to change { ActionMailer::Base.deliveries.count }.by(1)
         end
       end
     end
 
-    context 'partner with send reminders active' do
-      let(:partner) { create :partner, organization: organization }
+    context 'partner inactivated send reminders' do
+      let(:partner) { create :partner, organization: complete_organization, send_reminders: false }
 
-      it 'executes perform' do
-        Sidekiq::Testing.inline! do
+      it 'does not send the notify deadline e-mail' do
+        with_features reminders_active: true do
+          expect(ReminderDeadlineMailer).not_to receive(:notify_deadline)
           expect do
-            expect(ReminderDeadlineMailer).to receive(:notify_deadline).with(partner, organization)
-            ReminderDeadlineJob.perform_async
-          end
+            ReminderDeadlineJob.perform_now
+          end.not_to change { ActionMailer::Base.deliveries.count }
         end
       end
     end
 
-    context 'partner without send reminders active' do
-      let(:partner) { create :partner, organization: organization, send_reminders: false }
+    context 'organization without deadline dates' do
+      let(:incomplete_organization) { create :organization, reminder_day: todays_day, deadline_day: nil }
+      let(:partner) { create :partner, organization: incomplete_organization }
 
-      it 'executes perform' do
-        Sidekiq::Testing.inline! do
+      it 'does not send the notify deadline email' do
+        with_features reminders_active: true do
+          expect(ReminderDeadlineMailer).not_to receive(:notify_deadline)
           expect do
-            expect(ReminderDeadlineMailer).not_to receive(:notify_deadline)
-            ReminderDeadlineJob.perform_async
-          end
+            ReminderDeadlineJob.perform_now
+          end.not_to change { ActionMailer::Base.deliveries.count }
         end
       end
     end
 
-    context 'organization without reminder and deadline dates' do
-      let(:organization) { create :organization, reminder_day: nil, deadline_day: nil }
-      let(:partner) { create :partner, organization: organization }
+    context 'organization with deadline dates, but no reminder day' do
+      let(:incomplete_organization) { create :organization, reminder_day: nil, deadline_day: deadline_day }
+      let(:partner) { create :partner, organization: incomplete_organization }
 
-      it 'executes perform' do
-        Sidekiq::Testing.inline! do
+      it 'does not send the notify deadline email' do
+        with_features reminders_active: true do
+          expect(ReminderDeadlineMailer).not_to receive(:notify_deadline)
           expect do
-            expect(ReminderDeadlineMailer).not_to receive(:notify_deadline)
-            ReminderDeadlineJob.perform_async
-          end
+            ReminderDeadlineJob.perform_now
+          end.not_to change { ActionMailer::Base.deliveries.count }
         end
       end
     end
 
-    context 'organization with 11 as reminder date' do
-      let(:organization) { create :organization, reminder_day: 11, deadline_day: 21 }
-      let(:partner) { create :partner, organization: organization }
+    context 'organization with a reminder and deadline date set, but when today is not the reminder day' do
+      let(:indifferent_organization) { create :organization, reminder_day: not_today, deadline_day: deadline_day }
+      let(:partner) { create :partner, organization: indifferent_organization }
 
-      it 'executes perform' do
-        Sidekiq::Testing.inline! do
+      it 'does not send the notify deadline email' do
+        with_features reminders_active: true do
+          expect(ReminderDeadlineMailer).not_to receive(:notify_deadline)
           expect do
-            expect(ReminderDeadlineMailer).not_to receive(:notify_deadline)
-            ReminderDeadlineJob.perform_async
-          end
+            ReminderDeadlineJob.perform_now
+          end.not_to change { ActionMailer::Base.deliveries.count }
         end
       end
     end

--- a/spec/jobs/update_diaper_partner_job_spec.rb
+++ b/spec/jobs/update_diaper_partner_job_spec.rb
@@ -9,18 +9,16 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
 
       it "checks the partner status is default set to pending" do
         with_features email_active: true do
-          Sidekiq::Testing.inline! do
-            expect do
-              UpdateDiaperPartnerJob.perform_later(@partner.id)
-              @partner.reload
-            end
-            expect(@partner.status).to eq("uninvited")
+          expect do
+            UpdateDiaperPartnerJob.perform_now(@partner.id)
+            @partner.reload
           end
+          expect(@partner.status).to eq("uninvited")
         end
       end
     end
 
-    context "with a unsuccessful POST response" do
+    context "with an unsuccessful POST response" do
       before do
         @partner = create(:partner)
         response = double("Response", value: nil)
@@ -28,27 +26,19 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
       end
 
       it "sets the partner status to error" do
-        pending
         with_features email_active: true do
-          Sidekiq::Testing.inline! do
-            expect do
-              UpdateDiaperPartnerJob.perform_later(@partner.id)
-              @partner.reload
-            end.to change { @partner.status }.to("error")
-          end
+          expect do
+            UpdateDiaperPartnerJob.perform_now(@partner.id)
+            @partner.reload
+          end.to change { @partner.status }.to("error")
         end
       end
 
       it "posts via DiaperPartnerClient" do
         with_features email_active: true do
-          Sidekiq::Testing.inline! do
-            partner = create(:partner)
-            allow(Flipper).to receive(:enabled?) { true }
-
-            expect(DiaperPartnerClient).to receive(:post)
-
-            UpdateDiaperPartnerJob.perform_later(partner.id)
-          end
+          allow(Flipper).to receive(:enabled?) { true }
+          expect(DiaperPartnerClient).to receive(:post)
+          UpdateDiaperPartnerJob.perform_now(@partner.id)
         end
       end
     end

--- a/spec/jobs/update_diaper_partner_job_spec.rb
+++ b/spec/jobs/update_diaper_partner_job_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
 
       it "posts via DiaperPartnerClient" do
         with_features email_active: true do
-          allow(Flipper).to receive(:enabled?) { true }
           expect(DiaperPartnerClient).to receive(:post)
           UpdateDiaperPartnerJob.perform_now(@partner.id)
         end

--- a/spec/jobs/update_diaper_partner_job_spec.rb
+++ b/spec/jobs/update_diaper_partner_job_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
         # match what is actually happening.
         allow(DiaperPartnerClient).to receive(:post)
           .with(fake_partner.attributes.merge({ organization_email: fake_organization_email }), fake_invitation_text)
-          .and_return({})
+          .and_return(Net::HTTPSuccess)
 
         allow(fake_partner).to receive(:invited!)
       end

--- a/spec/jobs/update_diaper_partner_job_spec.rb
+++ b/spec/jobs/update_diaper_partner_job_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
         with_features email_active: true do
           Sidekiq::Testing.inline! do
             expect do
-              UpdateDiaperPartnerJob.perform_async(@partner.id)
+              UpdateDiaperPartnerJob.perform_later(@partner.id)
               @partner.reload
             end
             expect(@partner.status).to eq("uninvited")
@@ -32,7 +32,7 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
         with_features email_active: true do
           Sidekiq::Testing.inline! do
             expect do
-              UpdateDiaperPartnerJob.perform_async(@partner.id)
+              UpdateDiaperPartnerJob.perform_later(@partner.id)
               @partner.reload
             end.to change { @partner.status }.to("error")
           end
@@ -47,7 +47,7 @@ RSpec.describe UpdateDiaperPartnerJob, job: true do
 
             expect(DiaperPartnerClient).to receive(:post)
 
-            UpdateDiaperPartnerJob.perform_async(partner.id)
+            UpdateDiaperPartnerJob.perform_later(partner.id)
           end
         end
       end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe Partner, type: :model do
     end
 
     it "not send emails after importing a csv file" do
-      expect(UpdateDiaperPartnerJob).not_to receive(:perform_async)
+      expect(UpdateDiaperPartnerJob).not_to receive(:perform_now)
 
       import_file_path = Rails.root.join("spec", "fixtures", "partners.csv")
       data = File.read(import_file_path, encoding: "BOM|UTF-8")

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe "Partners", type: :request do
 
   describe "POST #invite" do
     it "send the invite" do
-      expect(UpdateDiaperPartnerJob).to receive(:perform_async)
+      expect(UpdateDiaperPartnerJob).to receive(:perform_now)
       post invite_partner_path(default_params.merge(id: create(:partner, organization: @organization)))
       expect(response).to have_http_status(:found)
     end

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe DistributionCreateService, type: :service do
     end
 
     it "Sends a PartnerMailer" do
-      expect(PartnerMailerJob).to receive(:perform_async).once
+      expect(PartnerMailerJob).to receive(:perform_now).once
       allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
       subject.new(distribution_params).call
     end

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -21,7 +21,7 @@ RSpec.feature "Distributions", type: :system do
 
         expect do
           click_button "Save", match: :first
-        end.to change { PartnerMailerJob.jobs.size }.by(1)
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
 
         expect(page).to have_content "Distributions"
         expect(page.find(".alert-info")).to have_content "reated"
@@ -38,7 +38,7 @@ RSpec.feature "Distributions", type: :system do
         select @partner.name, from: "Partner"
         expect do
           click_button "Save"
-        end.not_to change { PartnerMailerJob.jobs.size }
+        end.not_to change { ActionMailer::Base.deliveries.count }
 
         # verify line items appear on reload
         expect(page).to have_content "New Distribution"


### PR DESCRIPTION
Resolves #1588

### Description
Paired with @coderpaz 

This ticket was originally for a trivial change: setting all jobs to inherit from ApplicationJob. We quickly encountered an error -- the jobs all had `include Sidekiq::Worker` mixed-in, but Sidekiq doesn't like that. The author of Sidekiq explicitly said that you should not be mixing it in with ActiveJob descendants. We already had Sidekiq set as the queue adapter, so we just removed the `include` reference.

That broke some specs. The specs were inappropriately intimate with Sidekiq in general, rather than working through the ActiveJob API. We added the `rspec-sidekiq` gem, which gave some new ways of verifying Job status. We removed all the "Sidekiq::Inline" blocks, and replaced `perform_async` with `perform_now`. 

In all of this, we discovered three bigger issues, which were also addressed:
1) Many of the specs weren't actually testing what they said they were.
2) There was an Inefficiency in `DistributionReminderEmail` -- it would allow the work to be queued up in an async queue whether or not the job would even be valid when it executed. Instead, we're pre-checking to see if it's valid for mailing before adding it to the queue.
3) There was a bug in `UpdateDiaperPartnerJob`, where the status of the API call was not being checked before deciding whether or not to set the partner's status to "active". This has never been an issue because we control both sides of the API so it's never errored (I'm guessing).

### Type of change
* Bug fix (non-breaking change which fixes an issue)
* Spec fix

### How Has This Been Tested?
Fixed specs