### PR TITLE
Revert "Bump webpacker from 5.1.1 to 5.2.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -491,7 +491,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webpacker (5.2.1)
+    webpacker (5.1.1)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)


### PR DESCRIPTION
This upgrade actually requires a bump on the node version we have in the deployment environment. As a consequence, deployment isn't working because of this.
```
 DEBUG [a7de610f] 	Webpacker requires Node.js ">=10.17.0" and you are using v10.16.3
```

I'll revert it for now and come back to upgrading this /w the node upgrade.