### PR TITLE
Fix from_email to not accept empty emails

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -208,6 +208,7 @@ class Organization < ApplicationRecord
 
   def from_email
     return get_admin_email if email.blank?
+
     email
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -207,7 +207,8 @@ class Organization < ApplicationRecord
   end
 
   def from_email
-    email || get_admin_email
+    return get_admin_email if email.blank?
+    email
   end
 
   private

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -379,7 +379,19 @@ RSpec.describe Organization, type: :model do
       admin = create(:organization_admin, organization: org)
       expect(org.from_email).to eq(admin.email)
     end
-  end
+
+    it "returns admin email when it's empty" do
+      org = create(:organization, email: "")
+      admin = create(:organization_admin, organization: org)
+      expect(org.from_email).to eq(admin.email)
+    end
+
+    it "returns admin email when it's empty space" do
+      org = create(:organization, email: " ")
+      admin = create(:organization_admin, organization: org)
+      expect(org.from_email).to eq(admin.email)
+    end
+end
 
   describe 'reminder_day' do
     it "can only contain numbers 1-14" do

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -391,7 +391,7 @@ RSpec.describe Organization, type: :model do
       admin = create(:organization_admin, organization: org)
       expect(org.from_email).to eq(admin.email)
     end
-end
+  end
 
   describe 'reminder_day' do
     it "can only contain numbers 1-14" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1868 <!--fill issue number-->

### Description
We have a `from_email` method on our `organization.r` model that, in theory, is supposed to grab one of the random admins on a site as a backup email for mailers when an organization hasn't set an email. The problem is that some organizations have saved and empty string `""` as their email

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

I tested creating some specs that can simulate the situation where the email of the organization's admin can be nil, empty, or invalid.
