### PR TITLE
Add ability to export requests

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -3,13 +3,10 @@ class RequestsController < ApplicationController
   def index
     setup_date_range_picker
 
-    @paginated_requests = current_organization
-                          .ordered_requests
-                          .during(helpers.selected_range)
-                          .page(params[:page])
-    respond_to do |format|
-      format.html
-    end
+    @requests = current_organization.ordered_requests.during(helpers.selected_range)
+    @paginated_requests = @requests.page(params[:page])
+
+    respond_to { |format| format.html }
   end
 
   def show

--- a/app/models/adjustment.rb
+++ b/app/models/adjustment.rb
@@ -16,6 +16,7 @@ class Adjustment < ApplicationRecord
   belongs_to :storage_location
   belongs_to :user
 
+  include Exportable
   include Itemizable
   include Filterable
   scope :at_location, ->(location_id) { where(storage_location_id: location_id) }

--- a/app/models/barcode_item.rb
+++ b/app/models/barcode_item.rb
@@ -23,6 +23,7 @@ class BarcodeItem < ApplicationRecord
   validates :quantity, numericality: { only_integer: true, greater_than: 0 }
 
   include Filterable
+  include Exportable
   default_scope { order("barcodeable_type DESC, created_at ASC") }
 
   scope :barcodeable_id, ->(barcodeable_id) { where(barcodeable_id: barcodeable_id) }

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -1,0 +1,17 @@
+module Exportable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def csv_export_headers
+      raise 'not implemented'
+    end
+
+    def csv_export(data)
+      [csv_export_headers] + data.map(&:csv_export_attributes)
+    end
+  end
+
+  def csv_export_attributes
+    raise 'not implemented'
+  end
+end

--- a/app/models/concerns/provideable.rb
+++ b/app/models/concerns/provideable.rb
@@ -2,6 +2,7 @@ require "csv"
 # Encapsulates some common behaviors for third-parties that provide inventory
 # e.g. DiaperDriveParticipant, Vendor
 module Provideable
+  include Exportable
   extend ActiveSupport::Concern
 
   included do

--- a/app/models/data_export.rb
+++ b/app/models/data_export.rb
@@ -5,18 +5,19 @@ require "csv"
 # the classes for which this can work.
 class DataExport
   SUPPORTED_TYPES = %w(
+    Adjustment
+    BarcodeItem
+    DiaperDriveParticipant
+    Distribution
     Donation
     DonationSite
+    Item
     Partner
     Purchase
-    Distribution
-    DiaperDriveParticipant
-    Vendor
+    Request
     StorageLocation
-    Adjustment
     Transfer
-    Item
-    BarcodeItem
+    Vendor
   ).map(&:freeze).freeze
 
   def initialize(organization, type)
@@ -28,9 +29,7 @@ class DataExport
     return nil unless current_organization.present? && type.present?
     return nil unless SUPPORTED_TYPES.include? type
 
-    data_to_export = type.constantize.for_csv_export(current_organization)
-    headers = type.constantize.csv_export_headers
-    generate_csv(data_to_export, headers)
+    generate_csv
   end
 
   def self.supported_types
@@ -41,12 +40,18 @@ class DataExport
 
   attr_reader :current_organization, :type
 
-  def generate_csv(data, headers)
-    CSV.generate(headers: true) do |csv|
-      csv << headers
+  def model_class
+    @model_class ||= type.constantize
+  end
 
-      data.each do |element|
-        csv << element.csv_export_attributes
+  def data_to_export
+    model_class.for_csv_export(current_organization)
+  end
+
+  def generate_csv
+    CSV.generate(headers: true) do |csv|
+      model_class.csv_export(data_to_export).each do |row|
+        csv << row
       end
     end
   end

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -28,6 +28,7 @@ class Distribution < ApplicationRecord
 
   # Distributions contain many different items
   include Itemizable
+  include Exportable
 
   has_one :request, dependent: :nullify
   accepts_nested_attributes_for :request

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -33,7 +33,7 @@ class Donation < ApplicationRecord
   belongs_to :storage_location
 
   include Itemizable
