### PR TITLE
Persist filter choices in requests and distributions

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -47,7 +47,10 @@ class DistributionsController < ApplicationController
     @total_items_paginated_distributions = total_items(@paginated_distributions)
     @items = current_organization.items.alphabetized
     @partners = @distributions.collect(&:partner).uniq.sort_by(&:name)
-    @states = Distribution.states.transform_keys(&:humanize)
+    @statuses = Distribution.states.transform_keys(&:humanize)
+    @selected_item = filter_params[:by_item_id]
+    @selected_partner = filter_params[:by_partner]
+    @selected_status = filter_params[:by_state]
   end
 
   def create

--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -11,9 +11,11 @@ class RequestsController < ApplicationController
     @paginated_requests = @requests.page(params[:page])
     @calculate_product_totals = total_items(@requests)
     @items = current_organization.items.alphabetized
-    @partners = @requests.collect(&:partner).uniq.sort_by(&:name)
+    @partners = current_organization.partners.order(:name)
     @statuses = Request.statuses.transform_keys(&:humanize)
-
+    @selected_request_item = filter_params[:by_request_item_id]
+    @selected_partner = filter_params[:by_partner]
+    @selected_status = filter_params[:by_status]
     respond_to { |format| format.html }
   end
 

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -39,18 +39,18 @@
                 <% if @items.present? %>
                   <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= label_tag "by Item" %>
-                    <%= collection_select(:filters, :by_item_id, @items || {}, :id, :name, {include_blank: true}, {class: "form-control"}) %>
+                    <%= collection_select(:filters, :by_request_item_id, @items || {}, :id, :name, {include_blank: true, selected: @selected_request_item}, {class: "form-control"}) %>
                   </div>
                 <% end %>
                 <% if @partners.present? %>
                   <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= label_tag "by Partner" %>
-                    <%= collection_select(:filters, :by_partner, @partners || {}, :id, :name, {include_blank: true}, {class: "form-control"}) %>
+                    <%= collection_select(:filters, :by_partner, @partners || {}, :id, :name, {include_blank: true, selected: @selected_partner}, {class: "form-control"}) %>
                   </div>
                 <% end %>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                   <%= label_tag "by Status" %>
-                  <%= collection_select(:filters, :by_state, @states || {}, :last, :first, {include_blank: true}, {class: "form-control"}) %>
+                  <%= collection_select(:filters, :by_state, @statuses || {}, :last, :first, {include_blank: true, selected: @selected_status}, {class: "form-control"}) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                   <%= label_tag "Date Range" %>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -39,7 +39,7 @@
                 <% if @items.present? %>
                   <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= label_tag "by Item" %>
-                    <%= collection_select(:filters, :by_request_item_id, @items || {}, :id, :name, {include_blank: true, selected: @selected_request_item}, {class: "form-control"}) %>
+                    <%= collection_select(:filters, :by_item_id, @items || {}, :id, :name, {include_blank: true, selected: @selected_item}, {class: "form-control"}) %>
                   </div>
                 <% end %>
                 <% if @partners.present? %>

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -40,18 +40,18 @@
                 <% if @items.present? %>
                   <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= label_tag "by Item" %>
-                    <%= collection_select(:filters, :by_request_item_id, @items || {}, :id, :name, {include_blank: true}, {class: "form-control"}) %>
+                    <%= collection_select(:filters, :by_request_item_id, @items || {}, :id, :name, {include_blank: true, selected: @selected_request_item}, {class: "form-control"}) %>
                   </div>
                 <% end %>
                 <% if @partners.present? %>
                   <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= label_tag "by Partner" %>
-                    <%= collection_select(:filters, :by_partner, @partners || {}, :id, :name, {include_blank: true}, {class: "form-control"}) %>
+                    <%= collection_select(:filters, :by_partner, @partners || {}, :id, :name, {include_blank: true, selected: @selected_partner}, {class: "form-control"}) %>
                   </div>
                 <% end %>
                 <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                   <%= label_tag "by Status" %>
-                  <%= collection_select(:filters, :by_status, @statuses || {}, :last, :first, {include_blank: true}, {class: "form-control"}) %>
+                  <%= collection_select(:filters, :by_status, @statuses || {}, :last, :first, {include_blank: true, selected: @selected_status}, {class: "form-control"}) %>
                 </div>
                 <div class="form-group col-lg-3 col-md-4 col-sm-6 col-xs-12">
                   <%= label_tag "Date Range" %>


### PR DESCRIPTION
Resolves #1922 

### Description
`collection_select` accepts an optional `selected` key that pre-selects the provided option. This is captured in the controller during the request and then applied to the filter in the view.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
I manually tested it. Screenshots below. 

I think this feature should probably get a helper similar to `UiHelper`, or maybe a partial. 
We've got lots of samples to make a good abstraction here. That would help these be a little more explicit in terms of what it's needing.


### Screenshots
<img width="1090" alt="Screen Shot 2020-10-01 at 3 06 54 PM" src="https://user-images.githubusercontent.com/502363/94852538-0aa09180-03f8-11eb-951e-0f86a118223f.png">
<img width="938" alt="Screen Shot 2020-10-01 at 3 07 05 PM" src="https://user-images.githubusercontent.com/502363/94852541-0d02eb80-03f8-11eb-9214-a74dce2637da.png">
<img width="721" alt="Screen Shot 2020-10-01 at 3 07 25 PM" src="https://user-images.githubusercontent.com/502363/94852591-1d1acb00-03f8-11eb-827e-8f171789d698.png">
<img width="830" alt="Screen Shot 2020-10-01 at 3 08 10 PM" src="https://user-images.githubusercontent.com/502363/94852598-2015bb80-03f8-11eb-8b23-ff7f1a77602c.png">
