### PR TITLE
Organization from email address for distribution email reminder

### DIFF
--- a/app/mailers/reminder_deadline_mailer.rb
+++ b/app/mailers/reminder_deadline_mailer.rb
@@ -3,6 +3,6 @@ class ReminderDeadlineMailer < ApplicationMailer
   def notify_deadline(partner, organization)
     @partner = partner
     @organization = organization
-    mail(to: @partner.email, subject: "#{@organization.name} Deadline Reminder")
+    mail(from: @organization.from_email, to: @partner.email, subject: "#{@organization.name} Deadline Reminder")
   end
 end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -188,6 +188,10 @@ class Organization < ApplicationRecord
     end
   end
 
+  def from_email
+    email || get_admin_email
+  end
+
   private
 
   def update_partner_sections
@@ -206,5 +210,9 @@ class Organization < ApplicationRecord
     return if deadline_day.blank? || reminder_day.blank?
 
     errors.add(:deadline_day, "must be after the reminder date") if deadline_day < reminder_day
+  end
+
+  def get_admin_email
+    User.where(organization_id: id, organization_admin: true).sample.email
   end
 end

--- a/spec/mailers/reminder_deadline_mailer_spec.rb
+++ b/spec/mailers/reminder_deadline_mailer_spec.rb
@@ -1,6 +1,7 @@
 describe ReminderDeadlineMailer do
   describe 'notify deadline' do
     let(:organization) { create :organization }
+    let!(:user) { create(:organization_admin, organization: organization) }
     let(:partner) { create :partner, organization: organization }
     let(:mail) { ReminderDeadlineMailer.notify_deadline(partner, organization) }
 
@@ -13,11 +14,21 @@ describe ReminderDeadlineMailer do
     end
 
     it 'renders the sender email' do
-      expect(mail.from).to contain_exactly('info@diaper.app')
+      expect(mail.from).to contain_exactly(organization.email)
     end
 
     it 'renders the body' do
       expect(mail.body).to include(organization.deadline_day)
+    end
+
+    context 'organization email not present' do
+      before do
+        allow(organization).to receive(:email).and_return(nil)
+      end
+
+      it 'renders the sender email as admin email' do
+        expect(mail.from).to contain_exactly(user.email)
+      end
     end
   end
 end

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -332,6 +332,19 @@ RSpec.describe Organization, type: :model do
       expect(intial_count).to_not eq(final_count)
     end
   end
+
+  describe 'from_email' do
+    it 'returns email when present' do
+      expect(organization.from_email).to eq(organization.email)
+    end
+
+    it 'returns admin email when not present' do
+      org = create(:organization, email: nil)
+      admin = create(:organization_admin, organization: org)
+      expect(org.from_email).to eq(admin.email)
+    end
+  end
+
   describe 'reminder_day' do
     it "can only contain numbers 1-14" do
       expect(build(:organization, reminder_day: 14)).to be_valid


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves  #1760  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.

Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
According to the issue, the distribution reminder "from" email address should not use info@diaper.app. Instead, it should use the organization's email address when present. If not present, then it should use an organization admins' email address. This would allow partners to respond to the email if they have any questions.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

Added `from_email` method to Organization class to return the email address and if it is not present, returns an organization admins' email address.

Modified `ReminderDeadlineMailer` to set the "from" email address using Organization `from_email` method.



### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

Added tests to check that the distribution reminder "from" email address was being set to the organization's email address and if not present, then set to an organization admins' email address.

Added tests check that the "from_email" method in the organization class was returning the email and if not present, then returning an organization admins' email address.
