### PR TITLE
Bug fix: throw errors for invalid multiple item quantities

### DIFF
--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -17,7 +17,7 @@ module Itemizable
       def assign_insufficiency_errors(insufficiency_hash)
         insufficiency_hash = insufficiency_hash.index_by { |i| i[:item_id] }
         each do |line_item|
-          next unless insufficiency = insufficiency_hash.fetch(line_item.item_id)
+          next unless insufficiency = insufficiency_hash[line_item.item_id]
 
           line_item.errors.add(:quantity, :insufficient, message: "too high. Change to #{insufficiency[:quantity_on_hand]} or less")
         end

--- a/spec/factories/storage_locations.rb
+++ b/spec/factories/storage_locations.rb
@@ -20,17 +20,27 @@ FactoryBot.define do
 
     trait :with_items do
       transient do
+        item_count { 1 }
         item_quantity { 100 }
         item { nil }
       end
 
       after(:create) do |storage_location, evaluator|
-        item = evaluator.item.nil? ? create(:item) : evaluator.item
-        item.save if item.new_record?
-        create_list(:inventory_item, 1,
-                    storage_location: storage_location,
-                    quantity: evaluator.item_quantity,
-                    item: item)
+        if evaluator.item.nil?
+          item_count = evaluator.item_count
+
+          create_list(:inventory_item, item_count,
+                      storage_location: storage_location,
+                      quantity: evaluator.item_quantity)
+        else
+          item = evaluator.item
+          item.save if item.new_record?
+          create_list(:inventory_item, 1,
+                      storage_location: storage_location,
+                      quantity: evaluator.item_quantity,
+                      item: item,
+                    )
+        end
       end
     end
   end

--- a/spec/factories/storage_locations.rb
+++ b/spec/factories/storage_locations.rb
@@ -38,8 +38,7 @@ FactoryBot.define do
           create_list(:inventory_item, 1,
                       storage_location: storage_location,
                       quantity: evaluator.item_quantity,
-                      item: item,
-                    )
+                      item: item,)
         end
       end
     end

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe DistributionCreateService, type: :service do
               "0": { item_id: storage_location.items.first.id, quantity: 2 },
               "1": { item_id: storage_location.items.last.id, quantity: 500 }
             }
-          }
+        }
       end
 
       it "preserves the Insufficiency error and is unsuccessful" do

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -59,7 +59,18 @@ RSpec.describe DistributionCreateService, type: :service do
     end
 
     context "when there's multiple line items and one has insufficient inventory" do
-      let(:too_much_params) { { organization_id: @organization.id, partner_id: @partner.id, storage_location_id: storage_location.id, line_items_attributes: { "0": { item_id: storage_location.items.first.id, quantity: 2 }, "1": { item_id: storage_location.items.last.id, quantity: 500 } } } }
+      let(:too_much_params) do
+        {
+          organization_id: @organization.id,
+          partner_id: @partner.id,
+          storage_location_id: storage_location.id,
+          line_items_attributes:
+            {
+              "0": { item_id: storage_location.items.first.id, quantity: 2 },
+              "1": { item_id: storage_location.items.last.id, quantity: 500 }
+            }
+          }
+      end
 
       it "preserves the Insufficiency error and is unsuccessful" do
         result = subject.new(too_much_params).call


### PR DESCRIPTION
Resolves #1794

### Description

This is a bug fix. `Hash.fetch` throws an error that was failing silently if the key wasn't present. I've switched it to a normal Hash retrieval with `[]`. In order to test this change, I've also modified the storage_location factory `:with_items` to accept a number of items so that storage locations with multiple items can be created easily in specs.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

* I've added a unit test and confirmed that it fails without the change and passes with it
* I've also QAed in the browser

### Screenshots
![Screen Shot 2020-09-03 at 3 28 10 PM](https://user-images.githubusercontent.com/5439589/92158551-18afc200-edfa-11ea-8ecd-ca7e26ef6bcf.png)
