### PR TITLE
Refactor donation source text

### DIFF
--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -51,6 +51,14 @@ class DiaperDrive < ApplicationRecord
     donations.sum(&:value_per_itemizable)
   end
 
+  def source_view
+    drive_display = if name.present?
+      kind = "diaper drive"
+
+      "#{name} (#{kind})"
+    end
+  end
+
   def self.search_date_range(dates)
     dates = dates.split(" - ")
     @search_date_range = { start_date: dates[0], end_date: dates[1] }

--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -52,11 +52,10 @@ class DiaperDrive < ApplicationRecord
   end
 
   def source_view
-    drive_display = if name.present?
-      kind = "diaper drive"
+    return unless name.present?
+    kind = "diaper drive"
 
-      "#{name} (#{kind})"
-    end
+    "#{name} (#{kind})"
   end
 
   def self.search_date_range(dates)

--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -51,7 +51,7 @@ class DiaperDrive < ApplicationRecord
     donations.sum(&:value_per_itemizable)
   end
 
-  def source_view
+  def donation_source_view
     return unless name.present?
 
     "#{name} (diaper drive)"

--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -52,8 +52,6 @@ class DiaperDrive < ApplicationRecord
   end
 
   def donation_source_view
-    return unless name.present?
-
     "#{name} (diaper drive)"
   end
 

--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -53,9 +53,8 @@ class DiaperDrive < ApplicationRecord
 
   def source_view
     return unless name.present?
-    kind = "diaper drive"
 
-    "#{name} (#{kind})"
+    "#{name} (diaper drive)"
   end
 
   def self.search_date_range(dates)

--- a/app/models/diaper_drive_participant.rb
+++ b/app/models/diaper_drive_participant.rb
@@ -33,10 +33,8 @@ class DiaperDriveParticipant < ApplicationRecord
 
   def source_view
     return unless contact_name.present?
-    name = contact_name
-    kind = "participant"
 
-    "#{name} (#{kind})"
+    "#{contact_name} (participant)"
   end
 
 end

--- a/app/models/diaper_drive_participant.rb
+++ b/app/models/diaper_drive_participant.rb
@@ -32,12 +32,11 @@ class DiaperDriveParticipant < ApplicationRecord
   end
 
   def source_view
-    contact_display = if contact_name.present?
-      name = contact_name
-      kind = "participant"
+    return unless contact_name.present?
+    name = contact_name
+    kind = "participant"
 
-      "#{name} (#{kind})"
-    end
+    "#{name} (#{kind})"
   end
 
 end

--- a/app/models/diaper_drive_participant.rb
+++ b/app/models/diaper_drive_participant.rb
@@ -31,7 +31,7 @@ class DiaperDriveParticipant < ApplicationRecord
     donations.map { |d| d.line_items.total }.reduce(:+)
   end
 
-  def source_view
+  def donation_source_view
     return unless contact_name.present?
 
     "#{contact_name} (participant)"

--- a/app/models/diaper_drive_participant.rb
+++ b/app/models/diaper_drive_participant.rb
@@ -30,4 +30,14 @@ class DiaperDriveParticipant < ApplicationRecord
   def volume
     donations.map { |d| d.line_items.total }.reduce(:+)
   end
+
+  def source_view
+    contact_display = if contact_name.present?
+      name = contact_name
+      kind = "participant"
+
+      "#{name} (#{kind})"
+    end
+  end
+
 end

--- a/app/models/diaper_drive_participant.rb
+++ b/app/models/diaper_drive_participant.rb
@@ -32,9 +32,8 @@ class DiaperDriveParticipant < ApplicationRecord
   end
 
   def donation_source_view
-    return unless contact_name.present?
+    return if contact_name.blank?
 
     "#{contact_name} (participant)"
   end
-
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -92,7 +92,13 @@ class Donation < ApplicationRecord
 
   def source_view
     if from_diaper_drive?
-      format_drive_name
+      if !diaper_drive_participant.nil? && diaper_drive_participant.contact_name.present?
+        "#{diaper_drive_participant.contact_name} (participant)"
+      elsif !diaper_drive.nil? && diaper_drive.name.present?
+        "#{diaper_drive.name} (diaper drive)"
+      else
+        source
+      end
     else
       source
     end
