### PR TITLE
Fix for bug when a diaper bank attempts to view an uninvited partner.

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -31,8 +31,8 @@ class PartnersController < ApplicationController
   end
 
   def show
-    @impact_metrics = JSON.parse(DiaperPartnerClient.get({ id: params[:id] }, query_params: { impact_metrics: true }))
     @partner = current_organization.partners.find(params[:id])
+    @impact_metrics = JSON.parse(DiaperPartnerClient.get({ id: params[:id] }, query_params: { impact_metrics: true })) unless @partner.uninvited?
     @partner_distributions = @partner.distributions.order(created_at: :desc)
   end
 

--- a/app/views/partners/_show_header.html.erb
+++ b/app/views/partners/_show_header.html.erb
@@ -57,3 +57,22 @@
     </span>
   </div>
 </div>
+<div id="seeZipcodes" class="modal fade">
+  <div class="modal-dialog">
+    <!-- Modal content-->
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title">Serviced zipcodes</h4>
+      </div><!-- modal-header -->
+      <div class="modal-body">
+        <div class="box-body">
+          <ul>
+            <% @impact_metrics.dig("agency", "family_zipcodes_list").each do |zipcode| %>
+              <li><%= zipcode %></li>
+            <% end %>
+          </ul>
+        </div><!-- box-body -->
+      </div><!-- modal-body -->
+    </div><!-- modal-content -->
+  </div><!-- modal-dialog -->
+</div><!-- seeZipcodes -->

--- a/app/views/partners/_uninvited_header.html.erb
+++ b/app/views/partners/_uninvited_header.html.erb
@@ -1,0 +1,13 @@
+<div class="card card-info card-outline">
+  <div class="card-header">
+    <h2 class="card-title"><%= partner.name %></h2>
+  </div>
+  <div class="card-body p-0">
+  </div>
+  <!-- /.card-body -->
+  <div class="card-footer">
+    <%= edit_button_to edit_partner_path(partner) %>
+    <span class="float-right">
+    </span>
+  </div>
+</div>

--- a/app/views/partners/show.html.erb
+++ b/app/views/partners/show.html.erb
@@ -27,8 +27,11 @@
     <div class="row">
       <div class="col-12">
         <!-- Default box -->
-        <%= render "show_header", partner: @partner, impact_metrics: @impact_metrics, partner_distributions: @partner_distributions %>
-
+        <% if @partner.uninvited? %>
+        <%= render "uninvited_header", partner: @partner %>
+          <% else %>
+          <%= render "show_header", partner: @partner, impact_metrics: @impact_metrics, partner_distributions: @partner_distributions %>
+        <% end %>
         <% if @partner.notes.present? %>
           <%= render "notes", partner: @partner %>
         <% end %>
@@ -109,24 +112,4 @@
       </div><!-- modal-content -->
     </div><!-- modal-dialog -->
   </div><!-- addUserModal -->
-  <div id="seeZipcodes" class="modal fade">
-    <div class="modal-dialog">
-      <!-- Modal content-->
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title">Serviced zipcodes</h4>
-        </div><!-- modal-header -->
-        <div class="modal-body">
-          <div class="box-body">
-          <ul>
-            <% @impact_metrics.dig("agency", "family_zipcodes_list").each do |zipcode| %>
-              <li><%= zipcode %></li>
-            <% end %>
-          </ul>
-          </div><!-- box-body -->
-        </div><!-- modal-body -->
-      </div><!-- modal-content -->
-    </div><!-- modal-dialog -->
-  </div><!-- seeZipcodes -->
-
 </section>

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Partners", type: :request do
   end
 
   describe "GET #show" do
-    let(:partner) { create(:partner, organization: @organization) }
+    let(:partner) { create(:partner, organization: @organization, status: :approved) }
     let(:fake_get_return) do
       { "agency" => {
         "families_served" => Faker::Number.number,

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -40,6 +40,19 @@ RSpec.describe "Partner management", type: :system, js: true do
     end
   end
 
+  context "when viewing an uninvited partner" do
+    let(:uninvited) { create(:partner, name: "Uninvited Partner", status: :uninvited) }
+    subject { url_prefix + "/partners/#{uninvited.id}" }
+
+    it 'only has an edit option available' do
+      visit subject
+
+      expect(page).to have_selector(:link_or_button, 'Edit')
+      expect(page).to_not have_selector(:link_or_button, 'View')
+      expect(page).to_not have_selector(:link_or_button, 'Activate Partner Now')
+      expect(page).to_not have_selector(:link_or_button, 'Add/Remind Partner')
+    end
+  end
   context "when creating a new partner" do
     subject { url_prefix + "/partners/new" }
 


### PR DESCRIPTION
Resolves #1936 

Remove all the unneeded cruft from uninvited partners and only makes the edit button visible on the show page so they can still add notes/uploads/etc on them.

![image](https://user-images.githubusercontent.com/667909/94505554-55908e00-01d9-11eb-9570-2e9d9099049f.png)
