### PR TITLE
Utilize DistributionService superclass on Distribution-like services

### DIFF
--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -1,5 +1,4 @@
 class DistributionCreateService < DistributionService
-
   def initialize(distribution_params, request_id = nil)
     @distribution = Distribution.new(distribution_params)
     @request = Request.find(request_id) if request_id

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -8,18 +8,18 @@ class DistributionCreateService < DistributionService
 
   def call
     perform_distribution_service do
-      @distribution.save!
-      @distribution.scheduled!
-      @distribution.storage_location.decrease_inventory @distribution
-      @distribution.reload
-      @request&.update!(distribution_id: @distribution.id, status: 'fulfilled')
-      send_notification if @distribution.partner&.send_reminders
+      distribution.save!
+      distribution.scheduled!
+      distribution.storage_location.decrease_inventory distribution
+      distribution.reload
+      @request&.update!(distribution_id: distribution.id, status: 'fulfilled')
+      send_notification if distribution.partner&.send_reminders
     end
   end
 
   private
 
   def send_notification
-    PartnerMailerJob.perform_now(distribution_organization.id, @distribution.id, 'Your Distribution') if Flipper.enabled?(:email_active)
+    PartnerMailerJob.perform_now(distribution_organization.id, distribution.id, 'Your Distribution') if Flipper.enabled?(:email_active)
   end
 end

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -1,15 +1,12 @@
-class DistributionCreateService
-  attr_reader :distribution, :error
+class DistributionCreateService < DistributionService
 
   def initialize(distribution_params, request_id = nil)
     @distribution = Distribution.new(distribution_params)
     @request = Request.find(request_id) if request_id
-    @organization = @distribution.organization
-    @error = nil
   end
 
   def call
-    @distribution.transaction do
+    perform_distribution_service do
       @distribution.save!
       @distribution.scheduled!
       @distribution.storage_location.decrease_inventory @distribution
@@ -17,24 +14,11 @@ class DistributionCreateService
       @request&.update!(distribution_id: @distribution.id, status: 'fulfilled')
       send_notification if @distribution.partner&.send_reminders
     end
-  rescue Errors::InsufficientAllotment => e
-    @distribution.line_items.assign_insufficiency_errors(e.insufficient_items)
-    Rails.logger.error "[!] DistributionsController#create failed because of Insufficient Allotment #{@organization.short_name}: #{@distribution.errors.full_messages} [#{e.message}]"
-    @error = e
-  rescue StandardError => e
-    Rails.logger.error "[!] DistributionsController#create failed to save distribution for #{@organization.short_name}: #{@distribution.errors.full_messages} [#{e.inspect}]"
-    @error = e
-  ensure
-    return self
-  end
-
-  def success?
-    @error.nil?
   end
 
   private
 
   def send_notification
-    PartnerMailerJob.perform_now(@organization.id, @distribution.id, 'Your Distribution') if Flipper.enabled?(:email_active)
+    PartnerMailerJob.perform_now(distribution_organization.id, @distribution.id, 'Your Distribution') if Flipper.enabled?(:email_active)
   end
 end

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -1,4 +1,6 @@
 class DistributionCreateService < DistributionService
+  attr_reader :distribution
+
   def initialize(distribution_params, request_id = nil)
     @distribution = Distribution.new(distribution_params)
     @request = Request.find(request_id) if request_id

--- a/app/services/distribution_destroy_service.rb
+++ b/app/services/distribution_destroy_service.rb
@@ -1,5 +1,4 @@
 class DistributionDestroyService < DistributionService
-
   def initialize(distribution_id)
     @distribution_id = distribution_id
   end
@@ -10,5 +9,4 @@ class DistributionDestroyService < DistributionService
       @distribution.storage_location.increase_inventory(@distribution)
     end
   end
-
 end

--- a/app/services/distribution_destroy_service.rb
+++ b/app/services/distribution_destroy_service.rb
@@ -1,33 +1,14 @@
-class DistributionDestroyService
-  attr_reader :distribution, :error
+class DistributionDestroyService < DistributionService
 
   def initialize(distribution_id)
     @distribution_id = distribution_id
   end
 
   def call
