### PR TITLE
Gracefully fail donation destroy

### DIFF
--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -81,11 +81,11 @@ class DonationsController < ApplicationController
 
     if service.success?
       flash[:notice] = "Donation #{params[:id]} has been removed!"
-      redirect_to donations_path
     else
       flash[:error] = "Donation #{params[:id]} failed to be removed becuase #{service.error}"
-      redirect_to donations_path
     end
+
+    redirect_to donations_path
   end
 
   private

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -82,7 +82,7 @@ class DonationsController < ApplicationController
     if service.success?
       flash[:notice] = "Donation #{params[:id]} has been removed!"
     else
-      flash[:error] = "Donation #{params[:id]} failed to be removed becuase #{service.error}"
+      flash[:error] = "Donation #{params[:id]} failed to be removed because #{service.error}"
     end
 
     redirect_to donations_path

--- a/app/controllers/donations_controller.rb
+++ b/app/controllers/donations_controller.rb
@@ -76,14 +76,16 @@ class DonationsController < ApplicationController
   end
 
   def destroy
-    ActiveRecord::Base.transaction do
-      donation = current_organization.donations.find(params[:id])
-      donation.storage_location.decrease_inventory(donation)
-      donation.destroy!
-    end
+    service = DonationDestroyService.new(organization_id: current_organization.id, donation_id: params[:id])
+    service.call
 
-    flash[:notice] = "Donation #{params[:id]} has been removed!"
-    redirect_to donations_path
+    if service.success?
+      flash[:notice] = "Donation #{params[:id]} has been removed!"
+      redirect_to donations_path
+    else
+      flash[:error] = "Donation #{params[:id]} failed to be removed becuase #{service.error}"
+      redirect_to donations_path
+    end
   end
 
   private

--- a/app/services/donation_destroy_service.rb
+++ b/app/services/donation_destroy_service.rb
@@ -1,0 +1,40 @@
+class DonationDestroyService
+  attr_reader :error
+
+  def initialize(organization_id:, donation_id:)
+    @organization_id = organization_id
+    @donation_id = donation_id
+  end
+
+  def call
+    ActiveRecord::Base.transaction do
+      organization = Organization.find(organization_id)
+      donation = organization.donations.find(donation_id)
+      donation.storage_location.decrease_inventory(donation)
+      donation.destroy!
+    end
+  rescue ActiveRecord::RecordNotFound => e
+    Rails.logger.error "[!] #{self.class.name} failed to destroy donation #{donation_id} because organization or donation does does not exist"
+    set_error(e)
+  rescue Errors::InsufficientAllotment => e
+    Rails.logger.error "[!] #{self.class.name} failed because of Insufficient Allotment"
+    set_error(e)
+  rescue StandardError => e
+    Rails.logger.error "[!] #{self.class.name} failed to destroy donation"
+    set_error(e)
+  ensure
+    return self
+  end
+
+  def success?
+    error.nil?
+  end
+
+  private
+  attr_reader :organization_id, :donation_id
+
+  def set_error(error)
+    @error = error
+  end
+
+end

--- a/app/services/donation_destroy_service.rb
+++ b/app/services/donation_destroy_service.rb
@@ -31,10 +31,10 @@ class DonationDestroyService
   end
 
   private
+
   attr_reader :organization_id, :donation_id
 
   def set_error(error)
     @error = error
   end
-
 end

