### PR TITLE
Add missing code to send organization_email in Partner create API

### DIFF
--- a/app/services/diaper_partner_client.rb
+++ b/app/services/diaper_partner_client.rb
@@ -70,9 +70,10 @@ module DiaperPartnerClient
 
   def self.partner_json(attributes, invitation_message)
     { partner:
-          { diaper_bank_id: attributes["organization_id"],
-            diaper_partner_id: attributes["id"],
-            invitation_text: invitation_message,
-            email: attributes["email"] } }.to_json
+      { diaper_bank_id: attributes["organization_id"],
+        diaper_partner_id: attributes["id"],
+        invitation_text: invitation_message,
+        email: attributes["email"],
+        organization_email: attributes[:organization_email] } }.to_json
   end
 end

--- a/app/services/diaper_partner_client.rb
+++ b/app/services/diaper_partner_client.rb
@@ -74,6 +74,6 @@ module DiaperPartnerClient
         diaper_partner_id: attributes["id"],
         invitation_text: invitation_message,
         email: attributes["email"],
-        organization_email: attributes[:organization_email] } }.to_json
+        organization_email: attributes["organization_email"] } }.to_json
   end
 end

--- a/spec/services/diaper_partner_client_spec.rb
+++ b/spec/services/diaper_partner_client_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe DiaperPartnerClient, type: :service do
 
   describe '::post' do
     it 'performs a POST request' do
-      attributes = { 'id' => 123, 'organization_id' => 456, 'email' => 'foo@bar.com' }
+      attributes = { 'id' => 123, 'organization_id' => 456, 'email' => 'foo@bar.com', 'organization_email' => 'fake@example.com' }
       invitation_text = 'invitation'
       expected_body = {
         partner:
@@ -14,7 +14,8 @@ RSpec.describe DiaperPartnerClient, type: :service do
           diaper_bank_id: attributes["organization_id"],
           diaper_partner_id: attributes["id"],
           invitation_text: invitation_text,
-          email: attributes["email"]
+          email: attributes["email"],
+          organization_email: attributes["organization_email"]
         }
       }.to_json
       stub_partner_request(:post, 'https://partner-register.com/', body: expected_body)


### PR DESCRIPTION
Adds extra missing part for - https://github.com/rubyforgood/diaper/pull/1610

### Description
When testing the code for https://github.com/rubyforgood/partner/pull/309, I noticed that the API request isn't sending the `organization_email` as intended from https://github.com/rubyforgood/diaper/pull/1610

**Blocks https://github.com/rubyforgood/partner/pull/309**
   
### Type of change

* Bug fix (non-breaking change which fixes an issue)

