### PR TITLE
Address fields were not showing up. 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,7 @@ gem 'bootstrap-daterangepicker-rails'
 
 group :development, :test do
   gem "awesome_print"
+  gem "fakeredis", require: "fakeredis/rspec"
   gem "guard-rspec"
   gem "pry-rails"
   gem "pry-remote"
@@ -87,7 +88,6 @@ group :test do
   gem "capybara-screenshot"
   gem "database_cleaner"
   gem "factory_bot_rails"
-  gem "fakeredis", require: "fakeredis/rspec"
   gem "launchy"
   gem "rails-controller-testing"
   gem "rspec-sidekiq"

--- a/app/views/partners/approve_partner.html.erb
+++ b/app/views/partners/approve_partner.html.erb
@@ -45,11 +45,11 @@
                 <p>Proof of Agency Status
                   (Link): <%= link_to File.basename(@agency[:proof_of_agency_status]), documentation_url(@agency[:proof_of_agency_status]), target: :_blank %></p>
                 <p>Agency Mission: <%= @agency[:agency_mission] %></p>
-                <p>Address <%= @agency[:address1] %></p>
-                <p>Address <%= @agency[:address2] %></p>
-                <p>City: <%= @agency[:city] %></p>
-                <p>State: <%= @agency[:state] %></p>
-                <p>Zip Code: <%= @agency[:zip_code] %></p>
+                <p>Address Line 1: <%= @agency[:address][:address1] %></p>
+                <p>Address Line 2: <%= @agency[:address][:address2] %></p>
+                <p>City: <%= @agency[:address][:city] %></p>
+                <p>State: <%= @agency[:address][:state] %></p>
+                <p>Zip Code: <%= @agency[:address][:zip_code] %></p>
                 <br>
                 <% if @fields.include?('media_information') || @fields.empty? %>
                   <h2>Media Information</h2>


### PR DESCRIPTION
Got some feedback from a diaper bank that the address fields were not showing up in their approve partner page. This PR fixes that. 

This also moves the `fakeredis` gem back into the development section since folks have been having an issue with that.