### PR TITLE
1898 display quotas

### DIFF
--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -6,8 +6,8 @@ module RequestsHelper
   end
 
   def quota_column_class(total, partner)
-    return "" if partner.quota.blank? || total < partner.quota
+    return "" if partner.quota.blank? || total.to_i < partner.quota
 
-    "text-danger font-weight-bold"
+    "font-italic font-weight-bold"
   end
 end

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -1,0 +1,7 @@
+module RequestsHelper
+  def quota_display(partner)
+    return "" if partner.quota.blank?
+
+    "(#{partner.quota})"
+  end
+end

--- a/app/helpers/requests_helper.rb
+++ b/app/helpers/requests_helper.rb
@@ -4,4 +4,10 @@ module RequestsHelper
 
     "(#{partner.quota})"
   end
+
+  def quota_column_class(total, partner)
+    return "" if partner.quota.blank? || total < partner.quota
+
+    "text-danger font-weight-bold"
+  end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -76,4 +76,8 @@ class Request < ApplicationRecord
   def self.csv_export(requests)
     Exports::ExportRequestService.new(requests).call
   end
+
+  def total_items
+    request_items.sum { |item| item["quantity"] }
+  end
 end

--- a/app/views/requests/_request_row.html.erb
+++ b/app/views/requests/_request_row.html.erb
@@ -1,7 +1,7 @@
 <tr>
   <td class="date"><%= request_row.created_at.strftime("%m/%d/%Y") %></td>
   <td><%= request_row.partner.name %> </td>
-  <td>
+  <td class="<%= quota_column_class(request_row.total_items, request_row.partner) %>">
     <%= request_row.total_items %>
     <%= quota_display(request_row.partner) %>
   </td>

--- a/app/views/requests/_request_row.html.erb
+++ b/app/views/requests/_request_row.html.erb
@@ -2,6 +2,10 @@
   <td class="date"><%= request_row.created_at.strftime("%m/%d/%Y") %></td>
   <td><%= request_row.partner.name %> </td>
   <td>
+    <%= request_row.total_items %>
+    <%= quota_display(request_row.partner) %>
+  </td>
+  <td>
     <%= render partial: "status", locals: {status: request_row.status} %>
   </td>
   <td class="text-right">

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -92,6 +92,7 @@
               <tr>
                 <th style="width: 10px">Date</th>
                 <th>Requestor</th>
+                <th># of Items (Request Limit)</th>
                 <th>Status</th>
                 <th class="text-right">Actions</th>
               </tr>

--- a/app/views/requests/show.html.erb
+++ b/app/views/requests/show.html.erb
@@ -74,6 +74,14 @@
                   <td><%= item.on_hand %></td>
                 </tr>
               <% end %>
+              <tr>
+                <td>Total (Quota)</td>
+                <td>
+                  <%= @request.total_items %>
+                  <%= quota_display(@request.partner) %>
+                </td>
+                <td />
+              </tr>
               </tbody>
             </table>
           </div>

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -27,4 +27,12 @@ RSpec.describe Request, type: :model do
       end
     end
   end
+
+  describe "total_items" do
+    let(:request) { create(:request, request_items: [{ item_id: Item.active.first.id, quantity: 15 }, { item_id: Item.active.last.id, quantity: 18 }]) }
+
+    it "adds the quantity of all items in the request" do
+      expect(request.total_items).to eq(33)
+    end
+  end
 end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1898 <!--fill issue number-->

### Description

Display quotas in the requests page so that diaper banks will see which requests are over the limit.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Adding specs for the `total_items` method.
Verify that the quota shows up in the page.

### Screenshots

![Screen Shot 2020-09-24 at 11 55 34 PM](https://user-images.githubusercontent.com/46204/94169742-c118e980-fec1-11ea-91ef-6fe93c3b3908.png)

![Screen Shot 2020-09-24 at 11 22 07 PM](https://user-images.githubusercontent.com/46204/94169781-cc6c1500-fec1-11ea-9eb0-c0c33a80cb02.png)

