### PR TITLE
Refactor transfer quantity validation

### DIFF
--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -35,5 +35,4 @@ class LineItem < ApplicationRecord
   def package_count
     format("%g", has_packages) if has_packages
   end
-
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -22,6 +22,8 @@ class LineItem < ApplicationRecord
   validates :quantity, numericality: { only_integer: true, less_than: MAX_INT, greater_than: MIN_INT }
   scope :active, -> { joins(:item).where(items: { active: true }) }
 
+  delegate :name, to: :item
+
   def value_per_line_item
     (item&.value_in_cents || 0) * quantity
   end
@@ -34,7 +36,4 @@ class LineItem < ApplicationRecord
     format("%g", has_packages) if has_packages
   end
 
-  def name
-    item.name
-  end
 end

--- a/app/models/line_item.rb
+++ b/app/models/line_item.rb
@@ -33,4 +33,8 @@ class LineItem < ApplicationRecord
   def package_count
     format("%g", has_packages) if has_packages
   end
+
+  def name
+    item.name
+  end
 end

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -53,7 +53,7 @@ class StorageLocation < ApplicationRecord
   end
 
   def item_total(item_id)
-    inventory_items.select(:quantity).find_by(item_id: item_id).try(:quantity)
+    inventory_items.select(:quantity).find_by(item_id: item_id).try(:quantity) || 0
   end
 
   def size

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -80,12 +80,8 @@ class Transfer < ApplicationRecord
   def from_storage_locations_must_have_enough_to_transfer_out
     return if organization.nil? || from.nil?
 
-    quantity_by_id = from.inventory_items.reduce({}) do |memo, item|
-      memo.merge(item.item_id => item.quantity)
-    end
-
     insufficient = line_items.select do |item|
-      item.quantity > quantity_by_id.fetch(item.item_id, 0)
+      item.quantity > from.item_total(item.item_id)
     end
 
     names = insufficient.map(&:name)

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -84,14 +84,13 @@ class Transfer < ApplicationRecord
       memo.merge(inventory_item.item_id => inventory_item.quantity)
     end
 
-    insufficient_items = []
 
     filtered = line_items.select do |item|
       item.quantity > quantity_by_id.fetch(item.item_id, 0)
     end
 
-    filtered.each do |line_item|
-      insufficient_items << line_item.item.name
+    insufficient_items = filtered.map do |line_item|
+      line_item.item.name
     end
 
     if insufficient_items.any?

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -40,7 +40,7 @@ class Transfer < ApplicationRecord
   validate :line_item_items_exist_in_inventory
   validate :storage_locations_belong_to_organization
   validate :storage_locations_must_be_different
-  validate :from_storage_locations_must_have_enough_to_transfer_out
+  validate :from_storage_quantities
 
   def self.csv_export_headers
     ["From", "To", "Comment", "Total Moved"]
@@ -77,7 +77,7 @@ class Transfer < ApplicationRecord
     end
   end
 
-  def from_storage_locations_must_have_enough_to_transfer_out
+  def from_storage_quantities
     return if organization.nil? || from.nil?
 
     names = insufficient_items.map(&:name)

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -80,17 +80,20 @@ class Transfer < ApplicationRecord
   def from_storage_locations_must_have_enough_to_transfer_out
     return if organization.nil? || from.nil?
 
-    inventory_items = from.inventory_items.reduce({}) do |memo, inventory_item|
+    quantity_by_id = from.inventory_items.reduce({}) do |memo, inventory_item|
       memo.merge(inventory_item.item_id => inventory_item.quantity)
     end
+
     insufficient_items = []
     line_items.each do |line_item|
-      if line_item.quantity > inventory_items.fetch(line_item.item_id, 0)
+      if line_item.quantity > quantity_by_id.fetch(line_item.item_id, 0)
         insufficient_items << line_item.item.name
       end
     end
+
     if insufficient_items.any?
       errors.add :from, "location has insufficient inventory for #{insufficient_items.join(', ')}"
     end
   end
+
 end

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -88,6 +88,6 @@ class Transfer < ApplicationRecord
   end
 
   def insufficient_items
-    line_items.select { |i| i.quantity > (from.item_total(i.item_id) || 0) }
+    line_items.select { |i| i.quantity > from.item_total(i.item_id) }
   end
 end

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -90,5 +90,4 @@ class Transfer < ApplicationRecord
   def insufficient_items
     line_items.select { |i| i.quantity > from.item_total(i.item_id) }
   end
-
 end

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -88,7 +88,7 @@ class Transfer < ApplicationRecord
       item.quantity > quantity_by_id.fetch(item.item_id, 0)
     end
 
-    names = insufficient.map { |i| i.item.name }
+    names = insufficient.map(&:name)
 
     if names.any?
       errors.add :from, "location has insufficient inventory for #{names.join(', ')}"

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -84,14 +84,11 @@ class Transfer < ApplicationRecord
       memo.merge(inventory_item.item_id => inventory_item.quantity)
     end
 
-
     insufficient = line_items.select do |item|
       item.quantity > quantity_by_id.fetch(item.item_id, 0)
     end
 
