### PR TITLE
Revert #1835

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -154,7 +154,7 @@ class DistributionsController < ApplicationController
   end
 
   def send_notification(org, dist, subject: 'Your Distribution')
-    PartnerMailerJob.perform_async(org, dist, subject) if Flipper.enabled?(:email_active)
+    PartnerMailerJob.perform_now(org, dist, subject) if Flipper.enabled?(:email_active)
   end
 
   def schedule_reminder_email(distribution)

--- a/app/jobs/partner_mailer_job.rb
+++ b/app/jobs/partner_mailer_job.rb
@@ -1,7 +1,5 @@
 # This job notifies a Partner that they have a pending distribution
-class PartnerMailerJob
-  include Sidekiq::Worker
-
+class PartnerMailerJob < ApplicationJob
   def perform(org_id, dist_id, subject)
     current_organization = Organization.find(org_id)
     distribution = Distribution.find(dist_id)

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -20,6 +20,6 @@ class DistributionCreateService < DistributionService
   private
 
   def send_notification
-    PartnerMailerJob.perform_async(distribution_organization.id, distribution.id, 'Your Distribution') if Flipper.enabled?(:email_active)
+    PartnerMailerJob.perform_now(distribution_organization.id, distribution.id, 'Your Distribution') if Flipper.enabled?(:email_active)
   end
 end

--- a/spec/jobs/partner_mailer_job_spec.rb
+++ b/spec/jobs/partner_mailer_job_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe PartnerMailerJob, type: :job do
 
     it "does not send mail for past distributions" do
       expect do
-        PartnerMailerJob.new.perform(organization.id, past_distribution.id, mailer_subject)
+        PartnerMailerJob.perform_now(organization.id, past_distribution.id, mailer_subject)
       end.not_to change { ActionMailer::Base.deliveries.count }
     end
 
     it "sends mail for future distributions immediately" do
       expect do
-        PartnerMailerJob.new.perform(organization.id, future_distribution.id, mailer_subject)
+        PartnerMailerJob.perform_now(organization.id, future_distribution.id, mailer_subject)
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
   end

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -62,12 +62,13 @@ RSpec.describe "Distributions", type: :request do
         expect(partner).to be_valid
         expect(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
 
-        post distributions_path(params)
+        expect do
+          post distributions_path(params)
 
-        expect(response).to have_http_status(:redirect)
-        last_distribution = Distribution.last
-        expect(response).to redirect_to(distribution_path(last_distribution))
-        expect(PartnerMailerJob).to have_enqueued_sidekiq_job(last_distribution.organization.id, last_distribution.id, /Your Distribution/)
+          expect(response).to have_http_status(:redirect)
+          last_distribution = Distribution.last
+          expect(response).to redirect_to(distribution_path(last_distribution))
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
       end
 
       it "renders #new again on failure, with notice" do
@@ -231,18 +232,14 @@ RSpec.describe "Distributions", type: :request do
         before { allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true) }
 
         it "does not send an e-mail" do
-          Sidekiq::Testing.inline! do
-            subject
-            expect(PartnerMailerJob).not_to have_enqueued_sidekiq_job(distribution.organization.id, distribution.id, "Your Distribution")
-          end
+          expect { subject }.not_to change { ActionMailer::Base.deliveries.count }
         end
 
         context "sending" do
           let(:issued_at) { distribution.issued_at + 1.day }
 
-          it "does send the email" do
-            subject
-            expect(PartnerMailerJob).to have_enqueued_sidekiq_job(distribution.organization.id, distribution.id, /Your Distribution Date Has Changed/)
+          it "does send an e-mail" do
+            expect { subject }.to change { ActionMailer::Base.deliveries.count }.by(1)
           end
         end
 

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -22,9 +22,8 @@ RSpec.describe DistributionCreateService, type: :service do
         @partner.update!(send_reminders: true)
         allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
 
-        result = subject.new(distribution_params).call
-
-        expect(PartnerMailerJob).to have_enqueued_sidekiq_job(@organization.id, result.distribution.id, "Your Distribution")
+        expect(PartnerMailerJob).to receive(:perform_now).once
+        subject.new(distribution_params).call
       end
     end
 
@@ -33,7 +32,7 @@ RSpec.describe DistributionCreateService, type: :service do
         @partner.update!(send_reminders: false)
         allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
 
-        expect(PartnerMailerJob).not_to receive(:perform_async)
+        expect(PartnerMailerJob).not_to receive(:perform_now)
         subject.new(distribution_params).call
       end
     end

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -19,9 +19,10 @@ RSpec.feature "Distributions", type: :system do
         choose "Pick up"
 
         fill_in "Comment", with: "Take my wipes... please"
-        expect(PartnerMailerJob).to receive(:perform_async)
 
-        click_button "Save", match: :first
+        expect do
+          click_button "Save", match: :first
+        end.to change { ActionMailer::Base.deliveries.count }.by(1)
 
         expect(page).to have_content "Distributions"
         expect(page.find(".alert-info")).to have_content "reated"


### PR DESCRIPTION
### Description

There were some unusual bugs occurring due to the use of sidekiq for partner mailing. This reverts the PR https://github.com/rubyforgood/diaper/pull/1835


### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Travis CI

