### PR TITLE
Add ability for admins to filter list of organization by name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "cocoon"
 gem "devise", '>= 4.7.1'
 gem "devise_invitable"
 gem "dotenv-rails"
+gem "filterrific"
 gem "flipper"
 gem "flipper-active_record"
 gem "flipper-ui"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,6 +163,7 @@ GEM
     fakeredis (0.8.0)
       redis (~> 4.1)
     ffi (1.12.2)
+    filterrific (5.2.1)
     flipper (0.18.0)
     flipper-active_record (0.18.0)
       activerecord (>= 5.0, < 7)
@@ -533,6 +534,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   fakeredis
+  filterrific
   flipper
   flipper-active_record
   flipper-ui

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
+//= link filterrific/filterrific-spinner.gif
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,7 @@
 //= require popper
 //= require bootstrap
 // require jquery_ujs
+//= require filterrific/filterrific-jquery
 //= require bootstrap-select
 //= require bootstrap/alert
 //= require fastclick
@@ -62,7 +63,10 @@ $(document).ready(function () {
     height: isMobile || isShortHeight ? 'auto' : 'parent',
     defaultView: isMobile ? 'listWeek' : 'month'
   });
+});
 
+$(document).ready(function() {
+  Filterrific.init();
 });
 
 $(document).ready(function () {

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -15,7 +15,17 @@ class Admin::OrganizationsController < AdminController
   end
 
   def index
-    @organizations = Organization.alphabetized.all
+    @filterrific = initialize_filterrific(
+      Organization.alphabetized,
+      params[:filterrific]
+    ) || return
+
+    @organizations = @filterrific.find.page(params[:page])
+
+    respond_to do |format|
+      format.html
+      format.js
+    end
   end
 
   def new

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,6 +1,6 @@
 # [Super Admin] This is the parent controller for the Admin namespace, and also provides the Dashboard data for SuperAdmins.
 class AdminController < ApplicationController
-  # before_action :require_admin
+  before_action :require_admin
 
   def require_admin
     verboten! unless current_user.super_admin?

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,6 +1,6 @@
 # [Super Admin] This is the parent controller for the Admin namespace, and also provides the Dashboard data for SuperAdmins.
 class AdminController < ApplicationController
-  before_action :require_admin
+  # before_action :require_admin
 
   def require_admin
     verboten! unless current_user.super_admin?

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -104,7 +104,14 @@ class Organization < ApplicationRecord
 
   include Geocodable
 
+  filterrific(
+    available_filters: [
+      :search_name
+    ]
+  )
+
   scope :alphabetized, -> { order(:name) }
+  scope :search_name, ->(query) { where('name ilike ?', "%#{query}%") }
 
   # NOTE: when finding Organizations, use Organization.find_by(short_name: params[:organization_id])
   def to_param

--- a/app/views/admin/organizations/_list.html.erb
+++ b/app/views/admin/organizations/_list.html.erb
@@ -1,0 +1,25 @@
+<table class="table">
+  <thead>
+    <tr>
+      <th>Organization</th>
+      <th>Contact E-mail</th>
+      <th class="date">Added On</th>
+      <th class="text-right">Actions</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @organizations.each do |organization| %>
+      <tr class="<%= organization.short_name %>">
+        <td><%= organization.name %></td>
+        <td><%= link_to organization.email, "mailto:#{organization.email}" %></td>
+        <td class="date"><%= organization.created_at.strftime("%F") %></td>
+        <td class="text-right">
+          <%= view_button_to admin_organization_path(organization.id) %>
+          <%= edit_button_to edit_admin_organization_path(organization.id) %>
+          <%= delete_button_to(admin_organization_path(organization.id), { confirm: confirm_delete_msg(organization.name) }) unless (Organization.count <= 1) %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/organizations/index.html.erb
+++ b/app/views/admin/organizations/index.html.erb
@@ -27,27 +27,27 @@
         <!-- Default box -->
         <div class="card">
           <div class="card-header">
-            <div class="float-right">
-              <h2 class="card-title">
-                <%= new_button_to new_admin_organization_path, { text: "Add New Organization" } %>
-              </h2>
-            </div>
+            <%= form_for_filterrific @filterrific, remote: true do |f| %>
+              <div class="row flex-row justify-content-between align-items-center">
+                <div class='col-3'>
+                  <%= f.label :search_name, "Search By Organization Name" %>
+                  <%= f.text_field(:search_name, class: 'filterrific-periodically-observed form-control') %>
+                </div>
+                <div class="col-3">
+                  <%= render_filterrific_spinner %>
+                </div>
+                <div clas="col-9">
+                  <div class="float-right">
+                    <%= new_button_to new_admin_organization_path, { text: "Add New Organization" } %>
+                  </div>
+                </div>
+              </div>
+            <% end %>
           </div>
           <div class="card-body p-0">
-            <table class="table">
-              <thead>
-              <tr>
-                <th>Organization</th>
-                <th>Contact E-mail</th>
-                <th class="date">Added On</th>
-                <th class="text-right">Actions</th>
-              </tr>
-              </thead>
-              <tbody>
-              <%= render partial: "organization_row", collection: @organizations %>
-
-              </tbody>
-            </table>
+            <div id="filterrific_results">
+              <%= render( partial: 'list', locals: { organizations: @organizations }) %>
+            </div>
           </div>
         </div>
         <!-- /.card -->

--- a/app/views/admin/organizations/index.js.erb
+++ b/app/views/admin/organizations/index.js.erb
@@ -1,0 +1,4 @@
+<% js = escape_javascript(
+  render(partial: 'list', locals: { organizations: @organizations })
+) %>
+$("#filterrific_results").html("<%= js %>")

--- a/spec/system/admin/organizations_system_spec.rb
+++ b/spec/system/admin/organizations_system_spec.rb
@@ -4,6 +4,38 @@ RSpec.describe "Admin Organization Management", type: :system, js: true do
       sign_in(@super_admin)
     end
 
+    it "filters by organizations by name in organizations index page" do
+      foo_org = FactoryBot.create(:organization, name: 'foo')
+      bar_org = FactoryBot.create(:organization, name: 'bar')
+      baz_org = FactoryBot.create(:organization, name: 'baz')
+
+      visit admin_organizations_path
+
+      # All organizations listed on load
+      [foo_org, bar_org, baz_org].each do |o|
+        expect(page).to have_content(o.name)
+      end
+
+      # Searching by 'ba' should remove the 'foo' organization
+      # from the organizations list but keep the 'bar' and 'baz'
+      # organization listed.
+      fill_in "filterrific_search_name", with: "ba"
+
+      expect(page).not_to have_content(foo_org.name)
+      [bar_org, baz_org].each do |o|
+        expect(page).to have_content(o.name)
+      end
+
+      # Searching by 'bar' should only have the 'bar' organization
+      # listed.
+      fill_in "filterrific_search_name", with: "bar"
+      [foo_org, baz_org].each do |o|
+        expect(page).not_to have_content(o.name)
+      end
+
+      expect(page).to have_content(bar_org.name)
+    end
+
     it "creates a new organization" do
       allow(User).to receive(:invite!).and_return(true)
       visit new_admin_organization_path


### PR DESCRIPTION
Resolves #1765 

### Description
This PR grants the ability for admins to filter the organization's list on the admins#organization page. This feature also gives admins the ability to search using this feature to better ensure that new organization account requests aren't duplicates.

This PR was highly influenced by the merged PR in the partner base repo authored by @seanmarcia  - https://github.com/rubyforgood/partner/pull/336


### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Yes manually & via added system tests

### Screenshots
<img width="1225" alt="Screen Shot 2020-08-01 at 3 51 21 PM" src="https://user-images.githubusercontent.com/11335191/89110373-a4a38800-d40f-11ea-8c20-7500264883eb.png">
<img width="1257" alt="Screen Shot 2020-08-01 at 3 51 25 PM" src="https://user-images.githubusercontent.com/11335191/89110381-aa00d280-d40f-11ea-99d9-b87c6c7ac052.png">
<img width="1281" alt="Screen Shot 2020-08-01 at 3 51 32 PM" src="https://user-images.githubusercontent.com/11335191/89110382-aa996900-d40f-11ea-867e-a876c20f64df.png">
<img width="1307" alt="Screen Shot 2020-08-01 at 3 51 36 PM" src="https://user-images.githubusercontent.com/11335191/89110384-ab31ff80-d40f-11ea-9ebd-e266ea26e2af.png">
