### PR TITLE
Longer feedback messages

### DIFF
--- a/app/models/feedback_message.rb
+++ b/app/models/feedback_message.rb
@@ -14,5 +14,5 @@
 class FeedbackMessage < ApplicationRecord
   belongs_to :user
 
-  validates :message, presence: true, length: { minimum: 10, maximum: 200 }
+  validates :message, presence: true, length: { minimum: 10 }
 end

--- a/app/models/feedback_message.rb
+++ b/app/models/feedback_message.rb
@@ -3,7 +3,7 @@
 # Table name: feedback_messages
 #
 #  id         :bigint           not null, primary key
-#  message    :string
+#  message    :text
 #  path       :string
 #  resolved   :boolean
 #  created_at :datetime         not null

--- a/db/migrate/20200921182529_change_message_type_text_on_feedback_messages.rb
+++ b/db/migrate/20200921182529_change_message_type_text_on_feedback_messages.rb
@@ -1,0 +1,12 @@
+class ChangeMessageTypeTextOnFeedbackMessages < ActiveRecord::Migration[6.0]
+  def change
+    reversible do |dir|
+      dir.up do
+        change_column :feedback_messages, :message, :text
+      end
+      dir.down do
+        change_column :feedback_messages, :message, :string
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_06_185544) do
+ActiveRecord::Schema.define(version: 2020_09_21_182529) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -182,7 +182,7 @@ ActiveRecord::Schema.define(version: 2020_09_06_185544) do
 
   create_table "feedback_messages", force: :cascade do |t|
     t.bigint "user_id"
-    t.string "message"
+    t.text "message"
     t.string "path"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/feedback_message_spec.rb
+++ b/spec/models/feedback_message_spec.rb
@@ -17,6 +17,11 @@
 RSpec.describe FeedbackMessage, type: :model do
   let(:user) { FactoryBot.build(:user) }
 
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:message) }
+    it { is_expected.to validate_length_of(:message).is_at_least(10) }
+  end
+
   describe "relations and attributes" do
     it "belongs to a user" do
       expect(user.feedback_messages.count).to eql 0

--- a/spec/models/feedback_message_spec.rb
+++ b/spec/models/feedback_message_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe FeedbackMessage, type: :model do
   describe "validations" do
     it { is_expected.to validate_presence_of(:message) }
     it { is_expected.to validate_length_of(:message).is_at_least(10) }
+
+    it "allows long messages" do
+      message = FeedbackMessage.new(message: "Diapers! " * 1000, user: user)
+
+      expect(message).to be_valid
+    end
   end
 
   describe "relations and attributes" do

--- a/spec/models/feedback_message_spec.rb
+++ b/spec/models/feedback_message_spec.rb
@@ -3,7 +3,7 @@
 # Table name: feedback_messages
 #
 #  id         :bigint           not null, primary key
-#  message    :string
+#  message    :text
 #  path       :string
 #  resolved   :boolean
 #  created_at :datetime         not null


### PR DESCRIPTION
Resolves #1858

### Description

Removes the length limit from messages on bug reports/feedback messages.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

1. Submit a bug report with over 200 chars (https://www.lipsum.com/)
#####  Expected result:
1. Bug will be submitted correctly and an e-mail will be sent with the full text
##### Previous behavior:
1. An error message would be shown to the user
