### PR TITLE
fixes extra line item appearing in distribution form on errors

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -62,8 +62,7 @@ class DistributionsController < ApplicationController
     else
       @distribution = result.distribution
       flash[:error] = insufficient_error_message(result.error.message)
-      # NOTE: Can we just do @distribution.line_items.build, regardless?
-      @distribution.line_items.build if @distribution.line_items.count.zero?
+      @distribution.line_items.build if @distribution.line_items.size.zero?
       @items = current_organization.items.alphabetized
       @storage_locations = current_organization.storage_locations.alphabetized
       render :new


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1793

### Description
Changed count to size because count was checking for line_items in the database while size checks the length of the array. There were never any line_items in the database because they hadn't been saved when there was an error so count always returned zero.
 

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested manually. The bug was present whenever we tested before the change, and wasn't present after the change

### Screenshots
![Screen Shot 2020-09-05 at 8 44 35 AM](https://user-images.githubusercontent.com/57197140/92308664-25482d80-ef54-11ea-9428-39e5da997b85.png)
