### PR TITLE
Allow partners to not error out when importing duplicates.

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -46,7 +46,7 @@ class Partner < ApplicationRecord
       hash_rows = Hash[row.to_hash.map { |k, v| [k.downcase, v] }]
       loc = Partner.new(hash_rows)
       loc.organization_id = organization_id
-      loc.save!
+      loc.save
     end
   end
 

--- a/spec/fixtures/partners_with_duplicates.csv
+++ b/spec/fixtures/partners_with_duplicates.csv
@@ -1,0 +1,4 @@
+name,email
+Partner 1,partner1@example.com
+Partner 2,partner2@example.com
+Partner 4,partner4@example.com

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -83,16 +83,21 @@ RSpec.describe Partner, type: :model do
   describe "import_csv" do
     let(:organization) { create(:organization) }
 
-    it "imports storage locations from a csv file" do
+    it "imports partners from a csv file and prevents multiple imports" do
       before_import = Partner.count
       import_file_path = Rails.root.join("spec", "fixtures", "partners.csv")
       data = File.read(import_file_path, encoding: "BOM|UTF-8")
       csv = CSV.parse(data, headers: true)
       Partner.import_csv(csv, organization.id)
       expect(Partner.count).to eq before_import + 3
+      import_file_path2 = Rails.root.join("spec", "fixtures", "partners_with_duplicates.csv")
+      data2 = File.read(import_file_path2, encoding: "BOM|UTF-8")
+      csv2 = CSV.parse(data2, headers: true)
+      Partner.import_csv(csv2, organization.id)
+      expect(Partner.count).to eq before_import + 4
     end
 
-    it "imports storage locations from a csv file with BOM encodings" do
+    it "imports partners from a csv file with BOM encodings" do
       import_file_path = Rails.root.join("spec", "fixtures", "partners_with_bom_encoding.csv")
       data = File.read(import_file_path, encoding: "BOM|UTF-8")
       csv = CSV.parse(data, headers: true)


### PR DESCRIPTION
We had a diaper bank complain that they received a 500 message when importing partners. They attempted to import a partner that already existed which caused an error. This PR fixes that and gracefully ignores duplicates.