@@ -170,16 +176,6 @@ class Donation < ApplicationRecord
 
   def combine_duplicates
     line_items.combine!
-  end
-
-  def format_drive_name
-    if !diaper_drive_participant.nil? && diaper_drive_participant.contact_name.present?
-      "#{diaper_drive_participant.contact_name} (participant)"
-    elsif !diaper_drive.nil? && diaper_drive.name.present?
-      "#{diaper_drive.name} (diaper drive)"
-    else
-      source
-    end
   end
 
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -94,16 +94,6 @@ class Donation < ApplicationRecord
     from_diaper_drive? ? format_drive_name : source
   end
 
-  def format_drive_name
-    if !diaper_drive_participant.nil? && diaper_drive_participant.contact_name.present?
-      "#{diaper_drive_participant.contact_name} (participant)"
-    elsif !diaper_drive.nil? && diaper_drive.name.present?
-      "#{diaper_drive.name} (diaper drive)"
-    else
-      source
-    end
-  end
-
   def self.daily_quantities_by_source(start, stop)
     joins(:line_items).includes(:line_items)
                       .between(start, stop)
@@ -177,4 +167,15 @@ class Donation < ApplicationRecord
   def combine_duplicates
     line_items.combine!
   end
+
+  def format_drive_name
+    if !diaper_drive_participant.nil? && diaper_drive_participant.contact_name.present?
+      "#{diaper_drive_participant.contact_name} (participant)"
+    elsif !diaper_drive.nil? && diaper_drive.name.present?
+      "#{diaper_drive.name} (diaper drive)"
+    else
+      source
+    end
+  end
+
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -94,14 +94,7 @@ class Donation < ApplicationRecord
     return source unless from_diaper_drive?
 
     contact_display = diaper_drive_participant&.source_view
-
-    drive_name = diaper_drive&.name
-    drive_display = if drive_name.present?
-      name = drive_name
-      kind = "diaper drive"
-
-      "#{name} (#{kind})"
-    end
+    drive_display = diaper_drive&.source_view
 
     contact_display || drive_display || source
   end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -93,10 +93,7 @@ class Donation < ApplicationRecord
   def source_view
     return source unless from_diaper_drive?
 
-    contact_display = diaper_drive_participant&.source_view
-    drive_display = diaper_drive&.source_view
-
-    contact_display || drive_display || source
+    diaper_drive_participant&.source_view || diaper_drive&.source_view || source
   end
 
   def self.daily_quantities_by_source(start, stop)

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -91,7 +91,11 @@ class Donation < ApplicationRecord
   end
 
   def source_view
-    from_diaper_drive? ? format_drive_name : source
+    if from_diaper_drive?
+      format_drive_name
+    else
+      source
+    end
   end
 
   def self.daily_quantities_by_source(start, stop)

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -93,7 +93,7 @@ class Donation < ApplicationRecord
   def source_view
     return source unless from_diaper_drive?
 
-    diaper_drive_participant&.donation_source_view || diaper_drive&.donation_source_view
+    diaper_drive_participant&.donation_source_view || diaper_drive.donation_source_view
   end
 
   def self.daily_quantities_by_source(start, stop)

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -93,13 +93,7 @@ class Donation < ApplicationRecord
   def source_view
     return source unless from_diaper_drive?
 
-    contact_name = diaper_drive_participant&.contact_name
-    contact_display = if contact_name.present?
-      name = contact_name
-      kind = "participant"
-
-      "#{name} (#{kind})"
-    end
+    contact_display = diaper_drive_participant&.source_view
 
     drive_name = diaper_drive&.name
     drive_display = if drive_name.present?

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -97,13 +97,15 @@ class Donation < ApplicationRecord
     drive_name = diaper_drive&.name
 
     if contact_name.present?
+      name = contact_name
       kind = "participant"
 
-      "#{contact_name} (#{kind})"
+      "#{name} (#{kind})"
     elsif drive_name.present?
+      name = drive_name
       kind = "diaper drive"
 
-      "#{drive_name} (#{kind})"
+      "#{name} (#{kind})"
     else
       source
     end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -94,10 +94,12 @@ class Donation < ApplicationRecord
     return source unless from_diaper_drive?
 
     contact_name = diaper_drive_participant&.contact_name
