### PR TITLE
Add paperclip back to the gemfile so legacy migrations work.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem "kaminari"
 gem "momentjs-rails"
 gem "newrelic_rpm"
 gem "nokogiri", ">= 1.10.4"
+gem "paperclip" # needed for legacy migrations
 gem "pg", "~> 1.2.3"
 gem 'popper_js'
 gem "prawn-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
     chartkick (3.3.0)
     childprocess (3.0.0)
     choice (0.2.0)
+    climate_control (0.2.0)
     cocoon (1.2.14)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
@@ -243,6 +244,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
     mimemagic (0.3.5)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
@@ -264,6 +268,12 @@ GEM
       nenv (~> 0.1)
       shellany (~> 0.0)
     orm_adapter (0.5.0)
+    paperclip (6.1.0)
+      activemodel (>= 4.2.0)
+      activesupport (>= 4.2.0)
+      mime-types
+      mimemagic (~> 0.3.0)
+      terrapin (~> 0.6.0)
     parallel (1.19.2)
     parser (2.7.1.4)
       ast (~> 2.4.1)
@@ -451,6 +461,8 @@ GEM
       sshkit (~> 1.12)
     terminal-notifier (2.0.0)
     terminal-notifier-guard (1.7.0)
+    terrapin (0.6.0)
+      climate_control (>= 0.0.3, < 1.0)
     thor (1.0.1)
     thread_safe (0.3.6)
     thwait (0.1.0)
@@ -541,6 +553,7 @@ DEPENDENCIES
   momentjs-rails
   newrelic_rpm
   nokogiri (>= 1.10.4)
+  paperclip
   pg (~> 1.2.3)
   popper_js
   prawn-rails


### PR DESCRIPTION
I had a new contributor complain that running `rails db:migrate` didn't work and that our migrations were broken.

It turns out that since we used to have paperclip in the application and we had a migration that depended on it we need to put this back to let new folks be able to run the migrations.

This is obviously a short term fix. We'll need to eventually remove the gem and the fix the migrations but this immediately unbreaks things and lets new contributors run migrations as expected.