### PR TITLE
Prevent Setting Self as Non Admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,11 +9,13 @@ ruby "2.7.1"
 
 gem "api-auth", "~> 2.4"
 gem 'bootstrap', '~> 4.5.2'
+gem 'bootstrap-daterangepicker-rails'
 gem 'bootstrap-select-rails'
 gem "bugsnag"
 gem "chartkick"
 gem "cocoon"
 gem "devise", '>= 4.7.1'
+gem 'discard', '~> 1.2'
 gem "devise_invitable"
 gem "dotenv-rails"
 gem "filterrific"
@@ -30,28 +32,26 @@ gem "jbuilder"
 gem "jquery-rails"
 gem "jquery-ui-rails"
 gem "kaminari"
+gem "mini_racer", "~> 0.3.1"
 gem "momentjs-rails"
 gem "newrelic_rpm"
 gem "nokogiri", ">= 1.10.4"
 gem "paperclip" # needed for legacy migrations
 gem "pg", "~> 1.2.3"
+gem "simple_form"
 gem 'popper_js'
 gem "prawn-rails"
 gem "puma"
 gem "rails", "~> 6.0.3"
 gem "sass-rails"
 gem "sidekiq"
-gem "simple_form"
+gem 'sidekiq-scheduler'
 gem "skylight"
 gem "sprockets", "~> 4.0.2"
-gem "uglifier", ">= 1.3.0"
-gem "mini_racer", "~> 0.3.1"
-gem "yajl-ruby"
 gem "toastr-rails"
+gem "uglifier", ">= 1.3.0"
 gem "webpacker", "> 4.0"
-gem 'sidekiq-scheduler'
-gem 'bootstrap-daterangepicker-rails'
-gem 'discard', '~> 1.2'
+gem "yajl-ruby"
 
 group :development, :test do
   gem "awesome_print"

--- a/app/views/users/_organization_user.html.erb
+++ b/app/views/users/_organization_user.html.erb
@@ -45,7 +45,7 @@
       <% if current_user.organization_admin? and user.organization_admin?%>
         <%= edit_button_to demote_to_user_organization_path(user_id: user.id),
                  {text: 'Make User'},
-                 {method: :post, rel: "nofollow", data: {confirm: 'This will demote the admin to user status. Are you sure that you want to submit this?', size: 'xs'}} %>
+                 {method: :post, rel: "nofollow", data: {confirm: 'This will demote the admin to user status. Are you sure that you want to submit this?', size: 'xs'}} unless user.id == current_user.id %>
       <% end %>
       </td>
   </td>

--- a/db/migrate/20170923232659_add_name_to_user.rb
+++ b/db/migrate/20170923232659_add_name_to_user.rb
@@ -2,13 +2,13 @@
 class AddNameToUser < ActiveRecord::Migration[5.1]
   def up
     add_column :users, :name, :string, null: false, default: "CHANGEME"
-    puts "Updating existing users:"
-    User.all.each do |u|
-      new_name = u.email.split("@").first
-      u.update_attributes(name: new_name)
-      puts "Updated #{u.email} with #{u.name}"
-    end
-    User.reset_column_information
+    # puts "Updating existing users:"
+    # User.all.each do |u|
+    #   new_name = u.email.split("@").first
+    #   u.update_attributes(name: new_name)
+    #   puts "Updated #{u.email} with #{u.name}"
+    # end
+    # User.reset_column_information
   end
 
   def down

--- a/spec/system/organization_system_spec.rb
+++ b/spec/system/organization_system_spec.rb
@@ -74,6 +74,7 @@ RSpec.describe "Organization management", type: :system, js: true do
     end
 
     it "can see 'Make user' button for admins" do
+      create(:organization_admin)
       visit url_prefix + "/organization"
       expect(page.find(".table.border")).to have_content "Make User"
     end


### PR DESCRIPTION
Hey, one of our awesome diaper banks was playing around in diaperbase and saw the new functionality of being able to convert admins to regular users. She suggested that you shouldn't be able to set yourself to a user which someone might do by accident. Which, if they did would make more work for us to go and set them back.

This tiny pull request prevents someone from accidentally converting themselves from an admin to a regular user.

I also alphabetized the Gemfile and edited an old migration that was preventing folks from setting up the database using db:migrate rather than db:setup.