### PR TITLE
Fixes extra line item appearing in distribution form for edit and edit with errors

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -62,8 +62,7 @@ class DistributionsController < ApplicationController
     else
       @distribution = result.distribution
       flash[:error] = insufficient_error_message(result.error.message)
-      # NOTE: Can we just do @distribution.line_items.build, regardless?
-      @distribution.line_items.build if @distribution.line_items.count.zero?
+      @distribution.line_items.build if @distribution.line_items.size.zero?
       @items = current_organization.items.alphabetized
       @storage_locations = current_organization.storage_locations.alphabetized
       render :new

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -89,7 +89,7 @@ class DistributionsController < ApplicationController
   def edit
     @distribution = Distribution.includes(:line_items).includes(:storage_location).find(params[:id])
     if (!@distribution.complete? && @distribution.future?) || current_user.organization_admin?
-      @distribution.line_items.build
+      @distribution.line_items.build if @distribution.line_items.size.zero?
       @items = current_organization.items.alphabetized
       @storage_locations = current_organization.storage_locations.alphabetized
     else
@@ -112,7 +112,7 @@ class DistributionsController < ApplicationController
       redirect_to @distribution, notice: "Distribution updated!"
     else
       flash[:error] = insufficient_error_message(result.error.message)
-      @distribution.line_items.build if @distribution.line_items.count.zero?
+      @distribution.line_items.build if @distribution.line_items.size.zero?
       @items = current_organization.items.alphabetized
       @storage_locations = current_organization.storage_locations.alphabetized
       render :edit

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -308,8 +308,6 @@ RSpec.feature "Distributions", type: :system do
         find_all(".numeric")[0].set 1
 
         click_on "Add another item"
-        second_item_name_field = 'distribution_line_items_attributes_1_item_id'
-        select(diaper_type, from: second_item_name_field)
         find_all(".numeric")[1].set 3
 
         first("button", text: "Save").click


### PR DESCRIPTION

Resolves #1793 

### Description
Used the same change as pull request #1805, changed count to size in the edit and update controller actions. Both had an extra line_item appearing on the form previously, and after the changes there are no extra line_items.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested manually. The bug was present whenever we tested before the change, and wasn't present after the change.

### Screenshots
Edit page before change:
![Screen Shot 2020-09-05 at 11 43 46 AM](https://user-images.githubusercontent.com/57197140/92311596-3fdad080-ef6d-11ea-8687-94775ea7a239.png)

Edit page after change:
![Screen Shot 2020-09-05 at 11 44 33 AM](https://user-images.githubusercontent.com/57197140/92311609-541ecd80-ef6d-11ea-9f4c-b673b2681098.png)
