### PR TITLE
Add quota and notes to partner agencies

### DIFF
--- a/app/assets/stylesheets/resources/partners.scss
+++ b/app/assets/stylesheets/resources/partners.scss
@@ -44,3 +44,7 @@ i.fa {
     }
   }
 }
+
+div#partner-notes {
+  padding: 0px 20px;
+}

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -131,7 +131,7 @@ class PartnersController < ApplicationController
   end
 
   def partner_params
-    params.require(:partner).permit(:name, :email, :send_reminders)
+    params.require(:partner).permit(:name, :email, :send_reminders, :quota, :notes)
   end
 
   def filter_params
@@ -140,5 +140,3 @@ class PartnersController < ApplicationController
     params.require(:filters).slice(:by_status)
   end
 end
-
-

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -6,4 +6,12 @@ module PartnersHelper
     uri.path = path
     uri.to_s
   end
+
+  def show_header_column_class(partner, additional_classes: "")
+    if partner.quota.present?
+      "col-sm-3 col-3 #{additional_classes}"
+    else
+      "col-sm-4 col-4 #{additional_classes}"
+    end
+  end
 end

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -5,6 +5,8 @@
 #  id              :integer          not null, primary key
 #  email           :string
 #  name            :string
+#  notes           :text
+#  quota           :integer
 #  send_reminders  :boolean          default(FALSE), not null
 #  status          :integer          default("uninvited")
 #  created_at      :datetime         not null

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -30,6 +30,8 @@ class Partner < ApplicationRecord
                     uniqueness: true,
                     format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i, on: :create }
 
