### PR TITLE
Enqueue PartnerMailerJob into sidekiq default queue

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -149,7 +149,7 @@ class DistributionsController < ApplicationController
   end
 
   def send_notification(org, dist, subject: 'Your Distribution')
-    PartnerMailerJob.perform_now(org, dist, subject) if Flipper.enabled?(:email_active)
+    PartnerMailerJob.perform_async(org, dist, subject) if Flipper.enabled?(:email_active)
   end
 
   def schedule_reminder_email(distribution)

--- a/app/jobs/partner_mailer_job.rb
+++ b/app/jobs/partner_mailer_job.rb
@@ -1,5 +1,7 @@
 # This job notifies a Partner that they have a pending distribution
-class PartnerMailerJob < ApplicationJob
+class PartnerMailerJob
+  include Sidekiq::Worker
+
   def perform(org_id, dist_id, subject)
     current_organization = Organization.find(org_id)
     distribution = Distribution.find(dist_id)

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -20,6 +20,6 @@ class DistributionCreateService < DistributionService
   private
 
   def send_notification
-    PartnerMailerJob.perform_now(distribution_organization.id, distribution.id, 'Your Distribution') if Flipper.enabled?(:email_active)
+    PartnerMailerJob.perform_async(distribution_organization.id, distribution.id, 'Your Distribution') if Flipper.enabled?(:email_active)
   end
 end

--- a/spec/jobs/partner_mailer_job_spec.rb
+++ b/spec/jobs/partner_mailer_job_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe PartnerMailerJob, type: :job do
 
     it "does not send mail for past distributions" do
       expect do
-        PartnerMailerJob.perform_now(organization.id, past_distribution.id, mailer_subject)
+        PartnerMailerJob.new.perform(organization.id, past_distribution.id, mailer_subject)
       end.not_to change { ActionMailer::Base.deliveries.count }
     end
 
     it "sends mail for future distributions immediately" do
       expect do
-        PartnerMailerJob.perform_now(organization.id, future_distribution.id, mailer_subject)
+        PartnerMailerJob.new.perform(organization.id, future_distribution.id, mailer_subject)
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
   end

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe DistributionCreateService, type: :service do
         @partner.update!(send_reminders: true)
         allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
 
-        expect(PartnerMailerJob).to receive(:perform_now).once
-        subject.new(distribution_params).call
+        result = subject.new(distribution_params).call
+
+        expect(PartnerMailerJob).to have_enqueued_sidekiq_job(@organization.id, result.distribution.id, "Your Distribution")
       end
     end
 

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe DistributionCreateService, type: :service do
         @partner.update!(send_reminders: false)
         allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
 
-        expect(PartnerMailerJob).not_to receive(:perform_now)
+        expect(PartnerMailerJob).not_to receive(:perform_async)
         subject.new(distribution_params).call
       end
     end

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -18,10 +18,9 @@ RSpec.feature "Distributions", type: :system do
         select @storage_location.name, from: "From storage location"
 
         fill_in "Comment", with: "Take my wipes... please"
+        expect(PartnerMailerJob).to receive(:perform_async)
 
-        expect do
-          click_button "Save", match: :first
-        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+        click_button "Save", match: :first
 
         expect(page).to have_content "Distributions"
         expect(page.find(".alert-info")).to have_content "reated"


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1787 with @egiurleo 

### Description
1. Change PartnerMailerJob from ActiveJob to a sidekiq worker
2. Enqueue the job into the default queue by using `perform_async`

Open questions: 🚨
@edwinthinks 
We are not sure how the production sidekiq environment is set up. Does it have mailing functionality? The original code is sending mails via the web server. Now with the new changes, the partner mail will get sent in the sidekiq instance.

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
We wrote a unit test. But we can't test this change locally/staging/production.
