### PR TITLE
BUGFIX: Pre-loads items collection, alphabetized, and scopes to organization

### DIFF
--- a/app/controllers/kits_controller.rb
+++ b/app/controllers/kits_controller.rb
@@ -1,6 +1,7 @@
 class KitsController < ApplicationController
   def index
     @kits = current_organization.kits.class_filter(filter_params)
+    @base_items = current_organization.items.alphabetized
     @selected_item = filter_params[:by_partner_key]
     @include_inactive = params[:include_inactive]
     unless params[:include_inactive]

--- a/app/views/kits/index.html.erb
+++ b/app/views/kits/index.html.erb
@@ -34,7 +34,7 @@
               <div class="row">
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
                   <%= label_tag "Filter by Base Item" %>
-                  <%= collection_select(:filters, :by_partner_key, Item.alphabetized, :partner_key, :name, {include_blank: true, selected: @selected_item}, class: "form-control") %>
+                  <%= collection_select(:filters, :by_partner_key, @base_items, :partner_key, :name, {include_blank: true, selected: @selected_item}, class: "form-control") %>
                 </div>
               </div>
               <div class="row">


### PR DESCRIPTION
Resolves #1925

### Description
We had duplicate entries appearing in the base items dropdown of kits. This was due to the collection be initialized as `Item.alphabetized` pulling globally. In production, this would likely be an absurdly large colleciton, since it would be pulling every item record ever :D 

This fix scopes it down, as we do elsewhere.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually. I don't think this justifies a test, since it was just a minor error in implementation.

### Screenshots
<img width="527" alt="Screen Shot 2020-10-01 at 2 39 11 PM" src="https://user-images.githubusercontent.com/502363/94849762-e6db4c80-03f3-11eb-9228-a24c6eccd885.png">
