### PR TITLE
Remove hr separator when removing nested line_item form

### DIFF
--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,19 +1,21 @@
-<section class="row nested-fields">
-  <span class='col-md-3 col-10'>
-    <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
-    <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner"> </div>
-  </span>
-  <span class="col-xs-6 col-md-12 col-sm-12">
-    <label class="pull-left">OR</label>
-  </span>
-  <span class="col-md-4 col-10 li-name">
-    <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
-  </span>
-  <div class='col-md-4 col-12 li-quantity'>
-    <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity" } %>
+<section class="nested-fields">
+  <div class="row">
+    <span class='col-md-3 col-10'>
+      <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
+      <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner"> </div>
+    </span>
+    <span class="col-xs-6 col-md-12 col-sm-12">
+      <label class="pull-left">OR</label>
+    </span>
+    <span class="col-md-4 col-10 li-name">
+      <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
+    </span>
+    <div class='col-md-4 col-12 li-quantity'>
+      <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity" } %>
+    </div>
+    <div class='col-md-2 col-12'>
+      <%= delete_line_item_button f %>
+    </div>
   </div>
-  <div class='col-md-2 col-12'>
-    <%= delete_line_item_button f %>
-  </div>
+  <hr class="line-item-separator">
 </section>
-<hr class="line-item-separator">


### PR DESCRIPTION
Resolves #1806

### Description
`delete_line_item_button` here calls `link_to_remove_association` which uses
the cocoon gem for this nested line_item form

More documentation: https://github.com/nathanvda/cocoon#link_to_remove_association

Because the `nested-fields` class was on the `<section>` tag which didn't
include the `<hr>`, when `link_to_remove_association` looked for the
nested form to remove, it only removed the `section` and not the `hr` too

This change wraps the nested form and the hr into one top level div with
the nested-fields class, and keeps the row class on the inner section to
preserve previous styling.


### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested manually

### Screenshots
See issue for bug.

Fix looks like:
![match_explorer](https://user-images.githubusercontent.com/217050/92312024-d4dfc880-ef71-11ea-8665-64819e66e44f.gif)