-    @distribution = Distribution.find(@distribution_id)
-    @organization = distribution.organization
-
-    @distribution.transaction do
+    perform_distribution_service do
       @distribution.destroy!
       @distribution.storage_location.increase_inventory(@distribution)
     end
-  rescue ActiveRecord::RecordNotFound => e
-    Rails.logger.error "[!] DistributionsController#destroy failed to destroy distribution #{@distribution_id} because it does not exist"
-    @error = e
-  rescue Errors::InsufficientAllotment => e
-    @distribution.line_items.assign_insufficiency_errors(e.insufficient_items)
-    Rails.logger.error "[!] DistributionsController#destroy failed because of Insufficient Allotment #{@organization.short_name}: #{@distribution.errors.full_messages} [#{e.message}]"
-    @error = e
-  rescue StandardError => e
-    Rails.logger.error "[!] DistributionsController#destroy failed to destroy distribution for #{@distribution.organization.short_name}: #{@distribution.errors.full_messages} [#{e.inspect}]"
-    @error = e
-  ensure
-    return self
   end
 
-  def success?
-    @error.nil?
-  end
 end

--- a/app/services/distribution_destroy_service.rb
+++ b/app/services/distribution_destroy_service.rb
@@ -5,8 +5,8 @@ class DistributionDestroyService < DistributionService
 
   def call
     perform_distribution_service do
-      @distribution.destroy!
-      @distribution.storage_location.increase_inventory(@distribution)
+      distribution.destroy!
+      distribution.storage_location.increase_inventory(distribution)
     end
   end
 end

--- a/app/services/distribution_service.rb
+++ b/app/services/distribution_service.rb
@@ -1,0 +1,56 @@
+class DistributionService
+  attr_reader :error, :distribution_id
+
+  def perform_distribution_service(&block)
+    distribution.transaction do
+      yield block
+    end
+  rescue ActiveRecord::RecordNotFound => e
+    Rails.logger.error "[!] #{self.class.name} failed to destroy distribution #{distribution_id} because it does not exist"
+    set_error(e)
+  rescue Errors::InsufficientAllotment => e
+    distribution.line_items.assign_insufficiency_errors(e.insufficient_items)
+    Rails.logger.error "[!] #{self.class.name} failed because of Insufficient Allotment #{distribution_organization.short_name}: #{distribution.errors.full_messages} [#{e.message}]"
+    set_error(e)
+  rescue StandardError => e
+    Rails.logger.error "[!] #{self.class.name} failed to destroy distribution for #{distribution_organization.short_name}: #{distribution.errors.full_messages} [#{e.inspect}]"
+    set_error(e)
+  ensure
+    return self
+  end
+
+  def success?
+    error.nil?
+  end
+
+  def distribution
+    # Return distribution if it has already been defined
+    return @distribution if @distribution
+
+    # Otherwise try to get this value with possibly
+    # provided distribution_id from initialize
+    if @distribution_id.present?
+      @distribution = Distribution.find(@distribution_id)
+    end
+  end
+
+  def distribution_id
+    return @distribution_id if @distribution_id
+
+    if distribution.present?
+      @distribution_id = distribution.id
+    end
+  end
+
+  private
+
+  def distribution_organization
+    @distribution_organization ||= distribution&.organization
+  end
+
+  def set_error(e)
+    @error = e
+  end
+
+end
+

--- a/app/services/distribution_service.rb
+++ b/app/services/distribution_service.rb
@@ -23,6 +23,16 @@ class DistributionService
     error.nil?
   end
 
+  private
+
+  def distribution_organization
+    @distribution_organization ||= distribution&.organization
+  end
+
+  def set_error(error)
+    @error = error
+  end
+
   def distribution
     # Return distribution if it has already been defined
     return @distribution if @distribution
@@ -40,16 +50,6 @@ class DistributionService
     if distribution.present?
       @distribution_id = distribution.id
     end