+    drive_name = diaper_drive&.name
+
     if contact_name.present?
       "#{contact_name} (participant)"
-    elsif diaper_drive&.name.present?
-      "#{diaper_drive.name} (diaper drive)"
+    elsif drive_name.present?
+      "#{drive_name} (diaper drive)"
     else
       source
     end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -92,9 +92,9 @@ class Donation < ApplicationRecord
 
   def source_view
     if from_diaper_drive?
-      if !diaper_drive_participant.nil? && diaper_drive_participant.contact_name.present?
+      if diaper_drive_participant&.contact_name.present?
         "#{diaper_drive_participant.contact_name} (participant)"
-      elsif !diaper_drive.nil? && diaper_drive.name.present?
+      elsif diaper_drive&.name.present?
         "#{diaper_drive.name} (diaper drive)"
       else
         source

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -169,5 +169,4 @@ class Donation < ApplicationRecord
   def combine_duplicates
     line_items.combine!
   end
-
 end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -93,7 +93,12 @@ class Donation < ApplicationRecord
   def source_view
     return source unless from_diaper_drive?
 
-    diaper_drive_participant&.source_view || diaper_drive&.source_view || source
+    [
+      diaper_drive_participant&.source_view,
+      diaper_drive&.source_view,
+      source
+    ].detect(&:present?)
+
   end
 
   def self.daily_quantities_by_source(start, stop)

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -94,21 +94,22 @@ class Donation < ApplicationRecord
     return source unless from_diaper_drive?
 
     contact_name = diaper_drive_participant&.contact_name
-    drive_name = diaper_drive&.name
-
-    if contact_name.present?
+    contact_display = if contact_name.present?
       name = contact_name
       kind = "participant"
 
       "#{name} (#{kind})"
-    elsif drive_name.present?
+    end
+
+    drive_name = diaper_drive&.name
+    drive_display = if drive_name.present?
       name = drive_name
       kind = "diaper drive"
 
       "#{name} (#{kind})"
-    else
-      source
     end
+
+    contact_display || drive_display || source
   end
 
   def self.daily_quantities_by_source(start, stop)

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -93,8 +93,9 @@ class Donation < ApplicationRecord
   def source_view
     return source unless from_diaper_drive?
 
-    if diaper_drive_participant&.contact_name.present?
-      "#{diaper_drive_participant.contact_name} (participant)"
+    contact_name = diaper_drive_participant&.contact_name
+    if contact_name.present?
+      "#{contact_name} (participant)"
     elsif diaper_drive&.name.present?
       "#{diaper_drive.name} (diaper drive)"
     else

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -91,14 +91,12 @@ class Donation < ApplicationRecord
   end
 
   def source_view
-    if from_diaper_drive?
-      if diaper_drive_participant&.contact_name.present?
-        "#{diaper_drive_participant.contact_name} (participant)"
-      elsif diaper_drive&.name.present?
-        "#{diaper_drive.name} (diaper drive)"
-      else
-        source
-      end
+    return source unless from_diaper_drive?
+
+    if diaper_drive_participant&.contact_name.present?
+      "#{diaper_drive_participant.contact_name} (participant)"
+    elsif diaper_drive&.name.present?
+      "#{diaper_drive.name} (diaper drive)"
     else
       source
     end

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -93,12 +93,7 @@ class Donation < ApplicationRecord
   def source_view
     return source unless from_diaper_drive?
 
-    [
-      diaper_drive_participant&.donation_source_view,
-      diaper_drive&.donation_source_view,
-      source
-    ].detect(&:present?)
-
+    diaper_drive_participant&.donation_source_view || diaper_drive&.donation_source_view
   end
 
   def self.daily_quantities_by_source(start, stop)

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -94,8 +94,8 @@ class Donation < ApplicationRecord
     return source unless from_diaper_drive?
 
     [
-      diaper_drive_participant&.source_view,
-      diaper_drive&.source_view,
+      diaper_drive_participant&.donation_source_view,
+      diaper_drive&.donation_source_view,
       source
     ].detect(&:present?)
 

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -97,9 +97,13 @@ class Donation < ApplicationRecord
     drive_name = diaper_drive&.name
 
     if contact_name.present?