-    names = insufficient.map do |line_item|
-      line_item.item.name
-    end
+    names = insufficient.map { |line_item| line_item.item.name }
 
     if names.any?
       errors.add :from, "location has insufficient inventory for #{names.join(', ')}"

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -80,8 +80,8 @@ class Transfer < ApplicationRecord
   def from_storage_locations_must_have_enough_to_transfer_out
     return if organization.nil? || from.nil?
 
-    quantity_by_id = from.inventory_items.reduce({}) do |memo, inventory_item|
-      memo.merge(inventory_item.item_id => inventory_item.quantity)
+    quantity_by_id = from.inventory_items.reduce({}) do |memo, item|
+      memo.merge(item.item_id => item.quantity)
     end
 
     insufficient = line_items.select do |item|

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -89,11 +89,11 @@ class Transfer < ApplicationRecord
       item.quantity > quantity_by_id.fetch(item.item_id, 0)
     end
 
-    insufficient_items = filtered.map do |line_item|
+    insufficient = filtered.map do |line_item|
       line_item.item.name
     end
 
-    if insufficient_items.any?
+    if insufficient.any?
       errors.add :from, "location has insufficient inventory for #{insufficient_items.join(', ')}"
     end
   end

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -85,10 +85,13 @@ class Transfer < ApplicationRecord
     end
 
     insufficient_items = []
-    line_items.each do |line_item|
-      if line_item.quantity > quantity_by_id.fetch(line_item.item_id, 0)
-        insufficient_items << line_item.item.name
-      end
+
+    filtered = line_items.select do |item|
+      item.quantity > quantity_by_id.fetch(item.item_id, 0)
+    end
+
+    filtered.each do |line_item|
+      insufficient_items << line_item.item.name
     end
 
     if insufficient_items.any?

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -85,16 +85,16 @@ class Transfer < ApplicationRecord
     end
 
 
-    filtered = line_items.select do |item|
+    insufficient = line_items.select do |item|
       item.quantity > quantity_by_id.fetch(item.item_id, 0)
     end
 
-    insufficient = filtered.map do |line_item|
+    names = insufficient.map do |line_item|
       line_item.item.name
     end
 
-    if insufficient.any?
-      errors.add :from, "location has insufficient inventory for #{insufficient_items.join(', ')}"
+    if names.any?
+      errors.add :from, "location has insufficient inventory for #{names.join(', ')}"
     end
   end
 

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -88,7 +88,7 @@ class Transfer < ApplicationRecord
       item.quantity > quantity_by_id.fetch(item.item_id, 0)
     end
 
-    names = insufficient.map { |line_item| line_item.item.name }
+    names = insufficient.map { |i| i.item.name }
 
     if names.any?
       errors.add :from, "location has insufficient inventory for #{names.join(', ')}"

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -80,8 +80,8 @@ class Transfer < ApplicationRecord
   def from_storage_locations_must_have_enough_to_transfer_out
     return if organization.nil? || from.nil?
 
-    inventory_items = from.inventory_items.each_with_object({}) do |inventory_item, memo|
-      memo[inventory_item.item_id] = inventory_item.quantity
+    inventory_items = from.inventory_items.reduce({}) do |memo, inventory_item|
+      memo.merge(inventory_item.item_id => inventory_item.quantity)
     end
     insufficient_items = []
     line_items.each do |line_item|

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -80,15 +80,15 @@ class Transfer < ApplicationRecord
   def from_storage_locations_must_have_enough_to_transfer_out
     return if organization.nil? || from.nil?
 
-    insufficient = line_items.select do |item|
-      item.quantity > from.item_total(item.item_id)
-    end
-
-    names = insufficient.map(&:name)
+    names = insufficient_items.map(&:name)
 
     if names.any?
       errors.add :from, "location has insufficient inventory for #{names.join(', ')}"
     end
+  end
+
+  def insufficient_items
+    line_items.select { |i| i.quantity > from.item_total(i.item_id) }
   end
 
 end

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -88,6 +88,6 @@ class Transfer < ApplicationRecord
   end
 
   def insufficient_items
-    line_items.select { |i| i.quantity > from.item_total(i.item_id) }
+    line_items.select { |i| i.quantity > (from.item_total(i.item_id) || 0) }
   end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
While looking into how transfers work (#1418), I noticed the custom validation `Transfer#from_storage_locations_must_have_enough_to_transfer_out`. The refactoring came out of curiosity of how it worked and to learn more about the model relationships involved.

This method is making sure "from" storage location has enough quantity in their inventory to fulfill the transfer being created. I noticed the existence of `StorageLocation#item_total` that we could use to simplify.

https://github.com/rubyforgood/diaper/blob/2f09730aa0585d50326199f981cdca4543a115d8/app/models/storage_location.rb#L55-L57

### Type of change

<!-- Please delete options that are not relevant. -->

* Refactoring

### How Has This Been Tested?

Full test run; The validation method is covered by this test: 
https://github.com/rubyforgood/diaper/blob/2f09730aa0585d50326199f981cdca4543a115d8/spec/models/transfer_spec.rb#L53-L59
