### PR TITLE
Fix styling on the document upload input field

### DIFF
--- a/app/views/partners/_form.html.erb
+++ b/app/views/partners/_form.html.erb
@@ -28,7 +28,7 @@
                 <%= f.input_field :notes, class: "form-control" %>
               <% end %>
               <%= f.input :documents, label: "Documents", wrapper: :input_group do %>
-                <%= f.input_field :documents, as: :file, multiple: true, accept: Partner::ALLOWED_MIME_TYPES.join(","), class: "form-control" %>
+                <%= f.input_field :documents, as: :file, multiple: true, accept: Partner::ALLOWED_MIME_TYPES.join(","), class: "form-control h-auto" %>
               <% end %>
             </div>
             <!-- /.card-body -->


### PR DESCRIPTION
### Description
I noticed that the button 'sticks' the border of the input field border. This PR enables the input field to expand in height to accommodate the size of the button
   
### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Test locally

### Screenshots
Before:
![Screen Shot 2020-09-26 at 11 44 08 AM](https://user-images.githubusercontent.com/11335191/94345711-9c219500-ffed-11ea-9b89-1dada9014835.png)

After:
![Screen Shot 2020-09-26 at 11 41 01 AM](https://user-images.githubusercontent.com/11335191/94345708-8a3ff200-ffed-11ea-9719-0d5081351d3e.png)