-  end
-
-  private
-
-  def distribution_organization
-    @distribution_organization ||= distribution&.organization
-  end
-
-  def set_error(error)
-    @error = error
   end
 end
 

--- a/app/services/distribution_service.rb
+++ b/app/services/distribution_service.rb
@@ -1,5 +1,5 @@
 class DistributionService
-  attr_reader :error, :distribution_id
+  attr_reader :error
 
   def perform_distribution_service(&block)
     distribution.transaction do
@@ -48,9 +48,8 @@ class DistributionService
     @distribution_organization ||= distribution&.organization
   end
 
-  def set_error(e)
-    @error = e
+  def set_error(error)
+    @error = error
   end
-
 end
 

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -8,17 +8,16 @@ class DistributionUpdateService < DistributionService
   def call
     perform_distribution_service do
       @old_issued_at = distribution.issued_at
-      @distribution.storage_location.increase_inventory(@distribution.to_a)
-
+      distribution.storage_location.increase_inventory(distribution.to_a)
       # Delete the line items -- they'll be replaced later
-      @distribution.line_items.each(&:destroy!)
-      @distribution.reload
+      distribution.line_items.each(&:destroy!)
+      distribution.reload
       # Replace the current distribution with the new parameters
-      @distribution.update! @params
-      @distribution.reload
-      @new_issued_at = @distribution.issued_at
+      distribution.update! @params
+      distribution.reload
+      @new_issued_at = distribution.issued_at
       # Apply the new changes to the storage location inventory
-      @distribution.storage_location.decrease_inventory(@distribution.to_a)
+      distribution.storage_location.decrease_inventory(distribution.to_a)
     end
   end
 

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -1,17 +1,14 @@
-class DistributionUpdateService
-  attr_reader :distribution, :error
+class DistributionUpdateService < DistributionService
 
   def initialize(old_distribution, new_distribution_params)
     @distribution = old_distribution
     @params = new_distribution_params
-    @organization = @distribution.organization
-    @error = nil
   end
 
   # FIXME: This doesn't allow for the storage location to be changed.
   def call
-    @distribution.transaction do
-      @old_issued_at = @distribution.issued_at
+    perform_distribution_service do
+      @old_issued_at = distribution.issued_at
       @distribution.storage_location.increase_inventory(@distribution.to_a)
 
       # Delete the line items -- they'll be replaced later
@@ -24,18 +21,6 @@ class DistributionUpdateService
       # Apply the new changes to the storage location inventory
       @distribution.storage_location.decrease_inventory(@distribution.to_a)
     end
-  rescue Errors::InsufficientAllotment => e
-    @distribution.line_items.assign_insufficiency_errors(e.insufficient_items)
-    Rails.logger.error "[!] DistributionsController#update failed because of Insufficient Allotment #{@organization.short_name}: #{@distribution.errors.full_messages} [#{e.message}]"
-    @error = e
-  rescue StandardError => e
-    Rails.logger.error "[!] DistributionsController#update failed to update distribution for #{@distribution.organization.short_name}: #{@distribution.errors.full_messages} [#{e.inspect}]"
-  ensure
-    return self
-  end
-
-  def success?
-    @error.nil?
   end
 
   def resend_notification?

--- a/app/services/distribution_update_service.rb
+++ b/app/services/distribution_update_service.rb
@@ -1,5 +1,4 @@
 class DistributionUpdateService < DistributionService
-
   def initialize(old_distribution, new_distribution_params)
     @distribution = old_distribution
     @params = new_distribution_params


### PR DESCRIPTION
Resolves #1584 

### Description

Based on the request on #1584 and to reduce the duplication of code, I've introduced through this PR a superclass `DistributionService` to contain common logic. The primary pieces of logic were:

- Using a transaction block
- Handling raised errors in that transaction block
- Use `self.class.name` to generalize the error messaging to the logger.
- Common logic for setting variables

(Opinionated~) This also attempts to hide `@` variables to try to remove some implementation details that the variable comes from a parameter. 

### Type of change
* New feature (non-breaking change which adds functionality)
