### PR TITLE
Allow admins to deactivate and reactivate organization users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ gem "toastr-rails"
 gem "webpacker", "> 4.0"
 gem 'sidekiq-scheduler'
 gem 'bootstrap-daterangepicker-rails'
+gem 'discard', '~> 1.2'
 
 group :development, :test do
   gem "awesome_print"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -143,6 +143,8 @@ GEM
       actionmailer (>= 5.0)
       devise (>= 4.6)
     diff-lcs (1.3)
+    discard (1.2.0)
+      activerecord (>= 4.2, < 7)
     docile (1.3.2)
     dotenv (2.7.6)
     dotenv-rails (2.7.6)
@@ -530,6 +532,7 @@ DEPENDENCIES
   database_cleaner
   devise (>= 4.7.1)
   devise_invitable
+  discard (~> 1.2)
   dotenv-rails
   factory_bot_rails
   faker

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -39,13 +39,13 @@ class OrganizationsController < ApplicationController
   end
 
   def deactivate_user
-    user = User.find_by!(id: params[:user_id], organization_id: current_organization.id)
+    user = User.with_discarded.find_by!(id: params[:user_id], organization_id: current_organization.id)
     user.discard!
     redirect_to organization_path, notice: "User has been deactivated."
   end
 
   def reactivate_user
-    user = User.find_by!(id: params[:user_id], organization_id: current_organization.id)
+    user = User.with_discarded.find_by!(id: params[:user_id], organization_id: current_organization.id)
     user.undiscard!
     redirect_to organization_path, notice: "User has been reactivated."
   end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -38,6 +38,12 @@ class OrganizationsController < ApplicationController
     redirect_to organization_path, notice: "User has been promoted!"
   end
 
+  def deactivate_user
+    user = User.find_by!(id: params[:user_id], organization_id: current_organization.id)
+    user.discard!
+    redirect_to organization_path, notice: "User has been deactivated."
+  end
+
   private
 
   def authorize_user

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -44,6 +44,12 @@ class OrganizationsController < ApplicationController
     redirect_to organization_path, notice: "User has been deactivated."
   end
 
+  def reactivate_user
+    user = User.find_by!(id: params[:user_id], organization_id: current_organization.id)
+    user.undiscard!
+    redirect_to organization_path, notice: "User has been reactivated."
+  end
+
   private
 
   def authorize_user

--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -36,13 +36,13 @@ module UiHelper
 
   def deactivate_button_to(link, options = {})
     data = options[:no_confirm] ? {} : { data: { confirm: options[:confirm] || "Are you sure?" } }
-    properties = { method: :put, rel: "nofollow" }.merge(data)
+    properties = { id: options[:id], method: :put, rel: "nofollow" }.merge(data)
     _link_to link, { icon: "ban", type: "danger", text: "Deactivate", size: "xs" }.merge(options), properties
   end
 
   def reactivate_button_to(link, options = {})
     data = options[:no_confirm] ? {} : { data: { confirm: options[:confirm] || "Are you sure?" } }
-    properties = { method: :put, rel: "nofollow" }.merge(data)
+    properties = { id: options[:id], method: :put, rel: "nofollow" }.merge(data)
     _link_to link, { icon: "repeat", type: "success", text: "Reactivate", size: "xs" }.merge(options), properties
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@
 #  id                     :integer          not null, primary key
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
+#  discarded_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  invitation_accepted_at :datetime
@@ -31,6 +32,7 @@
 #
 
 class User < ApplicationRecord
+  include Discard::Model
   belongs_to :organization, optional: proc { |u| u.super_admin? }
   has_many :feedback_messages, dependent: :destroy
   # Include default devise modules. Others available are:

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,7 +44,8 @@ class User < ApplicationRecord
 
   validates :name, :email, presence: true
 
-  scope :alphabetized, -> { order(:name) }
+  default_scope -> { kept }
+  scope :alphabetized, -> { order(discarded_at: :desc, name: :asc) }
 
   def invitation_status
     return "joined" if current_sign_in_at.present?

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -75,7 +75,7 @@
                   </tr>
                   </thead>
                   <tbody>
