### PR TITLE
Coerce item data type

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -83,7 +83,7 @@ class Request < ApplicationRecord
     request_items.sum { |item| item["quantity"] }
   end
 
-private
+  private
 
   def sanitize_items_data
     return unless request_items && request_items_changed?

--- a/db/migrate/20200925160112_sanitize_request_item_types.rb
+++ b/db/migrate/20200925160112_sanitize_request_item_types.rb
@@ -1,0 +1,8 @@
+class SanitizeRequestItemTypes < ActiveRecord::Migration[6.0]
+  def up
+    Request.find_each do |request|
+      request.send(:sanitize_items_data)
+      request.save
+    end
+  end
+end

--- a/db/migrate/20200925160112_sanitize_request_item_types.rb
+++ b/db/migrate/20200925160112_sanitize_request_item_types.rb
@@ -1,7 +1,9 @@
 class SanitizeRequestItemTypes < ActiveRecord::Migration[6.0]
   def up
     Request.find_each do |request|
-      request.send(:sanitize_items_data)
+      request.request_items = request.request_items&.map do |item|
+        item.merge("item_id" => item["item_id"]&.to_i, "quantity" => item["quantity"]&.to_i)
+      end
       request.save
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_22_144333) do
+ActiveRecord::Schema.define(version: 2020_09_25_160112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -28,6 +28,20 @@ RSpec.describe Request, type: :model do
     end
   end
 
+  describe "item data" do
+    it "coerces item quantity and id to always be an integer before saving" do
+      request = create(:request, request_items: [
+        { item_id: "25", quantity: "15" },
+        { item_id: "35", quantity: 18 },
+      ])
+
+      expect(request.request_items.first["item_id"]).to be 25
+      expect(request.request_items.first["quantity"]).to be 15
+      expect(request.request_items.last["item_id"]).to be 35
+      expect(request.request_items.last["quantity"]).to be 18
+    end
+  end
+
   describe "total_items" do
     let(:request) { create(:request, request_items: [{ item_id: Item.active.first.id, quantity: 15 }, { item_id: Item.active.last.id, quantity: 18 }]) }
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Request, type: :model do
   describe "item data" do
     it "coerces item quantity and id to always be an integer before saving" do
       request = create(:request, request_items: [
-        { item_id: "25", quantity: "15" },
-        { item_id: "35", quantity: 18 },
-      ])
+                         { item_id: "25", quantity: "15" },
+                         { item_id: "35", quantity: 18 },
+                       ])
 
       expect(request.request_items.first["item_id"]).to be 25
       expect(request.request_items.first["quantity"]).to be 15


### PR DESCRIPTION
Resolves #1905

### Description

Request items were being saved as they come. This could happen through the system itself, or through API calls. This PR adds data coercion before saving to request items' item_id and quantity

### Type of change

* Bug fix

### How Has This Been Tested?

This PR fixes for all input types, the specific bug request that raised this concern is https://github.com/rubyforgood/diaper/issues/1905, and we're still waiting for the user to describe how to reproduce this issue.

### Screenshots

See https://github.com/rubyforgood/diaper/issues/1905