-      "#{contact_name} (participant)"
+      kind = "participant"
+
+      "#{contact_name} (#{kind})"
     elsif drive_name.present?
-      "#{drive_name} (diaper drive)"
+      kind = "diaper drive"
+
+      "#{drive_name} (#{kind})"
     else
       source
     end

--- a/spec/models/diaper_drive_participant_spec.rb
+++ b/spec/models/diaper_drive_participant_spec.rb
@@ -42,5 +42,23 @@ RSpec.describe DiaperDriveParticipant, type: :model do
         expect(ddp.volume).to eq(10)
       end
     end
+
+    describe "donation_source_view" do
+      context "contact name present" do
+        it do
+          ddp = create(:diaper_drive_participant, contact_name: "Contact Name")
+
+          expect(ddp.donation_source_view).to eq("Contact Name (participant)")
+        end
+      end
+
+      context "no contact name" do
+        it do
+          ddp = create(:diaper_drive_participant, contact_name: nil)
+
+          expect(ddp.donation_source_view).to be_nil
+        end
+      end
+    end
   end
 end

--- a/spec/models/diaper_drive_participant_spec.rb
+++ b/spec/models/diaper_drive_participant_spec.rb
@@ -44,18 +44,20 @@ RSpec.describe DiaperDriveParticipant, type: :model do
     end
 
     describe "donation_source_view" do
-      context "contact name present" do
-        it do
-          ddp = create(:diaper_drive_participant, contact_name: "Contact Name")
+      let!(:ddp) { create(:diaper_drive_participant, contact_name: contact_name) }
 
+      context "contact name present" do
+        let(:contact_name) { "Contact Name" }
+
+        it do
           expect(ddp.donation_source_view).to eq("Contact Name (participant)")
         end
       end
 
       context "no contact name" do
-        it do
-          ddp = create(:diaper_drive_participant, contact_name: nil)
+        let(:contact_name) { nil }
 
+        it do
           expect(ddp.donation_source_view).to be_nil
         end
       end

--- a/spec/models/diaper_drive_participant_spec.rb
+++ b/spec/models/diaper_drive_participant_spec.rb
@@ -44,13 +44,13 @@ RSpec.describe DiaperDriveParticipant, type: :model do
     end
 
     describe "donation_source_view" do
-      let!(:ddp) { create(:diaper_drive_participant, contact_name: contact_name) }
+      let!(:participant) { create(:diaper_drive_participant, contact_name: contact_name) }
 
       context "contact name present" do
         let(:contact_name) { "Contact Name" }
 
         it do
-          expect(ddp.donation_source_view).to eq("Contact Name (participant)")
+          expect(participant.donation_source_view).to eq("Contact Name (participant)")
         end
       end
 
@@ -58,7 +58,7 @@ RSpec.describe DiaperDriveParticipant, type: :model do
         let(:contact_name) { nil }
 
         it do
-          expect(ddp.donation_source_view).to be_nil
+          expect(participant.donation_source_view).to be_nil
         end
       end
     end

--- a/spec/models/diaper_drive_spec.rb
+++ b/spec/models/diaper_drive_spec.rb
@@ -85,10 +85,8 @@ RSpec.describe DiaperDrive, type: :model do
   end
 
   describe "donation_source_view" do
-
     it "returns formatted text" do
       expect(diaper_drive.donation_source_view).to eq("Test Drive (diaper drive)")
     end
-
   end
 end

--- a/spec/models/diaper_drive_spec.rb
+++ b/spec/models/diaper_drive_spec.rb
@@ -83,4 +83,12 @@ RSpec.describe DiaperDrive, type: :model do
 
     it { is_expected.to eq(start_date: '2019-12-17', end_date: '2019-12-19') }
   end
+
+  describe "donation_source_view" do
+
+    it "returns formatted text" do
+      expect(diaper_drive.donation_source_view).to eq("Test Drive (diaper drive)")
+    end
+
+  end
 end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -191,10 +191,9 @@ RSpec.describe Donation, type: :model do
     end
 
     describe "source_view" do
-      let!(:donation) { create(:donation, source: source, diaper_drive_participant: diaper_drive_participant, diaper_drive: diaper_drive) }
 
       context "from a drive" do