--- a/spec/services/donation_destroy_service_spec.rb
+++ b/spec/services/donation_destroy_service_spec.rb
@@ -1,0 +1,129 @@
+require 'rails_helper'
+
+describe DonationDestroyService do
+
+  describe '#call' do
+    subject { described_class.new(organization_id: organization_id, donation_id: donation_id) }
+    let(:organization_id) { Faker::Number.number }
+    let(:donation_id) { Faker::Number.number }
+
+    context 'when the organization_id matches no Organization' do
+      before do
+        allow(Organization).to receive(:find)
+          .with(organization_id)
+          .and_raise(ActiveRecord::RecordNotFound)
+      end
+
+      it 'to not be a success' do
+        result = subject.call
+        expect(result).not_to be_success
+      end
+    end
+
+    context 'when the donation_id matches no Donation owned by the organization' do
+      let(:fake_organization) { instance_double(Organization, donations: fake_organization_donations) }
+      let(:fake_organization_donations) { instance_double('donations') }
+
+      before do
+        allow(Organization).to receive(:find)
+          .with(organization_id)
+          .and_return(fake_organization)
+        allow(fake_organization_donations).to receive(:find)
+          .with(donation_id)
+          .and_raise(ActiveRecord::RecordNotFound)
+      end
+
+      it 'to not be a success' do
+        result = subject.call
+        expect(result).not_to be_success
+      end
+    end
+
+    context 'when storage_location fails to decrease the inventory of the donation' do
+      let(:fake_organization) { instance_double(Organization, short_name: 'org_name', donations: fake_organization_donations) }
+      let(:fake_organization_donations) { instance_double('donations') }
+      let(:fake_donation) { instance_double(Donation, storage_location: fake_storage_location) }
+      let(:fake_storage_location) { instance_double(StorageLocation) }
+      let(:fake_insufficient_allotment_error) do
+        Errors::InsufficientAllotment.new(
+          fake_error_message,
+          fake_insufficient_items
+        )
+      end
+      let(:fake_error_message) { Faker::Lorem.sentence }
+      let(:fake_insufficient_items) do
+        [
+          {
+            item_id: Faker::Number.number,
+            item: Faker::Lorem.word,
+            quantity_on_hand: Faker::Number.number,
+            quantity_requested: Faker::Number.number
+          }
+        ]
+      end
+      before do
+        allow(Organization).to receive(:find)
+          .with(organization_id)
+          .and_return(fake_organization)
+        allow(fake_organization_donations).to receive(:find)
+          .with(donation_id)
+          .and_return(fake_donation)
+        allow(fake_storage_location).to receive(:decrease_inventory)
+          .with(fake_donation)
+          .and_raise(fake_insufficient_allotment_error)
+      end
+
+      it 'to not be a success' do
+        result = subject.call
+        expect(result).not_to be_success
+        expect(result.error).to be_instance_of(Errors::InsufficientAllotment)
+      end
+    end
+
+    context 'when the donation destroy fails' do
+      let(:fake_organization) { instance_double(Organization, short_name: 'org_name', donations: fake_organization_donations) }
+      let(:fake_organization_donations) { instance_double('donations') }
+      let(:fake_donation) { instance_double(Donation, storage_location: fake_storage_location) }
+      let(:fake_storage_location) { instance_double(StorageLocation) }
+
+      before do
+        allow(Organization).to receive(:find)
+          .with(organization_id)
+          .and_return(fake_organization)
+        allow(fake_organization_donations).to receive(:find)
+          .with(donation_id)
+          .and_return(fake_donation)
+        allow(fake_storage_location).to receive(:decrease_inventory).with(fake_donation)
+        allow(fake_donation).to receive(:destroy!).and_raise('boom')
+      end
+
+      it 'to not be a success' do
+        result = subject.call
+        expect(result).not_to be_success
+      end
+    end
+
+    context 'when the donation succesfully gets destroyed' do
+      let(:fake_organization) { instance_double(Organization, short_name: 'org_name', donations: fake_organization_donations) }
+      let(:fake_organization_donations) { instance_double('donations') }
+      let(:fake_donation) { instance_double(Donation, storage_location: fake_storage_location) }
+      let(:fake_storage_location) { instance_double(StorageLocation) }
+
+      before do
+        allow(Organization).to receive(:find)
+          .with(organization_id)
+          .and_return(fake_organization)
+        allow(fake_organization_donations).to receive(:find)
+          .with(donation_id)
+          .and_return(fake_donation)
+        allow(fake_storage_location).to receive(:decrease_inventory).with(fake_donation)
+        allow(fake_donation).to receive(:destroy!)
+      end
+
+      it 'to be a success' do
+        result = subject.call
+        expect(result).to be_success
+      end
+    end
+  end
+end

--- a/spec/services/donation_destroy_service_spec.rb
+++ b/spec/services/donation_destroy_service_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 describe DonationDestroyService do
-
   describe '#call' do
     subject { described_class.new(organization_id: organization_id, donation_id: donation_id) }
     let(:organization_id) { Faker::Number.number }


### PR DESCRIPTION
Related to https://github.com/rubyforgood/diaper/issues/1703

### Description
I noticed that in https://github.com/rubyforgood/diaper/issues/1703 the user encountered a 500 error. Instead of raising an error and presenting the 500 error page, we should gracefully handle it. This PR gracefully handles issues by wrapping the donation destroy action into a new service object `DonationDestroyService`

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
- Added specs
- Manually tested

### Screenshots
On Success
![Screen Shot 2020-06-27 at 11 37 48 AM](https://user-images.githubusercontent.com/11335191/85927487-ff275280-b86b-11ea-8028-8cfd57866462.png)

**The error message isn't the nicest or clearest, but better than 500**
![Screen Shot 2020-06-27 at 11 37 19 AM](https://user-images.githubusercontent.com/11335191/85927482-f9ca0800-b86b-11ea-865c-0379c56b6911.png)