### PR TITLE
Fix to dashboard display issues that were pointed out by a stakeholder.

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -186,9 +186,9 @@
             <div class="position-relative mb-4">
               <div class="box-body text-center float-center">
                 <%= new_button_to new_donation_path, {text: "New Donation"} %>
-                <h3 class="text-center"><%= dollar_value(total_received_money_donations) %> items
+                <h3 class="text-center"><%= total_received_donations %> items
                   received <%= @selected_date_range_label %></h3>
-                <h4 class="text-center">$<%= total_received_money_donations %>
+                <h4 class="text-center"><%= dollar_value(total_received_money_donations) %>
                   raised  <%= @selected_date_range_label %></h4>
                 <div class="box-body">
                   <h4>Recent Donations</h4>
@@ -217,9 +217,9 @@
           <div class="card-body">
             <div class="position-relative mb-4">
               <div class="box-body text-center float-center">
-                <h3 class="text-center"><%= total_received_donations %> items
+                <h3 class="text-center"><%= total_received_from_diaper_drives %> items
                   received <%= @selected_date_range_label %></h3>
-                <h4 class="text-center">$<%= total_received_money_donations %>
+                <h4 class="text-center"><%= dollar_value(total_received_money_donations) %>
                   raised  <%= @selected_date_range_label %></h4>
                 <div class="box-body">
                   <h4>Recent Donations from Diaper Drives</h4>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -15,6 +15,8 @@ require 'webdrivers'
 
 Sidekiq::Testing.fake! # fake is the default mode
 
+SimpleCov.start
+
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in


### PR DESCRIPTION
We had a diaper bank get in contact about some of the display statistics being off on the dashboard. Namely the money was off and the diaper drives were not showing just diaper drive items. We just had the wrong helpers on the various dashboard elements.

This PR fixes that.

Before:
![donations1](https://user-images.githubusercontent.com/667909/80282872-d2c34e80-86e1-11ea-9d5f-3d45404c6f4d.jpg)
![diaper drives1](https://user-images.githubusercontent.com/667909/80282895-f5edfe00-86e1-11ea-8c7e-b032dbbbf169.jpg)

After:
![donations2](https://user-images.githubusercontent.com/667909/80282898-fab2b200-86e1-11ea-84ad-025808dd4508.jpg)
![diaper drives2](https://user-images.githubusercontent.com/667909/80282899-fd150c00-86e1-11ea-8470-756863748abd.jpg)