-
+  include Exportable
   include Filterable
   scope :at_storage_location, ->(storage_location_id) {
     where(storage_location_id: storage_location_id)

--- a/app/models/donation_site.rb
+++ b/app/models/donation_site.rb
@@ -22,6 +22,7 @@ class DonationSite < ApplicationRecord
   has_many :donations, dependent: :destroy
 
   include Geocodable
+  include Exportable
 
   scope :for_csv_export, ->(organization) {
     where(organization: organization)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -35,6 +35,7 @@ class Item < ApplicationRecord
   has_many :distributions, through: :line_items, source: :itemizable, source_type: Distribution
 
   include Filterable
+  include Exportable
   scope :active, -> { where(active: true) }
   scope :visible, -> { where(visible_to_partners: true) }
   scope :alphabetized, -> { order(:name) }

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -36,6 +36,7 @@ class Partner < ApplicationRecord
   scope :alphabetized, -> { order(:name) }
 
   include Filterable
+  include Exportable
   scope :by_status, ->(status) {
     where(status: status.to_sym)
   }

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -22,6 +22,7 @@ class Purchase < ApplicationRecord
   include Itemizable
   include Filterable
   include IssuedAt
+  include Exportable
 
   scope :at_storage_location, ->(storage_location_id) {
                                 where(storage_location_id: storage_location_id)

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -34,6 +34,7 @@ class StorageLocation < ApplicationRecord
 
   include Geocodable
   include Filterable
+  include Exportable
   scope :containing, ->(item_id) {
     joins(:inventory_items).where("inventory_items.item_id = ?", item_id)
   }

--- a/app/models/transfer.rb
+++ b/app/models/transfer.rb
@@ -18,8 +18,9 @@ class Transfer < ApplicationRecord
   belongs_to :to, class_name: "StorageLocation", inverse_of: :transfers_to
 
   include Itemizable
-  alias_attribute :storage_location, :from # to make it play nice with Itemizable
   include Filterable
+  include Exportable
+  alias_attribute :storage_location, :from # to make it play nice with Itemizable
   scope :from_location, ->(location_id) { where(from_id: location_id) }
   scope :to_location, ->(location_id) { where(to_id: location_id) }
   scope :for_csv_export, ->(organization) {

--- a/app/services/exports/export_request_service.rb
+++ b/app/services/exports/export_request_service.rb
@@ -1,0 +1,48 @@
+module Exports
+  class ExportRequestService
+    def initialize(requests)
+      @requests = requests
+      @headers = %w[Date Requestor Status]
+    end
+
+    def call
+      [].tap do |csv_data|
+        csv_data << headers
+
+        rows.each do |request_row|
+          csv_data << headers.map { |header| request_row[header] }
+        end
+      end
+    end
+
+    private
+
+    attr_reader :requests, :headers
+
+    def rows
+      requests.map do |request|
+        {
+          "Date" => request.created_at.strftime("%m/%d/%Y"),
+          "Requestor" => request.partner.name,
+          "Status" => request.status.humanize
+        }.tap do |row|
+          request.request_items.each do |item_ref|
+            item = grouped_items[item_ref['item_id'].to_i]&.first
+            row[item.name] = item_ref['quantity']
+            headers << item.name unless headers.include?(item.name)
+          end
+        end
+      end
+    end
+
+    def grouped_items
+      @grouped_items ||= Item.where(id: request_item_ids).group_by(&:id)
+    end
+
+    def request_item_ids
+      requests.map do |request|
+        request.request_items.map { |item| item['item_id'] }
+      end.flatten
+    end
+  end
+end

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -59,7 +59,7 @@
                 <span class="float-right">
                   <%= download_button_to(csv_path(format: :csv, type: "Distribution"), text: "Export Distributions") if @distributions.length > 0 %>
                   <%= new_button_to new_distribution_path(organization_id: current_organization), {text: "New Distribution"} %>
-                    </span>
+                </span>
               </div>
             <% end # form %>
           </div>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -46,6 +46,9 @@
               <div class="card-footer">
                 <%= filter_button %>
                 <%= cancel_button_to requests_path, {text: "Clear Filters"} %>
+                <span class="float-right">
+                  <%= download_button_to(csv_path(format: :csv, type: "Request", filters: params[:filters]&.permit(:date_range)), text: "Export Requests") if @requests.length > 0 %>
+                </span>
               </div>
             <% end # form %>
             </div>

--- a/spec/models/data_export_spec.rb
+++ b/spec/models/data_export_spec.rb
@@ -143,6 +143,24 @@ RSpec.describe DataExport, type: :model do
         expect(subject.as_csv).to include("11")
       end
     end
+
+    context "type is Request >" do
+      let(:type) { "Request" }
+      let(:item) { create :item, name: "3T Diapers" }
+      let!(:request) do
+        create(:request,
+               :started,
+               organization: org,
+               request_items: [{ item_id: item.id, quantity: 150 }])
+      end
+
+      it "should return a CSV string with request and item data" do
+        expect(subject.as_csv).to include("Date,Requestor,Status")
+        expect(subject.as_csv).to include(request.created_at.strftime("%m/%d/%Y").to_s)
+        expect(subject.as_csv).to include(item.name)
+        expect(subject.as_csv).to include("150")
+      end
+    end
   end
 
   describe 'SUPPORTED_TYPES' do

--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe Exports::ExportRequestService do
+  let(:org) { create(:organization) }
+
+  let(:item_3t) { create :item, name: "3T Diapers" }
+  let!(:request_3t) do
+    create(:request,
+           :started,
+           organization: org,
+           request_items: [{ item_id: item_3t.id, quantity: 150 }])
+  end
+
+  let(:item_2t) { create :item, name: "2T Diapers" }
+  let!(:request_2t) do
+    create(:request,
+           :fulfilled,
+           organization: org,
+           request_items: [{ item_id: item_2t.id, quantity: 100 }])
+  end
+
+  subject do
+    described_class.new([request_3t, request_2t])
+  end
+
+  describe ".call" do
+    it "includes headers as the first row" do
+      expect(subject.call.first).to include("Date", "Requestor", "Status", item_3t.name, item_2t.name)
+    end
+
+    it "includes rows for each request" do
+      expect(subject.call.second).to include(request_3t.created_at.strftime("%m/%d/%Y").to_s)
+      expect(subject.call.second).to include(150)
+
+      expect(subject.call.third).to include(request_2t.created_at.strftime("%m/%d/%Y").to_s)
+      expect(subject.call.third).to include(100)
+    end
+  end
+end


### PR DESCRIPTION
### Description
* Unifies the call for header and row information behind a single class level method call, `export_data`. This allows for dynamic headers, such as what's included in this PR to include the names of requested items as columns in the CSV.
* Adds this method to existing implementations using the new `Exportable` model concern.

### Issue

Resolves https://github.com/rubyforgood/diaper/issues/1854

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

* Local testing
* Unit testing

### Screenshots
![Screen Shot 2020-09-22 at 10 25 31 AM](https://user-images.githubusercontent.com/1717864/93895578-fb199e00-fcbd-11ea-85fc-028563c911f0.png)