-        let(:source) { "Diaper Drive" }
+        let!(:donation) { create(:diaper_drive_donation, diaper_drive_participant: diaper_drive_participant, diaper_drive: diaper_drive) }
 
         let(:diaper_drive) { create(:diaper_drive, name: drive_name) }
         let(:drive_name) { "Test Drive" }
@@ -229,13 +228,10 @@ RSpec.describe Donation, type: :model do
       end
 
       context "not from a drive" do
-        let(:source) { "Misc. Donation" }
-
-        let(:diaper_drive_participant) { nil }
-        let(:diaper_drive) { nil }
+        let!(:donation) { create(:manufacturer_donation) }
 
         it "returns source" do
-          expect(donation.source_view).to eq(source)
+          expect(donation.source_view).to eq(donation.source)
         end
       end
     end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -193,15 +193,16 @@ RSpec.describe Donation, type: :model do
     describe "source_view" do
       let!(:donation) { create(:donation, source: source, diaper_drive_participant: diaper_drive_participant, diaper_drive: diaper_drive) }
 
-      context "when source is Diaper Drive" do
+      context "from a diaper drive" do
         let(:source) { "Diaper Drive" }
 
-        let(:diaper_drive) { create(:diaper_drive, name: "Test Drive") }
+        let(:diaper_drive) { create(:diaper_drive, name: drive_name) }
+        let(:drive_name) { "Test Drive" }
 
-        context "when participant exists" do
+        context "participant known" do
           let(:diaper_drive_participant) { create(:diaper_drive_participant, contact_name: contact_name) }
 
-          context "when contact name is known" do
+          context "contact name is known" do
             let(:contact_name) { "Contact Name" }
 
             it "returns participant display name" do
@@ -209,7 +210,7 @@ RSpec.describe Donation, type: :model do
             end
           end
 
-          context "when contact name is empty" do
+          context "contact name is empty" do
             let(:contact_name) { "" }
 
             it "returns drive display name" do
@@ -218,7 +219,7 @@ RSpec.describe Donation, type: :model do
 
           end
 
-          context "when contact name is spaces" do
+          context "contact name is spaces" do
             let(:contact_name) { "     " }
 
             it "returns drive display name" do
@@ -227,7 +228,7 @@ RSpec.describe Donation, type: :model do
 
           end
 
-          context "when contact name is nil" do
+          context "contact name is nil" do
             let(:contact_name) { nil }
 
             it "returns drive display name" do
@@ -238,14 +239,13 @@ RSpec.describe Donation, type: :model do
 
         end
 
-        context "when no drive participant" do
+        context "unknown participant" do
           let(:diaper_drive_participant) { nil }
 
           it "returns drive display name" do
             expect(donation.source_view).to eq("Test Drive (diaper drive)")
           end
         end
-
       end
     end
   end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -205,6 +205,15 @@ RSpec.describe Donation, type: :model do
           end
         end
 
+        context "when drive participant exists" do
+          let(:diaper_drive_participant) { create(:diaper_drive_participant, contact_name: "Contact Name") }
+          let(:diaper_drive) { create(:diaper_drive, name: "Test Drive") }
+
+          it "returns participant display name" do
+            expect(donation.source_view).to eq("Contact Name (participant)")
+          end
+        end
+
       end
     end
   end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -189,6 +189,15 @@ RSpec.describe Donation, type: :model do
         end
       end
     end
+
+    describe "source_view" do
+      let!(:donation) { create(:donation) }
+
+      it do
+        expect(donation.source_view).to eq(donation.source)
+      end
+
+    end
   end
 
   describe "SOURCES" do

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -199,10 +199,41 @@ RSpec.describe Donation, type: :model do
         let(:diaper_drive) { create(:diaper_drive, name: "Test Drive") }
 
         context "when participant exists" do
-          let(:diaper_drive_participant) { create(:diaper_drive_participant, contact_name: "Contact Name") }
+          let(:diaper_drive_participant) { create(:diaper_drive_participant, contact_name: contact_name) }
 
