### PR TITLE
Add letter_opener gem for testing emails in development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :development do
   gem "capistrano3-puma"
   gem "capistrano-rails-console", require: false
   gem 'capistrano-sidekiq'
+  gem "letter_opener"
   gem "listen", "~> 3.2.1"
   gem "rails-erd"
   gem "spring"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -234,6 +234,8 @@ GEM
     kaminari-core (1.2.1)
     launchy (2.5.0)
       addressable (~> 2.7)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
     libv8 (8.4.255.0)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -553,6 +555,7 @@ DEPENDENCIES
   jquery-ui-rails
   kaminari
   launchy
+  letter_opener
   listen (~> 3.2.1)
   mini_racer (~> 0.3.1)
   momentjs-rails

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -30,6 +30,10 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
+  # Use letter_opener for testing emails
+  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.perform_deliveries = true
+
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 


### PR DESCRIPTION
Resolves #1810

### Description

Added `letter_opener` gem for easier email testing on local development.

Although the issue said we might need to edit the fakeredis entry in development, I didn't see any mention of redis in `letter_opener`'s README and it seemed to work without changing it ¯\_(ツ)_/¯
   
### Type of change

* New (development only) feature (non-breaking change which adds functionality)

### How Has This Been Tested?

1. enable email with `Flipper.enable(:email_active)`
2. set or find a partner with `send_reminders: true`
3. Create a distribution going to that partner. Email should open in a browser tab

### Screenshots
<img width="1127" alt="Screen Shot 2020-09-12 at 12 17 23 AM" src="https://user-images.githubusercontent.com/217050/92990022-63ca7480-f48d-11ea-9234-c2f00c7666fc.png">
