### PR TITLE
1804 feedback sort

### DIFF
--- a/app/views/admin/feedback_messages/index.html.erb
+++ b/app/views/admin/feedback_messages/index.html.erb
@@ -38,12 +38,12 @@
               </tr>
               </thead>
               <tbody>
-              <% @feedback_messages.each do |feedback| %>
+              <% @feedback_messages.partition {|feedback| !feedback.resolved? }.flatten.each do |feedback| %>
                 <tr>
                   <td><%= feedback.message %></td>
                   <td><%= feedback.user.email %></td>
                   <td><%= feedback.path %></td>
-                  <td><%= check_box_tag 'Resolved', feedback.resolved, feedback.resolved, data: {url: admin_feedback_message_resolve_path(feedback), remote: true, method: :get} %></td>
+                  <td class="text-right"><%= check_box_tag 'Resolved', feedback.resolved, feedback.resolved, data: {url: admin_feedback_message_resolve_path(feedback), remote: true, method: :get} %></td>
                 </tr>
               <% end %>
               </tbody>

--- a/spec/system/admin/feedback_system_spec.rb
+++ b/spec/system/admin/feedback_system_spec.rb
@@ -18,5 +18,20 @@ RSpec.describe "Admin Feedback Message Management", type: :system, js: true do
       feedback_message.reload
       expect(feedback_message.resolved).to eq(true)
     end
+
+
+    it "should sort by unresolved first" do
+      feedback_message = FactoryBot.create(:feedback_message, resolved:true)
+      feedback_message_unResolved = FactoryBot.create(:feedback_message, resolved:false)
+      visit admin_feedback_messages_path
+
+      within(:xpath, "//table/tbody/tr[1]") do
+        expect(page).not_to have_field('Resolved', checked:true)
+      end
+      
+      within(:xpath, "//table/tbody/tr[2]") do
+        expect(page).to have_field('Resolved', checked:true)
+      end
+    end
   end
 end

--- a/spec/system/admin/feedback_system_spec.rb
+++ b/spec/system/admin/feedback_system_spec.rb
@@ -19,18 +19,17 @@ RSpec.describe "Admin Feedback Message Management", type: :system, js: true do
       expect(feedback_message.resolved).to eq(true)
     end
 
-
     it "should sort by unresolved first" do
-      feedback_message = FactoryBot.create(:feedback_message, resolved:true)
-      feedback_message_unResolved = FactoryBot.create(:feedback_message, resolved:false)
+      FactoryBot.create(:feedback_message, resolved: true)
+      FactoryBot.create(:feedback_message, resolved: false)
       visit admin_feedback_messages_path
 
       within(:xpath, "//table/tbody/tr[1]") do
-        expect(page).not_to have_field('Resolved', checked:true)
+        expect(page).not_to have_field('Resolved', checked: true)
       end
-      
+
       within(:xpath, "//table/tbody/tr[2]") do
-        expect(page).to have_field('Resolved', checked:true)
+        expect(page).to have_field('Resolved', checked: true)
       end
     end
   end


### PR DESCRIPTION


Resolves #1804 

### Description
Sorts the existing feedback based on `resolved: boolean`, where `resolved: false` is prioritized. 
Doesn't sort dynamically, but while manually testing hard-refresh will get the latest updates after setting resolved: true by checking a checkbox.

### Type of change
* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?
* New system test to check that unresolved (unchecked) feedback is prioritized via xpath 
* Manual browser testing: Check a checkbox, hard refresh, verify unchecked items are at the top of the list 

### Screenshots
![diaper1804 - Resolved correctly](https://user-images.githubusercontent.com/4556682/93004704-76c95d00-f4fe-11ea-8b51-8509221498aa.png)
