### PR TITLE
Fix and test admin/barcode_items forms

### DIFF
--- a/app/views/admin/barcode_items/_form.html.erb
+++ b/app/views/admin/barcode_items/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for form, html: {role: "form"} do |f| %>
+<%= simple_form_for [:admin, form], html: {role: "form"} do |f| %>
   <section class="content">
     <div class="container-fluid">
       <div class="row">
@@ -17,7 +17,7 @@
                 <span class="input-group-text"><i class="fa fa-sort-numeric-desc"></i></span>
                 <%= f.input_field :quantity, class: "form-control" %>
               <% end %>
-              <%= f.association :barcodeable, collection: @items, label: "Item", wrapper: :input_group %>
+              <%= f.association :barcodeable, collection: @base_items, label: "Item", wrapper: :input_group %>
               <%= f.input :value, label: "Barcode", wrapper: :input_group do %>
                 <span class="input-group-text"><i class="fa fa-barcode"></i></span>
                 <%= f.input_field :value, class: "form-control" %>

--- a/app/views/admin/barcode_items/new.html.erb
+++ b/app/views/admin/barcode_items/new.html.erb
@@ -21,4 +21,4 @@
   </div><!-- /.container-fluid -->
 </section>
 
-<%= render partial: "form", object: [:admin, @barcode_item] %>
+<%= render partial: "form", object: @barcode_item %>

--- a/spec/system/admin/barcode_items_system_spec.rb
+++ b/spec/system/admin/barcode_items_system_spec.rb
@@ -38,13 +38,14 @@ RSpec.describe "Barcode Items Admin", type: :system do
     end
 
     context "user visits the new page" do
+      let!(:item) { create(:item) }
+      let!(:base_item) { create(:base_item) }
+
       before do
         visit new_admin_barcode_item_path
       end
 
       it 'creates a new global barcode item' do
-        skip "`@items` is not being set in `new` action"
-
         fill_in "Quantity", with: 100
         select item.base_item.name, from: "barcode_item_barcodeable_id"
         fill_in "Barcode", with: 66_666
@@ -57,6 +58,8 @@ RSpec.describe "Barcode Items Admin", type: :system do
     end
 
     context "user visits the edit page" do
+      let!(:item) { create(:item) }
+      let!(:base_item) { create(:base_item) }
       let!(:barcode_item) { create(:global_barcode_item) }
 
       before do
@@ -64,8 +67,6 @@ RSpec.describe "Barcode Items Admin", type: :system do
       end
 
       it 'updates the barcode item' do
-        skip "`@items` is not being set in `edit` action"
-
         fill_in "Quantity", with: 100
         select item.base_item.name, from: "barcode_item_barcodeable_id"
         fill_in "Barcode", with: 66_666


### PR DESCRIPTION
Resolves #1777

### Description
- Fixes the admin barcode_items forms (edit and new) which were broken (some of the functionality was available through the index page)
- The base_item select wasn't being properly populated.
- The admin edit form was hitting the non-admin update, which seemed to work on development but not testing.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

* With system specs for admin/barcode_items