### PR TITLE
Refactor DistributionDestroyService with spec coverage

### DIFF
--- a/app/services/distribution_destroy_service.rb
+++ b/app/services/distribution_destroy_service.rb
@@ -30,5 +30,4 @@ class DistributionDestroyService
   def success?
     @error.nil?
   end
-
 end

--- a/app/services/distribution_destroy_service.rb
+++ b/app/services/distribution_destroy_service.rb
@@ -1,16 +1,34 @@
 class DistributionDestroyService
+  attr_reader :distribution, :error
+
   def initialize(distribution_id)
-    @distribution = Distribution.find(distribution_id)
+    @distribution_id = distribution_id
   end
 
   def call
+    @distribution = Distribution.find(@distribution_id)
+    @organization = distribution.organization
+
     @distribution.transaction do
       @distribution.destroy!
-      @distribution.storage_location.increase_inventory @distribution
-      OpenStruct.new(success?: true)
+      @distribution.storage_location.increase_inventory(@distribution)
     end
+  rescue ActiveRecord::RecordNotFound => e
+    Rails.logger.error "[!] DistributionsController#destroy failed to destroy distribution #{@distribution_id} because it does not exist"
+    @error = e
+  rescue Errors::InsufficientAllotment => e
+    @distribution.line_items.assign_insufficiency_errors(e.insufficient_items)
+    Rails.logger.error "[!] DistributionsController#destroy failed because of Insufficient Allotment #{@organization.short_name}: #{@distribution.errors.full_messages} [#{e.message}]"
+    @error = e
   rescue StandardError => e
     Rails.logger.error "[!] DistributionsController#destroy failed to destroy distribution for #{@distribution.organization.short_name}: #{@distribution.errors.full_messages} [#{e.inspect}]"
-    OpenStruct.new(success: false, distribution: @distribution, error: e)
+    @error = e
+  ensure
+    return self
   end
+
+  def success?
+    @error.nil?
+  end
+
 end

--- a/spec/services/distribution_destroy_service_spec.rb
+++ b/spec/services/distribution_destroy_service_spec.rb
@@ -1,0 +1,115 @@
+require 'rails_helper'
+
+describe DistributionDestroyService do
+
+  describe '#call' do
+    subject { described_class.new(distribution_id).call }
+    let(:distribution_id) { Faker::Number.number }
+
+    context 'when the distribution_id matches no Distribution' do
+      before do
+        allow(Distribution).to receive(:find)
+          .with(distribution_id)
+          .and_raise(ActiveRecord::RecordNotFound)
+      end
+
+      it 'to not be a success' do
+        result = subject.call
+        expect(result).not_to be_success
+      end
+    end
+
+    context 'when the distribution_id does match a Distribution' do
+      let!(:distribution) { create(:distribution, organization: create(:organization)) }
+
+      before do
+        # Use this approach to so that I can force outcomes on the
+        # instance of distribution that the service object is using.
+        allow(Distribution).to receive(:find).
+          with(distribution_id).
+          and_return(distribution)
+      end
+
+      context 'and the operations suceed' do
+        let(:fake_storage_location) { instance_double(StorageLocation) }
+        before do
+          allow(distribution).to receive(:storage_location).and_return(fake_storage_location)
+          allow(fake_storage_location).to receive(:increase_inventory)
+        end
+
+        it 'should destroy the Distribution' do
+          expect { subject }.to change { Distribution.count }.by(-1)
+        end
+
+        it 'should be successful' do
+          result = subject
+          expect(result).to be_success
+        end
+
+        it 'should increase the inventory of the storage location' do
+          subject
+          expect(fake_storage_location).to have_received(:increase_inventory).with(distribution)
+        end
+      end
+
+      context 'and the destroy! operation fails' do
+        let(:fake_destroy_error) { 'booom' }
+
+        before do
+          allow(distribution).to receive(:destroy!).and_raise(
+            StandardError.new(fake_destroy_error)
+          )
+        end
+
+        it 'should not delete the Distribution' do
+          expect { subject }.not_to change { Distribution.count }
+        end
+
+        it 'should not be successful and have the error message' do
+          result = subject
+          expect(result).not_to be_success
+          expect(result.error).to be_instance_of(StandardError)
+          expect(result.error.message).to eq(fake_destroy_error)
+        end
+      end
+
+      context 'and the increase inventory operations fails' do
+        let(:fake_storage_location) { instance_double(StorageLocation) }
+        let(:fake_insufficient_allotment_error) do
+          Errors::InsufficientAllotment.new(
+            fake_error_message,
+            fake_insufficient_items
+          )
+        end
+        let(:fake_error_message) { Faker::Lorem.sentence }
+        let(:fake_insufficient_items) do
+          [
+            {
+              item_id: Faker::Number.number,
+              item: Faker::Lorem.word,
+              quantity_on_hand: Faker::Number.number,
+              quantity_requested: Faker::Number.number
+            }
+          ]
+        end
+
+        before do
+          allow(distribution).to receive(:storage_location).and_return(fake_storage_location)
+          allow(fake_storage_location).to receive(:increase_inventory)
+            .with(distribution)
+            .and_raise(fake_insufficient_allotment_error)
+        end
+
+        it 'should not delete the Distribution' do
+          expect { subject }.not_to change { Distribution.count }
+        end
+
+        it 'should not be successful and have the error message' do
+          result = subject
+          expect(result).not_to be_success
+          expect(result.error).to be_instance_of(Errors::InsufficientAllotment)
+        end
+      end
+    end
+  end
+end

--- a/spec/services/distribution_destroy_service_spec.rb
+++ b/spec/services/distribution_destroy_service_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe DistributionDestroyService do
-
   describe '#call' do
     subject { described_class.new(distribution_id).call }
     let(:distribution_id) { Faker::Number.number }
@@ -25,9 +24,9 @@ describe DistributionDestroyService do
       before do
         # Use this approach to so that I can force outcomes on the
         # instance of distribution that the service object is using.
-        allow(Distribution).to receive(:find).
-          with(distribution_id).
-          and_return(distribution)
+        allow(Distribution).to receive(:find)
+          .with(distribution_id)
+          .and_return(distribution)
       end
 
       context 'and the operations suceed' do


### PR DESCRIPTION
Resolves #1583

### Description

This PR transforms the `DistributionDestroyService` to match more of what the Create / Update services for Distribution are like. This was done in preparation for DRYing up code with a superclass mentioned here https://github.com/rubyforgood/diaper/issues/1584

- Updated logic to include the case where the ID doesn't match any Distribution
- Add spec coverage for `DistributionDestroyService`
