### PR TITLE
Adds CSS data to body tag, with test coverage

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,7 +18,7 @@
   <link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
 
 </head>
-<body class="hold-transition sidebar-mini layout-fixed">
+<body id="<%= params.fetch(:controller, '').gsub(/[^\w\d]+/,'_') %>" class="<%= params.fetch(:action, '') %> hold-transition sidebar-mini layout-fixed">
 <!-- Site wrapper -->
 <div class="wrapper">
   <nav class="main-header navbar navbar-expand navbar-white navbar-light">

--- a/spec/system/layout_system_spec.rb
+++ b/spec/system/layout_system_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe "Layout", type: :system do
+  let!(:url_prefix) { "/#{@organization.to_param}" }
+
+  describe "Body CSS Data" do
+    it "sets the ID to the controller and the class to the action" do
+      sign_in(@user)
+      visit url_prefix + "/donations/new"
+      expect(page).to have_css("body#donations.new")
+
+      distribution = create(:distribution)
+      visit url_prefix + "/distributions/#{distribution.id}/edit"
+	  expect(page).to have_css("body#distributions.edit")
+    end
+  end
+end

--- a/spec/system/layout_system_spec.rb
+++ b/spec/system/layout_system_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Layout", type: :system do
 
       distribution = create(:distribution)
       visit url_prefix + "/distributions/#{distribution.id}/edit"
-	  expect(page).to have_css("body#distributions.edit")
+      expect(page).to have_css("body#distributions.edit")
     end
   end
 end


### PR DESCRIPTION
Resolves #1673

### Description
This sets the body `id` property to the controller name, and adds an additional class prefix which is the current action. If the controller is a namespaced controller (eg. "admin/donations") it will substitute the non-alphanumeric characters with `_` (`admin/donations` -> `admin_donations`).

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
I added a system spec for this that verifies it works.