### PR TITLE
Aligns the content of the partner notes card with the card title

### DIFF
--- a/app/views/partners/_notes.html.erb
+++ b/app/views/partners/_notes.html.erb
@@ -2,7 +2,7 @@
   <div class="card-header">
     <h2 class="card-title">Notes</h2>
   </div>
-  <div class="card-body p-0">
+  <div class="card-body p-2">
     <div class="row">
       <div class="col-xs-12 col-sm-12" id="partner-notes">
         <p><%= simple_format(partner.notes) %></p>


### PR DESCRIPTION
I noticed that the partner notes to text and the card title is misaligned. This fixes that :)


### Description
Before 
![Screen Shot 2020-09-26 at 11 36 20 AM](https://user-images.githubusercontent.com/11335191/94345585-89f32700-ffec-11ea-94ec-30a06f8e8a2e.png)

After
![Screen Shot 2020-09-26 at 11 36 26 AM](https://user-images.githubusercontent.com/11335191/94345587-8d86ae00-ffec-11ea-82d1-cb975ee51dbc.png)

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Locally