+  validates :quota, numericality: true, allow_blank: true
+
   scope :for_csv_export, ->(organization) {
     where(organization: organization)
       .order(:name)

--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -20,6 +20,13 @@
               <%= f.input :send_reminders, label: "Send Reminders?", wrapper: :input_group do %>
                 <%= f.check_box :send_reminders, {class: "input-group-text", id: "send_reminders"}, "true", "false" %>
               <% end %>
+              <%= f.input :quota, label: "Quota", wrapper: :input_group do %>
+                <span class="input-group-text"><i class="fa fa-warning"></i></span>
+                <%= f.input_field :quota, class: "form-control" %>
+              <% end %>
+              <%= f.input :notes, label: "Notes", wrapper: :input_group do %>
+                <%= f.input_field :notes, class: "form-control" %>
+              <% end %>
             </div>
             <!-- /.card-body -->
             <div class="card-footer">
@@ -34,4 +41,3 @@
     </div><!-- /.container-fluid -->
   </section>
 <% end %>
-

--- a/app/views/partners/_notes.html.erb
+++ b/app/views/partners/_notes.html.erb
@@ -1,0 +1,15 @@
+<div id="notesBarCode" class="modal fade">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Notes</h4>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p><%= simple_format(partner.notes) %></p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/partners/_notes.html.erb
+++ b/app/views/partners/_notes.html.erb
@@ -1,15 +1,15 @@
-<div id="notesBarCode" class="modal fade">
-  <div class="modal-dialog modal-lg">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h4 class="modal-title">Notes</h4>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
-      <div class="modal-body">
+<div class="card card-info card-outline">
+  <div class="card-header">
+    <h2 class="card-title">Notes</h2>
+  </div>
+  <div class="card-body p-0">
+    <div class="row">
+      <div class="col-xs-12 col-sm-12" id="partner-notes">
         <p><%= simple_format(partner.notes) %></p>
       </div>
     </div>
+  </div>
+  <!-- /.card-body -->
+  <div class="card-footer">
   </div>
 </div>

--- a/app/views/partners/_partner_row.html.erb
+++ b/app/views/partners/_partner_row.html.erb
@@ -2,6 +2,7 @@
 <tr>
   <td><%= link_to partner_row.name, partner_path(partner_row) %></td>
   <td><%= link_to partner_row.email, "mailto:#{partner_row.email}" %></td>
+  <td><%= partner_row.quota %></td>
   <td>
     <% case status %>
     <% when "uninvited" %>

--- a/app/views/partners/_show_header.html.erb
+++ b/app/views/partners/_show_header.html.erb
@@ -1,0 +1,59 @@
+<div class="card card-info card-outline">
+  <div class="card-header">
+    <h2 class="card-title"><%= partner.name %></h2>
+  </div>
+  <div class="card-body p-0">
+    <div class="row">
+      <div class="<%= show_header_column_class(partner) %>">
+        <div class="description-block border-right">
+          <h1 style="color:purple"><%= total_on_hand(impact_metrics.dig("agency", "families_served") || 0) %> </h1>
+          <h5>Families served</h5>
+        </div>
+        <!-- /.description-block -->
+      </div>
+      <!-- /.col -->
+      <div class="<%= show_header_column_class(partner) %>">
+        <div class="description-block border-right">
+          <h1 style="color:purple"><%= total_on_hand(impact_metrics.dig("agency", "children_served") || 0) %> </h1>
+          <h5>Children served</h5>
+        </div>
+        <!-- /.description-block -->
+      </div>
+      <!-- /.col -->
+      <div class="<%= show_header_column_class(partner) %>">
+        <div class="description-block border-right">
+          <h1 style="color:purple"><%= total_on_hand(impact_metrics.dig("agency", "family_zipcodes") || 0) %> </h1>
+          <h5>Zipcodes served</h5>
+          <%= modal_button_to("#seeZipcodes", {text: "See Zipcodes?", size: "xs"}) if impact_metrics.dig("agency", "family_zipcodes_list").present? %>
+        </div>
+        <!-- /.description-block -->
+      </div>
+
+      <% if partner.quota.present? %>
+        <!-- /.col -->
+        <div class="<%= show_header_column_class(partner) %>">
+          <div class="description-block border-right">
+            <h1 style="color:purple"><%= partner.quota %> </h1>
+            <h5>Monthly Limit</h5>
+          </div>
+          <!-- /.description-block -->
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <!-- /.card-body -->
+  <div class="card-footer">
+    <%= view_button_to approve_partner_partner_path(partner) %>
+    <%= edit_button_to edit_partner_path(partner) %>
+    <% if partner.deactivated? %>
+      <%= reactivate_button_to reactivate_partner_path(partner), {confirm: confirm_reactivate_msg(partner.name)} %>
+    <% else %>
+      <%= deactivate_button_to deactivate_partner_path(partner), {confirm: confirm_deactivate_msg(partner.name)} %>
+    <% end %>
+    <%= modal_button_to("#addUserModal", {text: "Add/Remind Partner", size: "xs"}) if can_administrate? %>
+    <%= print_button_to approve_application_partner_path(partner), {text: "Activate Partner Now", icon: "thumbs-o-up", type: "success", size: "xs"} if can_administrate? %>
+    <span class="float-right">
+      <%= download_button_to(csv_path(format: :csv, type: "PartnerDistribution", filters: { partner_id: partner.id }), text: "Export Partner Distributions") if partner_distributions&.length > 0 %>
+    </span>
+  </div>
+</div>

--- a/app/views/partners/index.html.erb
+++ b/app/views/partners/index.html.erb
@@ -59,6 +59,7 @@
               <tr>
                 <th>Partner</th>
                 <th>E-mail</th>
+                <th>Monthly Limit</th>
                 <th>Status</th>
                 <th>Action</th>
                 <th>&nbsp;</th>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -81,6 +81,7 @@
             <% end %>
             <%= modal_button_to("#addUserModal", {text: "Add/Remind Partner", size: "xs"}) if can_administrate? %>
             <%= print_button_to approve_application_partner_path(@partner), {text: "Activate Partner Now", icon: "thumbs-o-up", type: "success", size: "xs"} if can_administrate? %>
+            <%= modal_button_to("#notesBarCode", {text: "Notes", icon: "sticky-note", size: "xs"}) %>
           </div>
         </div>
       </div>
@@ -174,4 +175,8 @@
       </div><!-- modal-content -->
     </div><!-- modal-dialog -->
   </div><!-- seeZipcodes -->
+
+  <% if @partner.notes.present? %>
+    <%= render "notes", partner: @partner %>
+  <% end %>
 </section>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -33,7 +33,7 @@
           </div>
           <div class="card-body p-0">
             <div class="row">
-              <div class="col-sm-4 col-4">
+              <div class="<%= show_header_column_class(@partner) %>">
                 <div class="description-block border-right">
                   <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "families_served") || 0) %> </h1>
                   <h5>Families served</h5>
@@ -41,7 +41,7 @@
                 <!-- /.description-block -->
               </div>
               <!-- /.col -->
-              <div class="col-sm-4 col-4">
+              <div class="<%= show_header_column_class(@partner) %>">
                 <div class="description-block border-right">
                   <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "children_served") || 0) %> </h1>
                   <h5>Children served</h5>
@@ -49,7 +49,7 @@
                 <!-- /.description-block -->
               </div>
               <!-- /.col -->
