### PR TITLE
Fix brittleness of a request spec

### DIFF
--- a/spec/requests/admin/organizations_requests_spec.rb
+++ b/spec/requests/admin/organizations_requests_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Admin::Organizations", type: :request do
       end
 
       context 'when given a valid account request token in the query parameters' do
-        let!(:account_request) { FactoryBot.create(:account_request) }
+        let!(:account_request) { FactoryBot.create(:account_request, organization_name: "Pouros, O'Kon and Schumm") }
 
         it 'should render new with pre populate input fields from the account_request' do
           get new_admin_organization_url(token: account_request.identity_token)
@@ -24,14 +24,19 @@ RSpec.describe "Admin::Organizations", type: :request do
           # Just checking if the values appear in the template. This assumes
           # that if they are present in the body then they are pre-populating
           # the form. A system test will likely handle this test case.
-          expect(response.body).to include(account_request.name)
-          expect(response.body).to include(account_request.email)
-          expect(response.body).to include(account_request.organization_name)
-          expect(response.body).to include(account_request.organization_website)
+          #
+          # Using CGI.escapeHTML to match account_request attribute which is rendered
+          # to be HTML safe. If the organization_name or any attribute has unsafe characters
+          # then this test would fail. For example, if the organization_name were
+          # "Pouros, O'Kon and Schumm"
+          expect(response.body).to match(CGI::escapeHTML(account_request.name))
+          expect(response.body).to match(CGI::escapeHTML(account_request.email))
+          expect(response.body).to match(CGI::escapeHTML(account_request.organization_name))
+          expect(response.body).to match(CGI::escapeHTML(account_request.organization_website))
         end
       end
 
-      context 'whwne given a token that matches a account request that has already been processed' do
+      context 'when given a token that matches a account request that has already been processed' do
         let!(:account_request) { FactoryBot.create(:account_request) }
 
         before do

--- a/spec/requests/admin/organizations_requests_spec.rb
+++ b/spec/requests/admin/organizations_requests_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Admin::Organizations", type: :request do
       end
 
       context 'when given a valid account request token in the query parameters' do
-        let!(:account_request) { FactoryBot.create(:account_request, organization_name: "Pouros, O'Kon and Schumm") }
+        let!(:account_request) { FactoryBot.create(:account_request) }
 
         it 'should render new with pre populate input fields from the account_request' do
           get new_admin_organization_url(token: account_request.identity_token)
@@ -29,10 +29,13 @@ RSpec.describe "Admin::Organizations", type: :request do
           # to be HTML safe. If the organization_name or any attribute has unsafe characters
           # then this test would fail. For example, if the organization_name were
           # "Pouros, O'Kon and Schumm"
+          #
+          # rubocop:disable Style/ColonMethodCall
           expect(response.body).to match(CGI::escapeHTML(account_request.name))
           expect(response.body).to match(CGI::escapeHTML(account_request.email))
           expect(response.body).to match(CGI::escapeHTML(account_request.organization_name))
           expect(response.body).to match(CGI::escapeHTML(account_request.organization_website))
+          # rubocop:enable Style/ColonMethodCall
         end
       end
 


### PR DESCRIPTION
### Description

This PR addresses a brittle test that emerged were the spec couldn't match an expected text value on a template. The primary reason for this is that sometimes the attribute we are testing against is made HTML safe. More details are shown in the code changes

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Ran specs :)

