### PR TITLE
Only send distribution emails to partners requesting emails

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -105,7 +105,7 @@ class DistributionsController < ApplicationController
     result = DistributionUpdateService.new(@distribution, distribution_params).call
 
     if result.success?
-      if result.resend_notification?
+      if result.resend_notification? && @distribution.partner&.send_reminders
         send_notification(current_organization.id, @distribution.id, subject: "Your Distribution New Schedule Date is #{@distribution.issued_at}")
       end
       schedule_reminder_email(@distribution)

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -212,6 +212,15 @@ RSpec.describe "Distributions", type: :request do
             expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
           end
         end
+
+        context "partner reminder sending switched off" do
+          let(:issued_at) { distribution.issued_at + 1.day }
+          before { partner.update!(send_reminders: false) }
+
+          it "does not send the e-mail" do
+            expect { subject }.not_to change { ActionMailer::Base.deliveries.count }
+          end
+        end
       end
     end
   end

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -17,10 +17,24 @@ RSpec.describe DistributionCreateService, type: :service do
       expect(result.distribution).to be_scheduled
     end
 
-    it "Sends a PartnerMailer" do
-      expect(PartnerMailerJob).to receive(:perform_now).once
-      allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
-      subject.new(distribution_params).call
+    context "partner has send reminders setting set to true" do
+      it "Sends a PartnerMailer" do
+        @partner.update!(send_reminders: true)
+        allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
+
+        expect(PartnerMailerJob).to receive(:perform_now).once
+        subject.new(distribution_params).call
+      end
+    end
+
+    context "partner has send reminders setting set to false" do
+      it "does not send a PartnerMailer" do
+        @partner.update!(send_reminders: false)
+        allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
+
+        expect(PartnerMailerJob).not_to receive(:perform_now)
+        subject.new(distribution_params).call
+      end
     end
 
     context "when provided with a request ID" do


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/diaper/issues/1650

### Description
Modified create and update distribution logic so the mail is sent to partners only in case partners want to be notified.


