### PR TITLE
Add filters to requests page

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -6,9 +6,13 @@ class RequestsController < ApplicationController
     @requests = current_organization
                 .ordered_requests
                 .during(helpers.selected_range)
+                .class_filter(filter_params)
 
     @paginated_requests = @requests.page(params[:page])
     @calculate_product_totals = total_items(@requests)
+    @items = current_organization.items.alphabetized
+    @partners = @requests.collect(&:partner).uniq.sort_by(&:name)
+    @statuses = Request.statuses.transform_keys(&:humanize)
 
     respond_to { |format| format.html }
   end
@@ -57,5 +61,11 @@ class RequestsController < ApplicationController
     return unless @request.request_items
 
     @request.request_items.map { |json| RequestItem.from_json(json, current_organization) }
+  end
+
+  def filter_params
+    return {} unless params.key?(:filters)
+
+    params.require(:filters).slice(:by_request_item_id, :by_partner, :by_status)
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -24,6 +24,13 @@ class Request < ApplicationRecord
 
   enum status: { pending: 0, started: 1, fulfilled: 2 }, _prefix: true
 
+  include Filterable
+  # add request item scope to allow filtering distributions by request item
+  scope :by_request_item_id, ->(item_id) { where("request_items @> :with_item_id ", with_item_id: [{ item_id: item_id.to_i }].to_json) }
+  # partner scope to allow filtering by partner
+  scope :by_partner, ->(partner_id) { where(partner_id: partner_id) }
+  # status scope to allow filtering by status
+  scope :by_status, ->(status) { where(status: status) }
   scope :during, ->(range) { where(created_at: range) }
   scope :for_csv_export, ->(organization, *) {
     where(organization: organization)

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -37,6 +37,22 @@
           <div class="card-body">
             <%= form_tag(requests_path, method: :get) do |f| %>
               <div class="row">
+                <% if @items.present? %>
+                  <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
+                    <%= label_tag "by Item" %>
+                    <%= collection_select(:filters, :by_request_item_id, @items || {}, :id, :name, {include_blank: true}, {class: "form-control"}) %>
+                  </div>
+                <% end %>
+                <% if @partners.present? %>
+                  <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
+                    <%= label_tag "by Partner" %>
+                    <%= collection_select(:filters, :by_partner, @partners || {}, :id, :name, {include_blank: true}, {class: "form-control"}) %>
+                  </div>
+                <% end %>
+                <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
+                  <%= label_tag "by Status" %>
+                  <%= collection_select(:filters, :by_status, @statuses || {}, :last, :first, {include_blank: true}, {class: "form-control"}) %>
+                </div>
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
                   <%= label_tag "Date Range" %>
                   <%= render partial: "shared/date_range_picker", locals: {css_class: "form-control"} %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -61,8 +61,8 @@
               </div>
               <div class="card-footer">
                 <%= filter_button %>
-                <%= modal_button_to("#calculateTotals", {text: "Calculate Product Totals", icon: nil, size: "md", type: "success"}) %>
                 <%= cancel_button_to requests_path, {text: "Clear Filters"} %>
+                <%= modal_button_to("#calculateTotals", {text: "Calculate Product Totals", icon: nil, size: "md", type: "success"}) %>
                 <span class="float-right">
                   <%= download_button_to(csv_path(format: :csv, type: "Request", filters: params[:filters]&.permit(:date_range)), text: "Export Requests") if @requests.length > 0 %>
                 </span>

--- a/spec/system/request_system_spec.rb
+++ b/spec/system/request_system_spec.rb
@@ -63,5 +63,58 @@ RSpec.describe "Requests", type: :system, js: true do
         end
       end
     end
+
+    context "when filtering on the index page" do
+      subject { url_prefix + "/requests" }
+
+      let(:item1) { create(:item, name: "Good item") }
+      let(:item2) { create(:item, name: "Crap item") }
+      let(:partner1) { create(:partner, name: "This Guy", email: "thisguy@example.com") }
+      let(:partner2) { create(:partner, name: "Not This Guy", email: "ntg@example.com") }
+
+      it "filters by item id" do
+        create(:request, request_items: [{ "item_id": item1.id, "quantity": 3 }])
+        create(:request, request_items: [{ "item_id": item2.id, "quantity": 3 }])
+
+        visit subject
+        # check for all requests
+        expect(page).to have_css("table tbody tr", count: 3)
+        # filter
+        select(item1.name, from: "filters_by_request_item_id")
+        click_button("Filter")
+        # check for filtered requests
+        expect(page).to have_css("table tbody tr", count: 1)
+      end
+
+      it "filters by partner" do
+        create(:request, partner: partner1)
+        create(:request, partner: partner2)
+
+        visit subject
+        # check for all requests
+        expect(page).to have_css("table tbody tr", count: 3)
+        # filter
+        select(partner1.name, from: "filters_by_partner")
+        click_button("Filter")
+        # check for filtered requests
+        expect(page).to have_css("table tbody tr", count: 1)
+      end
+
+      it "filters by status" do
+        request1 = create(:request, status: "fulfilled")
+        create(:request, status: "pending")
+
+        visit subject
+        # check for all requests
+        expect(page).to have_css("table tbody tr", count: 3)
+        # filter
+        select(request1.status.humanize, from: "filters_by_status")
+        click_button("Filter")
+        # check for filtered requests
+        expect(page).to have_css("table tbody tr", count: 1)
+      end
+
+      it_behaves_like "Date Range Picker", Request, :created_at
+    end
   end
 end


### PR DESCRIPTION
# Checklist:

- [x] I have performed a self-review of my own code,
- [x] I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- [x] I have added tests that prove my fix is effective or that my feature works,
- [x] New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.


Resolves #1850

### Description
For navigating results on the Requests page we added the ability to filter by Status, Partner, and Item.  This is in addition to the date filter that was already implemented.

This functionality is also necessary for us to be able to support unfulfilled request inventory projection.  

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
This has been tested by choosing options from filters and seeing expected results.  If you choose more than one filter, Status and Item, it will filter by both selections.  System tests were also added for these filters.


### Screenshots
<img width="1291" alt="Screen Shot 2020-09-23 at 9 58 25 AM" src="https://user-images.githubusercontent.com/16119691/94022721-65e0dd00-fd83-11ea-83a1-eb8494a43612.png">

