### PR TITLE
Sort partner distributions new to old

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -33,6 +33,7 @@ class PartnersController < ApplicationController
   def show
     @impact_metrics = JSON.parse(DiaperPartnerClient.get({ id: params[:id] }, query_params: { impact_metrics: true }))
     @partner = current_organization.partners.find(params[:id])
+    @partner_distributions = @partner.distributions.order(created_at: :desc)
   end
 
   def new

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -92,7 +92,7 @@
                 </tr>
                 </thead>
                 <tbody>
-                <% @partner.distributions.each do |dist| %>
+                <% @partner_distributions.each do |dist| %>
                   <tr>
                     <td><%= dist.created_at.strftime("%m/%d/%Y") %></td>
                     <td><%= dist.storage_location.name %></td>


### PR DESCRIPTION
Resolves #1680 

### Description

I ordered the list of distributions to a specific partner on the partner show page from newest to oldest.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Based off the simplicity of the change, I'm not sure if tests are necessary.
