### PR TITLE
Allows partners to toggle items between active and inactive. Also fix…

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -113,7 +113,8 @@ class ItemsController < ApplicationController
       :package_size,
       :on_hand_minimum_quantity,
       :on_hand_recommended_quantity,
-      :distribution_quantity
+      :distribution_quantity,
+      :active
     )
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -188,7 +188,7 @@ class Organization < ApplicationRecord
   end
 
   def valid_items
-    items.map do |item|
+    items.active.map do |item|
       {
         id: item.id,
         partner_key: item.partner_key,

--- a/app/views/items/_form.html.erb
+++ b/app/views/items/_form.html.erb
@@ -36,6 +36,9 @@
                 <%= f.input_field :package_size, class: "form-control" %>
               <% end %>
 
+              <%= f.input :active, label: "Item is Active?", wrapper: :input_group do %>
+                <%= f.check_box :active, {class: "input-group-text", id: "active"}, "true", "false" %>
+              <% end %>
             </div>
             <!-- /.card-body -->
             <div class="card-footer">

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -325,6 +325,12 @@ RSpec.describe Organization, type: :model do
       expect(organization.valid_items.count).to eq(organization.items.count)
       expect(organization.valid_items).to include(expected)
     end
+    it 'only shows active valid items' do
+      intial_count = organization.valid_items.count
+      organization.items.last.update(active: false)
+      final_count = organization.valid_items.count
+      expect(intial_count).to_not eq(final_count)
+    end
   end
   describe 'reminder_day' do
     it "can only contain numbers 1-14" do


### PR DESCRIPTION
…es the issue where partners could see all items rather than just the active ones.

Resolves #1642 Resolves #1574 

Added an `Item is Active?` checkbox that corresponds to the boolean field we already have and we set when the item is marked to inactive. Also updated the `valid_items` method that the api uses to only show valid items.