### PR TITLE
Use object id for distribution reminder mailer

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -155,7 +155,7 @@ class DistributionsController < ApplicationController
   def schedule_reminder_email(distribution)
     return if distribution.past? || !distribution.partner.send_reminders
 
-    DistributionMailer.delay_until(distribution.issued_at - 1.day).reminder_email(distribution)
+    DistributionMailer.delay_until(distribution.issued_at - 1.day).reminder_email(distribution.id)
   end
 
   def distribution_params

--- a/app/mailers/distribution_mailer.rb
+++ b/app/mailers/distribution_mailer.rb
@@ -17,7 +17,8 @@ class DistributionMailer < ApplicationMailer
     mail(to: @partner.email, from: @from_email, subject: "#{subject} from #{current_organization.name}")
   end
 
-  def reminder_email(distribution)
+  def reminder_email(distribution_id)
+    distribution = Distribution.find(distribution_id)
     @partner = distribution.partner
     @distribution = distribution
     return if @distribution.past? || !@partner.send_reminders

--- a/app/services/distribution_reminder.rb
+++ b/app/services/distribution_reminder.rb
@@ -7,7 +7,7 @@ class DistributionReminder
       # NOTE: This is being also checked in the DistributionMailer itself
       return unless send_reminder?(distribution)
 
-      DistributionMailer.delay_until(distribution.issued_at - 1.day).reminder_email(distribution)
+      DistributionMailer.delay_until(distribution.issued_at - 1.day).reminder_email(distribution.id)
     end
 
     private

--- a/spec/mailers/distribution_mailer_spec.rb
+++ b/spec/mailers/distribution_mailer_spec.rb
@@ -1,18 +1,30 @@
 RSpec.describe DistributionMailer, type: :mailer do
   before do
     @organization.default_email_text = "Default email text example"
-    @distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment")
+    partner = create(:partner, name: 'PARTNER')
+    @distribution = create(:distribution, organization: @user.organization, comment: "Distribution comment", partner: partner)
   end
 
-  let(:mail) { DistributionMailer.partner_mailer(@organization, @distribution, 'test subject') }
+  describe "#partner_mailer" do
+    let(:mail) { DistributionMailer.partner_mailer(@organization, @distribution, 'test subject') }
 
-  it "renders the body with organizations email text" do
-    expect(mail.body.encoded).to match("Default email text example")
-    expect(mail.subject).to eq("test subject from DEFAULT")
+    it "renders the body with organizations email text" do
+      expect(mail.body.encoded).to match("Default email text example")
+      expect(mail.subject).to eq("test subject from DEFAULT")
+    end
+
+    it "renders the body with distributions text" do
+      expect(mail.body.encoded).to match("Distribution comment")
+      expect(mail.subject).to eq("test subject from DEFAULT")
+    end
   end
 
-  it "renders the body with distributions text" do
-    expect(mail.body.encoded).to match("Distribution comment")
-    expect(mail.subject).to eq("test subject from DEFAULT")
+  describe "#reminder_email" do
+    let(:mail) { DistributionMailer.reminder_email(@distribution.id) }
+
+    it "renders the body with organizations email text" do
+      expect(mail.body.encoded).to match("This is a friendly reminder")
+      expect(mail.subject).to eq("PARTNER Distribution Reminder")
+    end
   end
 end

--- a/spec/services/distribution_reminder_spec.rb
+++ b/spec/services/distribution_reminder_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe DistributionReminder do
 
     it "sends mail for future distributions" do
       DistributionReminder.perform(future_distribution.id)
-      expect(DistributionMailer.method(:reminder_email)).to be_delayed(future_distribution).until future_distribution.issued_at - 1.day
+      expect(DistributionMailer.method(:reminder_email)).to be_delayed(future_distribution.id).until future_distribution.issued_at - 1.day
     end
 
     it "does not send mail for future distributions if the partner wants no reminders" do
@@ -36,7 +36,7 @@ RSpec.describe DistributionReminder do
 
     it "sends mail for future distributions where the partner wants reminders" do
       DistributionReminder.perform(distribution_with_reminder.id)
-      expect(DistributionMailer.method(:reminder_email)).to be_delayed(distribution_with_reminder).until distribution_with_reminder.issued_at - 1.day
+      expect(DistributionMailer.method(:reminder_email)).to be_delayed(distribution_with_reminder.id).until distribution_with_reminder.issued_at - 1.day
     end
   end
 end

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -129,7 +129,7 @@ RSpec.feature "Distributions", type: :system do
         fill_in "Agency representative", with: "SOMETHING DIFFERENT"
         click_on "Save", match: :first
         distribution.reload
-        expect(DistributionMailer.method(:reminder_email)).to be_delayed(distribution)
+        expect(DistributionMailer.method(:reminder_email)).to be_delayed(distribution.id)
       end
     end
 


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/diaper/issues/1647

### Description
Distribution reminder mailer logic modified to be in compliance with Sidekiq best practices - create mailers with object id instead of the whole object. Also, did a small refactoring on the distribution_mailer_spec so that both methods from the mailer are tested.




