### PR TITLE
feature/add-distributions-status-filtering

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -39,7 +39,7 @@ class DistributionsController < ApplicationController
 
     @distributions = current_organization
                      .distributions
-                     .where(issued_at: selected_range, state: state_filter)
+                     .where(issued_at: selected_range)
                      .includes(:partner, :storage_location, :line_items, :items)
                      .order(issued_at: :desc)
                      .class_filter(filter_params)
@@ -51,7 +51,7 @@ class DistributionsController < ApplicationController
     @total_items_paginated_distributions = total_items(@paginated_distributions)
     @items = current_organization.items.alphabetized
     @partners = @distributions.collect(&:partner).uniq.sort_by(&:name)
-    @states = Distribution.pluck("DISTINCT(state)").map(&:titleize)
+    @states = Distribution.states.transform_keys(&:humanize)
   end
 
   def create
@@ -194,14 +194,7 @@ class DistributionsController < ApplicationController
   def filter_params
     return {} unless params.key?(:filters)
 
-    params.require(:filters).slice(:by_item_id, :by_partner)
-  end
-
-  def state_filter
-    distribution_states = Distribution.pluck("DISTINCT(state)")
-    return distribution_states if params[:filters].nil?
-
-    params[:filters][:state].presence&.downcase || distribution_states
+    params.require(:filters).slice(:by_item_id, :by_partner, :by_state)
   end
 
   def perform_inventory_check

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -48,6 +48,8 @@ class Distribution < ApplicationRecord
   scope :by_item_id, ->(item_id) { joins(:items).where(items: { id: item_id }) }
   # partner scope to allow filtering by partner
   scope :by_partner, ->(partner_id) { where(partner_id: partner_id) }
+  # state scope to allow filtering by state
+  scope :by_state, ->(state) { where(state: state) }
   scope :recent, ->(count = 3) { order(issued_at: :desc).limit(count) }
   scope :future, -> { where("issued_at >= :tomorrow", tomorrow: Time.zone.tomorrow) }
   scope :during, ->(range) { where(distributions: { issued_at: range }) }

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -50,7 +50,7 @@
                 <% end %>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                   <%= label_tag "by Status" %>
-                  <%= select_tag "filters[state]", options_for_select(@states) || {}, {include_blank: true, class: "form-control"} %>
+                  <%= collection_select(:filters, :by_state, @states || {}, :last, :first, {include_blank: true}, {class: "form-control"}) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                   <%= label_tag "Date Range" %>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -37,18 +37,22 @@
             <%= form_tag(distributions_path, method: :get) do |f| %>
               <div class="row">
                 <% if @items.present? %>
-                  <div class="form-group col-lg-4 col-md-4 col-sm-6 col-xs-12">
+                  <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= label_tag "by Item" %>
                     <%= collection_select(:filters, :by_item_id, @items || {}, :id, :name, {include_blank: true}, {class: "form-control"}) %>
                   </div>
                 <% end %>
                 <% if @partners.present? %>
-                  <div class="form-group col-lg-4 col-md-4 col-sm-6 col-xs-12">
+                  <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= label_tag "by Partner" %>
                     <%= collection_select(:filters, :by_partner, @partners || {}, :id, :name, {include_blank: true}, {class: "form-control"}) %>
                   </div>
                 <% end %>
-                <div class="form-group col-lg-4 col-md-4 col-sm-6 col-xs-12">
+                <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
+                  <%= label_tag "by Status" %>
+                  <%= select_tag "filters[state]", options_for_select(@states) || {}, {include_blank: true, class: "form-control"} %>
+                </div>
+                <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                   <%= label_tag "Date Range" %>
                   <%= render partial: "shared/date_range_picker", locals: {css_class: "form-control"} %>
                 </div>

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -448,6 +448,20 @@ RSpec.feature "Distributions", type: :system do
       expect(page).to have_css("table tbody tr", count: 1)
     end
 
+    it "filters by state" do
+      distribution1 = create(:distribution, state: "started")
+      create(:distribution, state: "complete")
+
+      visit subject
+      # check for all distributions
+      expect(page).to have_css("table tbody tr", count: 2)
+      # filter
+      select(distribution1.state.humanize, from: "filters_by_state")
+      click_button("Filter")
+      # check for filtered distributions
+      expect(page).to have_css("table tbody tr", count: 1)
+    end
+
     it_behaves_like "Date Range Picker", Distribution, :issued_at
   end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1851

### Description
This PR adds the ability to filter distributions by state.  For the purpose of UI/UX we are calling the filter "Status" instead of state.


### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

I tested this out locally by choosing each option in the drop down and seeing the expected results to pass.
I also tested the status filter with the other filters so that they work together 

### Screenshots
<img width="1675" alt="Screen Shot 2020-09-21 at 2 24 59 PM" src="https://user-images.githubusercontent.com/16119691/93806682-84c26080-fc17-11ea-8447-ba2cc43b12ab.png">
