### PR TITLE
Add delete link for partner documents

### DIFF
--- a/app/controllers/attachments_controller.rb
+++ b/app/controllers/attachments_controller.rb
@@ -1,0 +1,7 @@
+class AttachmentsController < ApplicationController
+  def destroy
+    ActiveStorage::Attachment.find(params[:id])&.purge
+
+    redirect_back fallback_location: partners_path
+  end
+end

--- a/app/views/partners/_documents.html.erb
+++ b/app/views/partners/_documents.html.erb
@@ -8,12 +8,14 @@
         <thead>
           <tr>
             <th>Filename</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
           <% partner.documents.each do |document| %>
             <tr>
               <td><%= link_to document.filename, rails_blob_path(document, disposition: "attachment") %></td>
+              <td><%= delete_button_to attachment_path(document), { size: "md", confirm: "Are you sure you want to permanently remove this document?" } %>
             </tr>
           <% end %>
         </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,6 +165,8 @@ Rails.application.routes.draw do
     get "csv", to: "data_exports#csv"
   end
 
+  resources :attachments, only: %i(destroy)
+
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   get "pages/:name", to: "static#page"

--- a/spec/requests/attachments_requests_spec.rb
+++ b/spec/requests/attachments_requests_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe "Attachments", type: :request do
+  before do
+    sign_in(@user)
+  end
+
+  describe "DELETE #destroy" do
+    let(:partner) { create(:partner, documents: [Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/dbase.pdf"), "application/pdf")]) }
+
+    it "redirects to referrer" do
+      delete attachment_path(partner.documents.first)
+      expect(response).to redirect_to(partners_path)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #1890 <!--fill issue number-->

### Description

Add delete link for partner documents in case they want to get rid of some documents.

I decided to add an `attachments` controller so the same endpoint can be reused in case we want to be able to delete attachments from other classes.

### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Add an `Attachments` request spec.
Make sure the documents are deleted when the link is clicked.

### Screenshots

![Screen Shot 2020-09-25 at 5 15 37 PM](https://user-images.githubusercontent.com/46204/94249639-c114fa00-ff52-11ea-98a4-4f965716503b.png)
