### PR TITLE
Tiny commit to add the time of day to the reminder emails

### DIFF
--- a/app/views/distribution_mailer/reminder_email.html.erb
+++ b/app/views/distribution_mailer/reminder_email.html.erb
@@ -5,6 +5,6 @@
   </head>
   <body>
     <p>Hello <%= @partner.name %>,</p>
-    <p>This is a friendly reminder that tomorrow, <%= @distribution.issued_at.strftime("%A, %B #{@distribution.issued_at.day.ordinalize} %Y") %>, is your distribution pick up date. </p>
+    <p>This is a friendly reminder that tomorrow, <%= @distribution.issued_at.strftime("%A, %B #{@distribution.issued_at.day.ordinalize} %Y at %I:%M%p") %>, is your distribution pick up date. </p>
   </body>
 </html>


### PR DESCRIPTION
Resolves #1570 

Tiny PR to add in the time of day to the distribution emails to fulfill a request of one of the stakeholders that it be added in. It changes:
`Sunday, March 8th 2020` to `Sunday, March 8th 2020 at 02:00PM`
