### PR TITLE
Remedy issue with Request controller (#1896)

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -52,7 +52,7 @@ class RequestsController < ApplicationController
 
     request_items.inject({}) do |item, (quantity, total)|
       item[quantity] ||= 0
-      item[quantity] += total
+      item[quantity] += total.to_i
       item
     end
   end

--- a/spec/system/request_system_spec.rb
+++ b/spec/system/request_system_spec.rb
@@ -73,8 +73,8 @@ RSpec.describe "Requests", type: :system, js: true do
       let(:partner2) { create(:partner, name: "Not This Guy", email: "ntg@example.com") }
 
       it "filters by item id" do
-        create(:request, request_items: [{ "item_id": item1.id, "quantity": 3 }])
-        create(:request, request_items: [{ "item_id": item2.id, "quantity": 3 }])
+        create(:request, request_items: [{ "item_id": item1.id, "quantity": '3' }])
+        create(:request, request_items: [{ "item_id": item2.id, "quantity": '3' }])
 
         visit subject
         # check for all requests


### PR DESCRIPTION
Resolves #1896

### Description
<!-- Please include a summary of the change and which issue is fixed. 
An issue was opened that mentioned there was a bug with the request controller failing to coerce a string into an integer.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Test coverage was introduced by modifying params in a system spec to match the format of params in production scenarios where the params would be strings instead of integers.