### PR TITLE
Improve partners request spec, add spec for add diaper partner job

### DIFF
--- a/spec/jobs/add_diaper_partner_job_spec.rb
+++ b/spec/jobs/add_diaper_partner_job_spec.rb
@@ -13,17 +13,15 @@ RSpec.describe AddDiaperPartnerJob, job: true do
       end
 
       it "invokes add method on diaper partner client with proper arguments" do
-        Sidekiq::Testing.inline! do
-          AddDiaperPartnerJob.perform_async(partner.id, email: 'test@test.com')
+        AddDiaperPartnerJob.perform_now(partner.id, email: 'test@test.com')
 
-          expect(DiaperPartnerClient).to have_received(:add) do |partner_data, invitation_text|
-            expect(invitation_text).to eq 'Invitation'
-            expect(partner_data).to include('email' => 'test@test.com',
-                                            'name' => partner.name,
-                                            'organization_id' => partner.organization_id,
-                                            'status' => partner.status,
-                                            'send_reminders' => partner.send_reminders)
-          end
+        expect(DiaperPartnerClient).to have_received(:add) do |partner_data, invitation_text|
+          expect(invitation_text).to eq 'Invitation'
+          expect(partner_data).to include('email' => 'test@test.com',
+                                          'name' => partner.name,
+                                          'organization_id' => partner.organization_id,
+                                          'status' => partner.status,
+                                          'send_reminders' => partner.send_reminders)
         end
       end
     end

--- a/spec/jobs/add_diaper_partner_job_spec.rb
+++ b/spec/jobs/add_diaper_partner_job_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe AddDiaperPartnerJob, job: true do
+  describe "#perform" do
+    let(:partner) do
+      partner = create(:partner)
+      partner.organization.update!(invitation_text: 'Invitation')
+      partner
+    end
+
+    context "successful diaper client request" do
+      before do
+        response = double("Response", value: Net::HTTPSuccess)
+        allow(DiaperPartnerClient).to receive(:add).and_return(response)
+      end
+
+      it "invokes add method on diaper partner client with proper arguments" do
+        Sidekiq::Testing.inline! do
+          AddDiaperPartnerJob.perform_async(partner.id, email: 'test@test.com')
+
+          expect(DiaperPartnerClient).to have_received(:add) do |partner_data, invitation_text|
+            expect(invitation_text).to eq 'Invitation'
+            expect(partner_data).to include('email' => 'test@test.com',
+                                            'name' => partner.name,
+                                            'organization_id' => partner.organization_id,
+                                            'status' => partner.status,
+                                            'send_reminders' => partner.send_reminders)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
References https://github.com/rubyforgood/diaper/issues/1024

### Description
This PR is adding tests for AddDiaperPartnerJob, and a request test for GET /:organization_id/partners/:id/approve_application endpoint

### Type of change

- Improvement

### How Has This Been Tested?
With Rspec and Rubocop.

### Screenshots
![Screenshot from 2020-04-07 18-05-02](https://user-images.githubusercontent.com/7805837/78692719-91b5f680-78fa-11ea-8868-85ef02c75d40.png)
![Screenshot from 2020-04-08 14-41-32](https://user-images.githubusercontent.com/7805837/78785370-57eef980-79a7-11ea-9b78-d40d56147a71.png)