-              <div class="col-sm-4 col-4">
+              <div class="<%= show_header_column_class(@partner) %>">
                 <div class="description-block border-right">
                   <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "family_zipcodes") || 0) %> </h1>
                   <h5>Zipcodes served</h5>
@@ -57,6 +57,17 @@
                 </div>
                 <!-- /.description-block -->
               </div>
+
+              <% if @partner.quota.present? %>
+                <!-- /.col -->
+                <div class="<%= show_header_column_class(@partner) %>">
+                  <div class="description-block border-right">
+                    <h1 style="color:purple"><%= @partner.quota %> </h1>
+                    <h5>Monthly Limit</h5>
+                  </div>
+                  <!-- /.description-block -->
+                </div>
+              <% end %>
             </div>
           </div>
           <!-- /.card-body -->

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -27,66 +27,11 @@
     <div class="row">
       <div class="col-12">
         <!-- Default box -->
-        <div class="card card-info card-outline">
-          <div class="card-header">
-            <h2 class="card-title"><%= @partner.name %></h2>
-          </div>
-          <div class="card-body p-0">
-            <div class="row">
-              <div class="<%= show_header_column_class(@partner) %>">
-                <div class="description-block border-right">
-                  <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "families_served") || 0) %> </h1>
-                  <h5>Families served</h5>
-                </div>
-                <!-- /.description-block -->
-              </div>
-              <!-- /.col -->
-              <div class="<%= show_header_column_class(@partner) %>">
-                <div class="description-block border-right">
-                  <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "children_served") || 0) %> </h1>
-                  <h5>Children served</h5>
-                </div>
-                <!-- /.description-block -->
-              </div>
-              <!-- /.col -->
-              <div class="<%= show_header_column_class(@partner) %>">
-                <div class="description-block border-right">
-                  <h1 style="color:purple"><%= total_on_hand(@impact_metrics.dig("agency", "family_zipcodes") || 0) %> </h1>
-                  <h5>Zipcodes served</h5>
-                  <%= modal_button_to("#seeZipcodes", {text: "See Zipcodes?", size: "xs"}) if @impact_metrics.dig("agency", "family_zipcodes_list").present? %>
-                </div>
-                <!-- /.description-block -->
-              </div>
+        <%= render "show_header", partner: @partner, impact_metrics: @impact_metrics, partner_distributions: @partner_distributions %>
 
-              <% if @partner.quota.present? %>
-                <!-- /.col -->
-                <div class="<%= show_header_column_class(@partner) %>">
-                  <div class="description-block border-right">
-                    <h1 style="color:purple"><%= @partner.quota %> </h1>
-                    <h5>Monthly Limit</h5>
-                  </div>
-                  <!-- /.description-block -->
-                </div>
-              <% end %>
-            </div>
-          </div>
-          <!-- /.card-body -->
-          <div class="card-footer">
-            <%= view_button_to approve_partner_partner_path(@partner) %>
-            <%= edit_button_to edit_partner_path(@partner) %>
-            <% if @partner.deactivated? %>
-              <%= reactivate_button_to reactivate_partner_path(@partner), {confirm: confirm_reactivate_msg(@partner.name)} %>
-            <% else %>
-              <%= deactivate_button_to deactivate_partner_path(@partner), {confirm: confirm_deactivate_msg(@partner.name)} %>
-            <% end %>
-            <%= modal_button_to("#addUserModal", {text: "Add/Remind Partner", size: "xs"}) if can_administrate? %>
-            <%= print_button_to approve_application_partner_path(@partner), {text: "Activate Partner Now", icon: "thumbs-o-up", type: "success", size: "xs"} if can_administrate? %>
-            <span class="float-right">
-              <%= download_button_to(csv_path(format: :csv, type: "PartnerDistribution", filters: { partner_id: @partner.id }), text: "Export Partner Distributions") if @partner_distributions&.length > 0 %>
-            </span>
-            <%= modal_button_to("#notesBarCode", {text: "Notes", icon: "sticky-note", size: "xs"}) %>
-          </div>
-        </div>
+        <% if @partner.notes.present? %>
+          <%= render "notes", partner: @partner %>
+        <% end %>
       </div>
     </div>
   </div>
@@ -179,7 +124,4 @@
     </div><!-- modal-dialog -->
   </div><!-- seeZipcodes -->
 
-  <% if @partner.notes.present? %>
-    <%= render "notes", partner: @partner %>
-  <% end %>
 </section>

