### PR TITLE
fixed typo for class StorageLocationDoesNotMatch

### DIFF
--- a/app/models/errors.rb
+++ b/app/models/errors.rb
@@ -43,7 +43,7 @@ module Errors
     end
   end
 
-  class StorageLocationDoestNotMatch < StandardError
+  class StorageLocationDoesNotMatch < StandardError
     def message
       "Storage location kit doesn't match"
     end

--- a/app/services/allocate_kit_inventory_service.rb
+++ b/app/services/allocate_kit_inventory_service.rb
@@ -24,7 +24,7 @@ class AllocateKitInventoryService
   private
 
   def validate_storage_location
-    raise Errors::StorageLocationDoestNotMatch if storage_location.organization != kit.organization
+    raise Errors::StorageLocationDoesNotMatch if storage_location.organization != kit.organization
   end
 
   def allocate_inventory_items

--- a/app/services/deallocate_kit_inventory_service.rb
+++ b/app/services/deallocate_kit_inventory_service.rb
@@ -19,7 +19,7 @@ class DeallocateKitInventoryService
   private
 
   def validate_storage_location
-    raise Errors::StorageLocationDoestNotMatch if storage_location.organization != kit.organization
+    raise Errors::StorageLocationDoesNotMatch if storage_location.organization != kit.organization
   end
 
   def deallocate_inventory_items


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

Resolves #1927 

### Description
Fixed class name typo 

### Type of change
* Class name change

