### PR TITLE
Show list of zipcodes

### DIFF
--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -33,7 +33,7 @@
           </div>
           <div class="card-body p-0">
             <div class="row">
-              <div class="col-sm-4 col-4">
+              <div class="col-sm-3 col-3">
                 <div class="description-block border-right">
                   <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "families_served") || 0) %> </h1>
                   <h5>Families served</h5>
@@ -41,7 +41,7 @@
                 <!-- /.description-block -->
               </div>
               <!-- /.col -->
-              <div class="col-sm-4 col-4">
+              <div class="col-sm-3 col-3">
                 <div class="description-block border-right">
                   <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "children_served") || 0) %> </h1>
                   <h5>Children served</h5>
@@ -49,10 +49,17 @@
                 <!-- /.description-block -->
               </div>
               <!-- /.col -->
-              <div class="col-sm-4 col-4">
+              <div class="col-sm-3 col-3">
                 <div class="description-block border-right">
                   <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "family_zipcodes") || 0) %> </h1>
                   <h5>Zipcodes served</h5>
+                </div>
+                <!-- /.description-block -->
+              </div>
+              <div class="col-sm-3 col-3">
+                <div class="description-block border-right">
+                  <h3 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "family_zipcodes_list")&.join(", ") || 0) %> </h3>
+                  <h5>List of zipcodes served</h5>
                 </div>
                 <!-- /.description-block -->
               </div>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -33,7 +33,7 @@
           </div>
           <div class="card-body p-0">
             <div class="row">
-              <div class="col-sm-3 col-3">
+              <div class="col-sm-4 col-4">
                 <div class="description-block border-right">
                   <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "families_served") || 0) %> </h1>
                   <h5>Families served</h5>
@@ -41,7 +41,7 @@
                 <!-- /.description-block -->
               </div>
               <!-- /.col -->
-              <div class="col-sm-3 col-3">
+              <div class="col-sm-4 col-4">
                 <div class="description-block border-right">
                   <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "children_served") || 0) %> </h1>
                   <h5>Children served</h5>
@@ -49,17 +49,11 @@
                 <!-- /.description-block -->
               </div>
               <!-- /.col -->
-              <div class="col-sm-3 col-3">
+              <div class="col-sm-4 col-4">
                 <div class="description-block border-right">
                   <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "family_zipcodes") || 0) %> </h1>
                   <h5>Zipcodes served</h5>
-                </div>
-                <!-- /.description-block -->
-              </div>
-              <div class="col-sm-3 col-3">
-                <div class="description-block border-right">
-                  <h3 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "family_zipcodes_list")&.join(", ") || 0) %> </h3>
-                  <h5>List of zipcodes served</h5>
+                  <%= modal_button_to("#addUserModal", {text: "See Zipcodes?", size: "xs"}) if can_administrate? %>
                 </div>
                 <!-- /.description-block -->
               </div>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -53,7 +53,7 @@
                 <div class="description-block border-right">
                   <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "family_zipcodes") || 0) %> </h1>
                   <h5>Zipcodes served</h5>
-                  <%= modal_button_to("#addUserModal", {text: "See Zipcodes?", size: "xs"}) if can_administrate? %>
+                  <%= modal_button_to("#seeZipcodes", {text: "See Zipcodes?", size: "xs"}) if @impact_metrics.dig("agency", "family_zipcodes_list").present? %>
                 </div>
                 <!-- /.description-block -->
               </div>
@@ -144,4 +144,23 @@
       </div><!-- modal-content -->
     </div><!-- modal-dialog -->
   </div><!-- addUserModal -->
+  <div id="seeZipcodes" class="modal fade">
+    <div class="modal-dialog">
+      <!-- Modal content-->
+      <div class="modal-content">
+        <div class="modal-header">
+          <h4 class="modal-title">Serviced zipcodes</h4>
+        </div><!-- modal-header -->
+        <div class="modal-body">
+          <div class="box-body">
+          <ul>
+            <% @impact_metrics.dig("agency", "family_zipcodes_list").each do |zipcode| %>
+              <li><%= zipcode %></li>
+            <% end %>
+          </ul>
+          </div><!-- box-body -->
+        </div><!-- modal-body -->
+      </div><!-- modal-content -->
+    </div><!-- modal-dialog -->
+  </div><!-- seeZipcodes -->
 </section>

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -17,13 +17,12 @@ RSpec.describe "Partners", type: :request do
   describe "GET #show" do
     let(:partner) { create(:partner, organization: @organization) }
     let(:fake_get_return) do
-      {"agency"=>{
-        "families_served"=>Faker::Number.number,
-        "children_served"=>Faker::Number.number,
-        "family_zipcodes"=>Faker::Number.number,
-        "family_zipcodes_list"=>[Faker::Number.number]
-        }
-      }.to_json
+      { "agency" => {
+        "families_served" => Faker::Number.number,
+        "children_served" => Faker::Number.number,
+        "family_zipcodes" => Faker::Number.number,
+        "family_zipcodes_list" => [Faker::Number.number]
+      } }.to_json
     end
 
     before do

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -17,8 +17,12 @@ RSpec.describe "Partners", type: :request do
   describe "GET #show" do
     let(:partner) { create(:partner, organization: @organization) }
     let(:fake_get_return) do
-      {
-        family_count: Faker::Number.number
+      {"agency"=>{
+        "families_served"=>Faker::Number.number,
+        "children_served"=>Faker::Number.number,
+        "family_zipcodes"=>Faker::Number.number,
+        "family_zipcodes_list"=>[Faker::Number.number]
+        }
       }.to_json
     end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves https://github.com/rubyforgood/diaper/issues/1623 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
Add `See Zipcodes` button. When that button gets clicked, show a modal that lists all of the zipcodes served by agency.

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

I tested this code change by running the diaper and partner apps locally.

**QUESTION**: If I don't include the safe navigation operator `.&` [here](https://github.com/rubyforgood/diaper/pull/1724/files#diff-b7b81b115096a908ce28d16c5319ce72R61) then this [spec](https://github.com/rubyforgood/diaper/blob/master/spec/requests/partners_requests_spec.rb#L29-L34) fails with the following error message. So according to the stack trace the failure happens when we hit this line of code `get partner_path(default_params.merge(id: partner))`. Any hints on why that's happening? Even when I stub `fake_get_return` to match the updated response from the partner app, I still get this error.

![image](https://user-images.githubusercontent.com/13841769/85932923-fd2ab700-b89e-11ea-9575-5631a9c32bc2.png)



### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
![zips](https://user-images.githubusercontent.com/13841769/90317377-062b2280-def7-11ea-8e2b-d8d89e94189b.gif)