--- a/db/migrate/20200922144333_add_notes_and_quota_for_partners.rb
+++ b/db/migrate/20200922144333_add_notes_and_quota_for_partners.rb
@@ -1,0 +1,6 @@
+class AddNotesAndQuotaForPartners < ActiveRecord::Migration[6.0]
+  def change
+    add_column :partners, :notes, :text
+    add_column :partners, :quota, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_21_182529) do
+ActiveRecord::Schema.define(version: 2020_09_22_144333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -283,6 +283,8 @@ ActiveRecord::Schema.define(version: 2020_09_21_182529) do
     t.integer "organization_id"
     t.integer "status", default: 0
     t.boolean "send_reminders", default: false, null: false
+    t.text "notes"
+    t.integer "quota"
     t.index ["organization_id"], name: "index_partners_on_organization_id"
   end
 

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -5,6 +5,8 @@
 #  id              :integer          not null, primary key
 #  email           :string
 #  name            :string
+#  notes           :text
+#  quota           :integer
 #  send_reminders  :boolean          default(FALSE), not null
 #  status          :integer          default("uninvited")
 #  created_at      :datetime         not null

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -5,6 +5,8 @@
 #  id              :integer          not null, primary key
 #  email           :string
 #  name            :string
+#  notes           :text
+#  quota           :integer
 #  send_reminders  :boolean          default(FALSE), not null
 #  status          :integer          default("uninvited")
 #  created_at      :datetime         not null

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe Partner, type: :model do
       expect(build(:partner, email: "foo@bar.com")).not_to be_valid
       expect(build(:partner, email: "boooooooooo")).not_to be_valid
     end
+
+    it "validates the quota is a number but it is not required" do
+      is_expected.to validate_numericality_of(:quota)
+      expect(build(:partner, email: "foo@bar.com", quota: "")).to be_valid
+    end
   end
 
   describe "Filters" do

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe "Partner management", type: :system, js: true do
     end
 
     it "shows invite button only for unapproved partners" do
-      expect(page.find(:xpath, "//table/tbody/tr[1]/td[4]")).to have_no_content('Invite')
-      expect(page.find(:xpath, "//table/tbody/tr[2]/td[4]")).to have_content('Invite')
-      expect(page.find(:xpath, "//table/tbody/tr[3]/td[4]")).to have_no_content('Invite')
+      expect(page.find(:xpath, "//table/tbody/tr[1]/td[5]")).to have_no_content('Invite')
+      expect(page.find(:xpath, "//table/tbody/tr[2]/td[5]")).to have_content('Invite')
+      expect(page.find(:xpath, "//table/tbody/tr[3]/td[5]")).to have_no_content('Invite')
     end
 
     context "when filtering" do
@@ -98,7 +98,7 @@ RSpec.describe "Partner management", type: :system, js: true do
     partner = create(:partner, name: 'Charities')
     visit url_prefix + "/partners"
 
-    within("table > tbody > tr:nth-child(1) > td:nth-child(4)") { click_on "Invite" }
+    within("table > tbody > tr:nth-child(1) > td:nth-child(5)") { click_on "Invite" }
     invite_alert = page.driver.browser.switch_to.alert
     expect(invite_alert.text).to eq("Send an invitation to #{partner.name} to begin using the partner application?")
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1859 <!--fill issue number-->

### Description

- Add `notes` and `quota` columns to the `Partner` table.
- Allow users to fill in `notes` and `quota` in the partner form.
- Show quota in the `Partner` list and show pages if it's present.
- Show a notes button which will launch a modal with the notes if the `Partner` has notes.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Add specs to `Partner` to make sure quotas are not required.
Make sure the quota and notes show up when appropriate.

### Screenshots

![Screen Shot 2020-09-23 at 8 19 03 PM](https://user-images.githubusercontent.com/46204/94012161-fb5b8b80-fdda-11ea-91fc-e8999ffab040.png)

![Screen Shot 2020-09-23 at 8 18 48 PM](https://user-images.githubusercontent.com/46204/94012223-13cba600-fddb-11ea-9778-f0bef4792a42.png)

![Screen Shot 2020-09-23 at 8 17 25 PM](https://user-images.githubusercontent.com/46204/94012232-162e0000-fddb-11ea-9b3a-dd7e7ed42cf1.png)

![Screen Shot 2020-09-23 at 8 17 17 PM](https://user-images.githubusercontent.com/46204/94012240-18905a00-fddb-11ea-8d8d-e699348f6ebb.png)

![Screen Shot 2020-09-23 at 11 07 05 PM](https://user-images.githubusercontent.com/46204/94031749-d0c8fd00-fdf1-11ea-8531-1242f8277340.png)
