### PR TITLE
Changing the name of the query parameter sent when getting aggregate data

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -31,6 +31,7 @@ class PartnersController < ApplicationController
   end
 
   def show
+    @impact_metrics = DiaperPartnerClient.get(id: params[:id], query_params: { impact_metrics: true })
     @partner = current_organization.partners.find(params[:id])
   end
 

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -15,9 +15,21 @@ RSpec.describe "Partners", type: :request do
   end
 
   describe "GET #show" do
+    let(:partner) { create(:partner, organization: @organization) }
+    let(:fake_get_return) do
+      {
+        family_count: Faker::Number.number
+      }
+    end
+
+    before do
+      allow(DiaperPartnerClient).to receive(:get).with(id: partner.to_param, query_params: { impact_metrics: true }).and_return(fake_get_return)
+    end
+
     it "returns http success" do
-      get partner_path(default_params.merge(id: create(:partner, organization: @organization)))
+      get partner_path(default_params.merge(id: partner))
       expect(response).to be_successful
+      expect(assigns[:impact_metrics]).to eq(fake_get_return)
     end
   end
 

--- a/spec/services/diaper_partner_client_spec.rb
+++ b/spec/services/diaper_partner_client_spec.rb
@@ -33,10 +33,10 @@ RSpec.describe DiaperPartnerClient, type: :service do
     end
 
     context 'with query_params' do
-      let(:query_params) { { additional_details: true } }
+      let(:query_params) { { impact_metrics: true } }
 
       it 'performs a GET request' do
-        stub_partner_request(:get, "https://partner-register.com/#{fake_random_id}?additional_details=true")
+        stub_partner_request(:get, "https://partner-register.com/#{fake_random_id}?impact_metrics=true")
         result = DiaperPartnerClient.get({ id: fake_random_id }, query_params: query_params)
         expect(result).to eq 'success'
       end


### PR DESCRIPTION
Per notes in #1606, we're getting aggregate data rather than detailed family and children data, so we've changed the name of the query parameter to check for. This change adjusts the API call to use the new query parameter (`additional_data` changed to `impact_metrics`)

Co-authored-by: Alicia Barrett <Aliciawyse@users.noreply.github.com>

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),

-->

Resolves #1605 (take 2)

### Description
Just a change to a parameter name. 

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

RSpec unit test change

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

