### PR TITLE
Display inventory number based off storage location

### DIFF
--- a/app/assets/javascripts/distributions_and_transfers.js
+++ b/app/assets/javascripts/distributions_and_transfers.js
@@ -63,6 +63,7 @@ $(function() {
   const default_item = $(".line-item-fields select");
 
   $(document).on("change", "select.storage-location-source", function() {
+    const default_item = $(".line-item-fields select");
     if (storage_location_required && !control.val()) {
       $("#__add_line_item").addClass("disabled");
     }

--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -34,7 +34,8 @@
           <div class="card-body">
             <!-- Default box -->
             <div class="box">
-              <%= simple_form_for @distribution, method: :post, 
+              <%= simple_form_for @distribution, method: :post,
+                html: {class: "storage-location-required"},
                 wrapper_mappings: {
                   datetime: :custom_multi_select
                 } do |f| %>


### PR DESCRIPTION
Resolves #1792

### Description
The form was missing `"storage-location-required"` class which triggers the inventory to be displayed in the drop down based off the storage location. 

Once this was fixed another issue arose which was that the inventory would not change based off the selected storage location.

When the storage location would change on the form a JavacSript event is triggered but if the user added extra "Items in this distribution" it would not know of the extra elements on the page.

So now when the event is triggered it will check again for the any elements with the class name `line-item-fields select`.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

This has been tested by me adding more Items and ensuring that the inventory is showing up and that when the storage location changes the inventory will also change.

### Screenshots
<img width="1381" alt="Screen Shot 2020-09-25 at 10 07 30 AM" src="https://user-images.githubusercontent.com/16119691/94277968-47601a80-ff18-11ea-89de-e80c8a8b1236.png">