-          it "returns participant display name" do
-            expect(donation.source_view).to eq("Contact Name (participant)")
+          context "when contact name is known" do
+            let(:contact_name) { "Contact Name" }
+
+            it "returns participant display name" do
+              expect(donation.source_view).to eq("Contact Name (participant)")
+            end
+          end
+
+          context "when contact name is empty" do
+            let(:contact_name) { "" }
+
+            it "returns drive display name" do
+              expect(donation.source_view).to eq("Test Drive (diaper drive)")
+            end
+
+          end
+
+          context "when contact name is spaces" do
+            let(:contact_name) { "     " }
+
+            it "returns drive display name" do
+              expect(donation.source_view).to eq("Test Drive (diaper drive)")
+            end
+
+          end
+
+          context "when contact name is nil" do
+            let(:contact_name) { nil }
+
+            it "returns drive display name" do
+              expect(donation.source_view).to eq("Test Drive (diaper drive)")
+            end
+
           end
 
         end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -191,10 +191,15 @@ RSpec.describe Donation, type: :model do
     end
 
     describe "source_view" do
-      let!(:donation) { create(:donation) }
+      let!(:donation) { create(:donation, diaper_drive_participant: diaper_drive_participant, diaper_drive: diaper_drive) }
 
-      it do
-        expect(donation.source_view).to eq(donation.source)
+      context "when no drive participant and no drive" do
+        let(:diaper_drive_participant) { nil }
+        let(:diaper_drive) { nil }
+
+        it "returns donation's source" do
+          expect(donation.source_view).to eq(donation.source)
+        end
       end
 
     end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -191,17 +191,21 @@ RSpec.describe Donation, type: :model do
     end
 
     describe "source_view" do
-      let!(:donation) { create(:donation, diaper_drive_participant: diaper_drive_participant, diaper_drive: diaper_drive) }
+      let!(:donation) { create(:donation, source: source, diaper_drive_participant: diaper_drive_participant, diaper_drive: diaper_drive) }
 
-      context "when no drive participant and no drive" do
-        let(:diaper_drive_participant) { nil }
-        let(:diaper_drive) { nil }
+      context "when source is Diaper Drive" do
+        let(:source) { "Diaper Drive" }
 
-        it "returns donation's source" do
-          expect(donation.source_view).to eq(donation.source)
+        context "when no drive participant" do
+          let(:diaper_drive_participant) { nil }
+          let(:diaper_drive) { create(:diaper_drive, name: "Test Drive") }
+
+          it "returns diaper drive display name" do
+            expect(donation.source_view).to eq("Test Drive (diaper drive)")
+          end
         end
-      end
 
+      end
     end
   end
 

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -216,9 +216,7 @@ RSpec.describe Donation, type: :model do
             it "returns drive display name" do
               expect(donation.source_view).to eq("Test Drive (diaper drive)")
             end
-
           end
-
         end
 
         context "unknown participant" do
@@ -239,7 +237,6 @@ RSpec.describe Donation, type: :model do
         it "returns source" do
           expect(donation.source_view).to eq(source)
         end
-
       end
     end
   end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -191,12 +191,10 @@ RSpec.describe Donation, type: :model do
     end
 
     describe "source_view" do
-
       context "from a drive" do
         let!(:donation) { create(:diaper_drive_donation, diaper_drive_participant: diaper_drive_participant, diaper_drive: diaper_drive) }
 
-        let(:diaper_drive) { create(:diaper_drive, name: drive_name) }
-        let(:drive_name) { "Test Drive" }
+        let(:diaper_drive) { create(:diaper_drive, name: "Test Drive") }
 
         context "participant known" do
           let(:diaper_drive_participant) { create(:diaper_drive_participant, contact_name: contact_name) }

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -193,7 +193,7 @@ RSpec.describe Donation, type: :model do
     describe "source_view" do
       let!(:donation) { create(:donation, source: source, diaper_drive_participant: diaper_drive_participant, diaper_drive: diaper_drive) }
 
-      context "from a diaper drive" do
+      context "from a drive" do
         let(:source) { "Diaper Drive" }
 
         let(:diaper_drive) { create(:diaper_drive, name: drive_name) }
@@ -246,6 +246,17 @@ RSpec.describe Donation, type: :model do
             expect(donation.source_view).to eq("Test Drive (diaper drive)")
           end
         end