-                  <%= render partial: "/users/organization_user", collection: @organization.users.alphabetized, as: :user %>
+                  <%= render partial: "/users/organization_user", collection: @organization.users.with_discarded.alphabetized, as: :user %>
                   </tbody>
                 </table>
               </div>

--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -1,25 +1,48 @@
 <tr>
-  <td><%= user.name %></td>
+  <td>
+    <%= user.name %>
+    <% if user.discarded? %>
+      <span class="badge badge-danger">Deactivated</span>
+    <% end %>
+  </td>
   <td><%= user.email %></td>
   <td><%= user.kind %> </td>
   <td><%= user.current_sign_in_at&.strftime('%Y/%m/%d') %></td>
   <td><%= user.invitation_status %></td>
   <td nowrap><%= reinvite_user_link(user) %></td>
-  <td nowrap><%= edit_button_to promote_to_org_admin_organization_path(user_id: user.id),
-    {text: 'Make admin'},
-    {method: :post, rel: "nofollow", data: {confirm: 'This will promote the user to admin status. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin? %></td>
-  <td nowrap>
-    <% if user.kept? %>
-      <%= edit_button_to deactivate_user_organization_path(user_id: user.id),
-        {text: 'Deactivate'},
-        {id: dom_id(user), method: :post, class: 'deactivate', rel: "nofollow", data: {confirm: 'This will deactivate the user. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin?
-      %>
-    <% else %>
-      <%= edit_button_to reactivate_user_organization_path(user_id: user.id),
-        {text: 'Reactivate'},
-        {id: dom_id(user), method: :post, class: 'reactivate', rel: "nofollow", data: {confirm: 'This will reactivate the user. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin?
-      %>
-    <% end %>
+  <td>
+      <% unless user.super_admin? || user.organization_admin? %>
+        <div class="dropdown">
+          <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+            Actions
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu">
+            <% if user.kept? %>
+              <li>
+                <%=
+                  edit_button_to(
+                    promote_to_org_admin_organization_path(user_id: user.id),
+                    {text: 'Make admin'},
+                    {method: :post, rel: "nofollow", data: {confirm: 'This will promote the user to admin status. Are you sure that you want to submit this?', size: 'xs'}}
+                  )
+                %>
+              </li>
+
+              <li>
+                <%= deactivate_button_to deactivate_user_organization_path(user_id: user.id),
+                  {id: dom_id(user), method: :post, class: 'deactivate', rel: "nofollow", data: {confirm: 'This will deactivate the user. Are you sure that you want to submit this?', size: 'xs'}}
+                %>
+              </li>
+            <% else %>
+              <%= reactivate_button_to reactivate_user_organization_path(user_id: user.id),
+                {id: dom_id(user), method: :post, class: 'reactivate', rel: "nofollow", data: {confirm: 'This will reactivate the user. Are you sure that you want to submit this?', size: 'xs'}}
+              %>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+      </td>
   </td>
 </tr>
 

--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -9,10 +9,17 @@
     {text: 'Make admin'},
     {method: :post, rel: "nofollow", data: {confirm: 'This will promote the user to admin status. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin? %></td>
   <td nowrap>
-    <%= edit_button_to deactivate_user_organization_path(user_id: user.id),
-      {text: 'Deactivate'},
-      {id: dom_id(user), method: :post, class: 'deactivate', rel: "nofollow", data: {confirm: 'This will deactivate the user. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin?
-    %>
+    <% if user.kept? %>
+      <%= edit_button_to deactivate_user_organization_path(user_id: user.id),
+        {text: 'Deactivate'},
+        {id: dom_id(user), method: :post, class: 'deactivate', rel: "nofollow", data: {confirm: 'This will deactivate the user. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin?
+      %>
+    <% else %>
+      <%= edit_button_to reactivate_user_organization_path(user_id: user.id),
+        {text: 'Reactivate'},
+        {id: dom_id(user), method: :post, class: 'reactivate', rel: "nofollow", data: {confirm: 'This will reactivate the user. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin?
+      %>
+    <% end %>
   </td>
 </tr>
 

--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -8,9 +8,11 @@
   <td nowrap><%= edit_button_to promote_to_org_admin_organization_path(user_id: user.id),
     {text: 'Make admin'},
     {method: :post, rel: "nofollow", data: {confirm: 'This will promote the user to admin status. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin? %></td>
-  <td nowrap><%= edit_button_to deactivate_user_organization_path(user_id: user.id),
-    {text: 'Deactivate'},
-    {method: :post, rel: "nofollow", data: {confirm: 'This will deactivate the user. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin? %>
+  <td nowrap>
+    <%= edit_button_to deactivate_user_organization_path(user_id: user.id),
+      {text: 'Deactivate'},
+      {id: dom_id(user), method: :post, class: 'deactivate', rel: "nofollow", data: {confirm: 'This will deactivate the user. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin?
+    %>
   </td>
 </tr>
 

--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -13,7 +13,7 @@
   <td>
       <% unless user.super_admin? || user.organization_admin? %>
         <div class="dropdown">
-          <button class="btn btn-default dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+          <button class="btn btn-default dropdown-toggle" type="button" id=<%= dom_id(user, "dropdownMenu") %> data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
             Actions
             <span class="caret"></span>
           </button>

--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -8,6 +8,10 @@
   <td nowrap><%= edit_button_to promote_to_org_admin_organization_path(user_id: user.id),
     {text: 'Make admin'},
     {method: :post, rel: "nofollow", data: {confirm: 'This will promote the user to admin status. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin? %></td>
+  <td nowrap><%= edit_button_to deactivate_user_organization_path(user_id: user.id),
+    {text: 'Deactivate'},
+    {method: :post, rel: "nofollow", data: {confirm: 'This will deactivate the user. Are you sure that you want to submit this?', size: 'xs'}} unless user.super_admin? or user.organization_admin? %>
+  </td>
 </tr>
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
       collection do
         post :invite_user
         post :deactivate_user
+        post :reactivate_user
         post :resend_user_invitation
         post :promote_to_org_admin
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
     resource :organization, path: :manage, only: %i(edit update) do
       collection do
         post :invite_user
+        post :deactivate_user
         post :resend_user_invitation
         post :promote_to_org_admin
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,8 +61,8 @@ Rails.application.routes.draw do
     resource :organization, path: :manage, only: %i(edit update) do
       collection do
         post :invite_user
-        post :deactivate_user
-        post :reactivate_user
+        put :deactivate_user
+        put :reactivate_user
         post :resend_user_invitation
         post :promote_to_org_admin
       end

--- a/db/migrate/20200905145818_add_discarded_at_to_users.rb
+++ b/db/migrate/20200905145818_add_discarded_at_to_users.rb
@@ -1,0 +1,5 @@
+class AddDiscardedAtToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :discarded_at, :datetime
+  end
+end

--- a/db/migrate/20200905204920_add_discarded_at_index_to_users.rb
+++ b/db/migrate/20200905204920_add_discarded_at_index_to_users.rb
@@ -1,0 +1,5 @@
+class AddDiscardedAtIndexToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_index :users, :discarded_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_05_145818) do
+ActiveRecord::Schema.define(version: 2020_09_05_204920) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -349,6 +349,7 @@ ActiveRecord::Schema.define(version: 2020_09_05_145818) do
     t.boolean "super_admin", default: false
     t.datetime "last_request_at"
     t.datetime "discarded_at"
+    t.index ["discarded_at"], name: "index_users_on_discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_05_164501) do
+ActiveRecord::Schema.define(version: 2020_09_05_145818) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -348,6 +348,7 @@ ActiveRecord::Schema.define(version: 2020_04_05_164501) do
     t.string "name", default: "CHANGEME", null: false
     t.boolean "super_admin", default: false
     t.datetime "last_request_at"
+    t.datetime "discarded_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -69,6 +69,17 @@ RSpec.describe OrganizationsController, type: :controller do
       end
     end
 
+    describe "POST #deactivate_user" do
+      subject { post :deactivate_user, params: default_params.merge(user_id: @user.id) }
+
+      it "deactivates the user" do
+        expect(subject).to have_http_status(:redirect)
+
+        @user.reload
+        expect(@user.discarded_at).to be_present
+      end
+    end
+
     context "when attempting to access a different organization" do
       let(:other_organization) { create(:organization) }
       let(:other_organization_params) do

--- a/spec/controllers/organizations_controller_spec.rb
+++ b/spec/controllers/organizations_controller_spec.rb
@@ -80,6 +80,18 @@ RSpec.describe OrganizationsController, type: :controller do
       end
     end
 
+    describe "POST #reactivate_user" do
+      subject { post :reactivate_user, params: default_params.merge(user_id: @user.id) }
+
+      it "reactivates the user" do
+        @user.discard!
+        expect(subject).to have_http_status(:redirect)
+
+        @user.reload
+        expect(@user.discarded_at).to be_nil
+      end
+    end
+
     context "when attempting to access a different organization" do
       let(:other_organization) { create(:organization) }
       let(:other_organization_params) do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -55,7 +55,7 @@ FactoryBot.define do
       organization_id { nil }
     end
 
-    trait :discarded do
+    trait :deactivated do
       discarded_at { Time.now }
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -53,5 +53,9 @@ FactoryBot.define do
       super_admin { true }
       organization_id { nil }
     end
+
+    trait :discarded do
+      discarded_at { Time.now }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -5,6 +5,7 @@
 #  id                     :integer          not null, primary key
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
+#  discarded_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  invitation_accepted_at :datetime

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -56,7 +56,7 @@ FactoryBot.define do
     end
 
     trait :deactivated do
-      discarded_at { Time.now }
+      discarded_at { Time.zone.now }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe User, type: :model do
 
   describe "Scopes >" do
     describe "->alphabetized" do
-      let(:discarded_at) { Time.now }
+      let(:discarded_at) { Time.zone.now }
 
       let!(:z_name_user) { create(:user, name: 'Zachary') }
       let!(:a_name_user) { create(:user, name: 'Amanda') }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe User, type: :model do
     end
 
     it "discarded?" do
-      expect(build(:user, :discarded).discarded?).to be true
+      expect(build(:user, :deactivated).discarded?).to be true
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -103,5 +103,9 @@ RSpec.describe User, type: :model do
       expect(build(:user, invitation_sent_at: Time.current - 6.days).reinvitable?).to be false
       expect(build(:user, invitation_sent_at: Time.current - 7.days, invitation_accepted_at: Time.current - 7.days).reinvitable?).to be false
     end
+
+    it "discarded?" do
+      expect(build(:user, :discarded).discarded?).to be true
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,6 +5,7 @@
 #  id                     :integer          not null, primary key
 #  current_sign_in_at     :datetime
 #  current_sign_in_ip     :inet
+#  discarded_at           :datetime
 #  email                  :string           default(""), not null
 #  encrypted_password     :string           default(""), not null
 #  invitation_accepted_at :datetime

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -74,14 +74,28 @@ RSpec.describe User, type: :model do
 
   describe "Scopes >" do
     describe "->alphabetized" do
+      let(:discarded_at) { Time.now }
+
       let!(:z_name_user) { create(:user, name: 'Zachary') }
       let!(:a_name_user) { create(:user, name: 'Amanda') }
+      let!(:deactivated_a_name_user) { create(:user, name: 'Alice', discarded_at: discarded_at) }
+      let!(:deactivated_z_name_user) { create(:user, name: 'Zeke', discarded_at: discarded_at) }
 
       it "retrieves users in the correct order" do
-        alphabetized_list = described_class.alphabetized
+        alphabetized_list = described_class.with_discarded.alphabetized
 
-        expect(alphabetized_list.first).to eq(a_name_user)
-        expect(alphabetized_list.last).to eq(z_name_user)
+        expect(alphabetized_list).to eq(
+          [
+            a_name_user,
+            @organization_admin,
+            @super_admin,
+            @super_admin_no_org,
+            @user,
+            z_name_user,
+            deactivated_a_name_user,
+            deactivated_z_name_user
+          ]
+        )
       end
     end
   end

--- a/spec/system/log_in_system_spec.rb
+++ b/spec/system/log_in_system_spec.rb
@@ -6,4 +6,19 @@ RSpec.describe "Authentication", type: :system, js: true do
       expect(page.find("h1")).to have_content "Dashboard"
     end
   end
+
+  describe "Deactivated user" do
+    before do
+      create(:user, :deactivated, email: "deactivated@exmaple.com")
+    end
+
+    it "should not allow the user to log in" do
+      visit "/users/sign_in"
+      fill_in "user_email", with: "deactivated@example.com"
+      fill_in "user_password", with: "password"
+      find('input[name="commit"]').click
+
+      expect(page).to have_content("Invalid Email or password")
+    end
+  end
 end

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe "Organization management", type: :system, js: true do
+  include ActionView::RecordIdentifier
   let!(:url_prefix) { "/#{@organization.to_param}" }
 
   context "while signed in as a normal user" do
@@ -65,6 +66,17 @@ RSpec.describe "Organization management", type: :system, js: true do
       create(:user, name: "Ye Olde Invited User", invitation_sent_at: Time.current - 7.days)
       visit url_prefix + "/organization"
       expect(page).to have_xpath("//i[@alt='Re-send invitation']")
+    end
+
+    it "can deactivate a user in the organization" do
+      user = create(:user, name: "User to be deactivated")
+      visit url_prefix + "/organization"
+      accept_confirm do
+        res = find_link("Deactivate")
+        click_link dom_id(user)
+      end
+
+      expect(user.reload.discarded_at).to be_present
     end
   end
 end

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe "Organization management", type: :system, js: true do
         click_link dom_id(user)
       end
 
+      expect(page).to have_content("User has been deactivated")
       expect(user.reload.discarded_at).to be_present
     end
 

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -72,11 +72,21 @@ RSpec.describe "Organization management", type: :system, js: true do
       user = create(:user, name: "User to be deactivated")
       visit url_prefix + "/organization"
       accept_confirm do
-        res = find_link("Deactivate")
         click_link dom_id(user)
       end
 
       expect(user.reload.discarded_at).to be_present
+    end
+
+    it "can re-activate a user in the organization" do
+      user = create(:user, :deactivated)
+      visit url_prefix + "/organization"
+      accept_confirm do
+        click_link dom_id(user)
+      end
+
+      expect(page).to have_content("User has been reactivated")
+      expect(user.reload.discarded_at).to be_nil
     end
   end
 end

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe "Organization management", type: :system, js: true do
       user = create(:user, name: "User to be deactivated")
       visit url_prefix + "/organization"
       accept_confirm do
+        click_button dom_id(user, "dropdownMenu")
         click_link dom_id(user)
       end
 
@@ -83,6 +84,7 @@ RSpec.describe "Organization management", type: :system, js: true do
       user = create(:user, :deactivated)
       visit url_prefix + "/organization"
       accept_confirm do
+        click_button dom_id(user, "dropdownMenu")
         click_link dom_id(user)
       end
 


### PR DESCRIPTION
Resolves #1757 

This work was done by both me and @cfanpnk.

### Description
This change allows admins to soft-delete (aka "deactivate") users they no longer want in their organization, and it allows them to reactivate users who have previously been deactivated.

Admins can perform these operations from the organization dashboard. Users who have been deactivated will have a red badge appear next to their name to indicate their current status.

We implemented the soft delete functionality using the [discard](https://github.com/jhawthorn/discard) gem.

Additionally, we made some changes to the user interface of the organizations dashboard. We added a dropdown menu that contains any action buttons to prevent multiple buttons from cluttering the UI.

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
We have provided unit tests for all model and controller changes, as well as a system test for deactivating and reactivating users from the organization dashboard.

One thing we tested manually was attempting to log in as a deactivated user. We found that a deactivated user CANNOT log in to their account, with an error message "Invalid email or password" appearing on a banner.

### Screenshots
![Screen-Recording-2020-09-05-at-4](https://user-images.githubusercontent.com/9601737/92313307-53e7f780-ef98-11ea-915f-bfdf289c76d3.gif)
