### PR TITLE
Redirect to show after update Partner

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -63,7 +63,7 @@ class PartnersController < ApplicationController
   def update
     @partner = current_organization.partners.find(params[:id])
     if @partner.update(partner_params)
-      redirect_to partners_path, notice: "#{@partner.name} updated!"
+      redirect_to partner_path(@partner), notice: "#{@partner.name} updated!"
     else
       flash[:error] = "Something didn't work quite right -- try again?"
       render action: :edit

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -135,20 +135,20 @@ RSpec.describe "Partners", type: :request do
         expect(response).to have_http_status(:found)
       end
 
-      it "redirects to #index" do
+      it "redirects to #show" do
         partner = create(:partner, organization: @organization)
         put partner_path(default_params.merge(id: partner, partner: partner_params))
-        expect(response).to redirect_to(partners_path)
+        expect(response).to redirect_to(partner_path(partner))
       end
     end
 
     context "unsuccessful save due to empty params" do
-      partner_params = { partner: { name: nil, email: nil } }
+      partner_params = { name: "", email: "" }
 
       it "renders :edit" do
         partner = create(:partner, organization: @organization)
         put partner_path(default_params.merge(id: partner, partner: partner_params))
-        expect(response).to redirect_to(partners_path)
+        expect(response).to render_template(:edit)
       end
     end
   end


### PR DESCRIPTION
Resolves #1924 

### Description
Change the redirect path to show when partner updates. 
   
### How Has This Been Tested?
The test on update was inconsistent for an unsuccessful.
