### PR TITLE
Remove the X from dashboard cards

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -100,9 +100,6 @@
               <button type="button" class="btn btn-tool" data-card-widget="collapse">
                 <i class="fas fa-minus"></i>
               </button>
-              <button type="button" class="btn btn-tool" data-card-widget="remove">
-                <i class="fas fa-times"></i>
-              </button>
             </div>
           </div>
           <div class="card-body">
@@ -148,9 +145,6 @@
               <button type="button" class="btn btn-tool" data-card-widget="collapse">
                 <i class="fas fa-minus"></i>
               </button>
-              <button type="button" class="btn btn-tool" data-card-widget="remove">
-                <i class="fas fa-times"></i>
-              </button>
             </div>
           </div>
           <div class="card-body">
@@ -176,9 +170,6 @@
             <div class="card-tools">
               <button type="button" class="btn btn-tool" data-card-widget="collapse">
                 <i class="fas fa-minus"></i>
-              </button>
-              <button type="button" class="btn btn-tool" data-card-widget="remove">
-                <i class="fas fa-times"></i>
               </button>
             </div>
           </div>
@@ -208,9 +199,6 @@
             <div class="card-tools">
               <button type="button" class="btn btn-tool" data-card-widget="collapse">
                 <i class="fas fa-minus"></i>
-              </button>
-              <button type="button" class="btn btn-tool" data-card-widget="remove">
-                <i class="fas fa-times"></i>
               </button>
             </div>
           </div>
@@ -243,9 +231,6 @@
               <button type="button" class="btn btn-tool" data-card-widget="collapse">
                 <i class="fas fa-minus"></i>
               </button>
-              <button type="button" class="btn btn-tool" data-card-widget="remove">
-                <i class="fas fa-times"></i>
-              </button>
             </div>
           </div>
           <div class="card-body">
@@ -276,9 +261,6 @@
               <button type="button" class="btn btn-tool" data-card-widget="collapse">
                 <i class="fas fa-minus"></i>
               </button>
-              <button type="button" class="btn btn-tool" data-card-widget="remove">
-                <i class="fas fa-times"></i>
-              </button>
             </div>
           </div>
           <div class="card-body">
@@ -307,9 +289,6 @@
               <h3 class="card-title">Itemized Donations
                 <small><%= @selected_date_range %></small></h3>
               <div class="card-tools">
-                <button type="button" class="btn btn-tool" data-card-widget="remove">
-                  <i class="fas fa-times"></i>
-                </button>
               </div>
             </div>
             <div class="box-body table-responsive no-padding">


### PR DESCRIPTION
Resolves #1834; done with @cfanpnk.

### Description
This PR removes the "X" buttons from all the cards on the dashboard.

### Type of change
UI fix

### How Has This Been Tested?
We have tested this by loading the app locally and observing that the X buttons have been removed.

### Screenshots
<img width="1440" alt="Screen Shot 2020-09-13 at 12 02 43 PM" src="https://user-images.githubusercontent.com/9601737/93022800-10554500-f5b9-11ea-9982-a54756842dca.png">