+      end
+
+      context "not from a drive" do
+        let(:source) { "Misc. Donation" }
+        let(:diaper_drive_participant) { nil }
+        let(:diaper_drive) { nil }
+
+        it "returns source" do
+          expect(donation.source_view).to eq(source)
+        end
+
       end
     end
   end

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -202,7 +202,7 @@ RSpec.describe Donation, type: :model do
         context "participant known" do
           let(:diaper_drive_participant) { create(:diaper_drive_participant, contact_name: contact_name) }
 
-          context "contact name is known" do
+          context "contact name present" do
             let(:contact_name) { "Contact Name" }
 
             it "returns participant display name" do
@@ -210,25 +210,7 @@ RSpec.describe Donation, type: :model do
             end
           end
 
-          context "contact name is empty" do
-            let(:contact_name) { "" }
-
-            it "returns drive display name" do
-              expect(donation.source_view).to eq("Test Drive (diaper drive)")
-            end
-
-          end
-
-          context "contact name is spaces" do
-            let(:contact_name) { "     " }
-
-            it "returns drive display name" do
-              expect(donation.source_view).to eq("Test Drive (diaper drive)")
-            end
-
-          end
-
-          context "contact name is nil" do
+          context "no contact name" do
             let(:contact_name) { nil }
 
             it "returns drive display name" do
@@ -250,6 +232,7 @@ RSpec.describe Donation, type: :model do
 
       context "not from a drive" do
         let(:source) { "Misc. Donation" }
+
         let(:diaper_drive_participant) { nil }
         let(:diaper_drive) { nil }
 

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -196,21 +196,22 @@ RSpec.describe Donation, type: :model do
       context "when source is Diaper Drive" do
         let(:source) { "Diaper Drive" }
 
-        context "when no drive participant" do
-          let(:diaper_drive_participant) { nil }
-          let(:diaper_drive) { create(:diaper_drive, name: "Test Drive") }
+        let(:diaper_drive) { create(:diaper_drive, name: "Test Drive") }
 
-          it "returns diaper drive display name" do
-            expect(donation.source_view).to eq("Test Drive (diaper drive)")
-          end
-        end
-
-        context "when drive participant exists" do
+        context "when participant exists" do
           let(:diaper_drive_participant) { create(:diaper_drive_participant, contact_name: "Contact Name") }
-          let(:diaper_drive) { create(:diaper_drive, name: "Test Drive") }
 
           it "returns participant display name" do
             expect(donation.source_view).to eq("Contact Name (participant)")
+          end
+
+        end
+
+        context "when no drive participant" do
+          let(:diaper_drive_participant) { nil }
+
+          it "returns drive display name" do
+            expect(donation.source_view).to eq("Test Drive (diaper drive)")
           end
         end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Ref #1024 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
With the motivation of learning more about this project and providing some value in the mean time, I targeted the issue of test coverage ( #1024 ). Additionally followed this up with refactoring.

`Donation#source_view` is a method that formats a string for the view. This string is conditionally built and didn't already have test coverage. 

Adding the test coverage revealed a few things about the implementation:
https://github.com/rubyforgood/diaper/blob/717f97438b0dd37f4f82d2a4d383e6ebb749cb22/app/models/donation.rb#L93-L105
- `!diaper_drive.nil?` is not needed, as a `DiaperDrive` association to a diaper drive `Donation` is required by validations.
https://github.com/rubyforgood/diaper/blob/717f97438b0dd37f4f82d2a4d383e6ebb749cb22/app/models/donation.rb#L62-L64
- `diaper_drive.name.present?` is not needed, as DiaperDrive is required by validations to have a name. https://github.com/rubyforgood/diaper/blob/717f97438b0dd37f4f82d2a4d383e6ebb749cb22/app/models/diaper_drive.rb#L26-L27
- `source` else case is never executed for the previous reasons points above.

Though these points were noticed by being unable to setup test situations for the conditions due to validation failure, I did notice these aren't enforced at the database level. There is a possibility that data exists that doesn't conform to application validations and we would need these checks for reading that data. If that's the case, we can re-add them.

### Type of change

* Test Coverage
* Refactoring

### How Has This Been Tested?

Automated tests

