### PR TITLE
Add new cops to config file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -199,6 +199,12 @@ Metrics/PerceivedComplexity:
     reader.
   Enabled: false
   Max: 7
+Layout/BeginEndAlignment:
+  Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: false
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: false
 Layout/LineLength:
   # This one metric can't be ratcheted via .rubocop_todo.yml :(
   # So instead, make a single PR that changes back to 100 and fix all violations
@@ -215,6 +221,96 @@ Lint/AssignmentInCondition:
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#safe-assignment-in-condition
   Enabled: false
   AllowSafeAssignment: true
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: false
+Lint/ConstantDefinitionInBlock:
+  Enabled: false
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: false
+Lint/DuplicateElsifCondition:
+  Enabled: false
+Lint/DuplicateRequire:
+  Enabled: false
+Lint/DuplicateRescueException:
+  Enabled: false
+Lint/EmptyConditionalBody:
+  Enabled: false
+Lint/EmptyFile:
+  Enabled: false
+Lint/FloatComparison:
+  Enabled: false
+Lint/IdentityComparison:
+  Enabled: false
+Lint/MissingSuper:
+  Enabled: false
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+Lint/OutOfRangeRegexpRef:
+  Enabled: false
+Lint/RaiseException:
+  Enabled: false
+Lint/SelfAssignment:
+  Enabled: false
+Lint/StructNewOverride:
+  Enabled: false
+Lint/TopLevelReturnWithArgument:
+  Enabled: false
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: false
+Lint/UnreachableLoop:
+  Enabled: false
+Lint/UselessMethodDefinition:
+  Enabled: false
+Lint/UselessTimes:
+  Enabled: false
+Style/AccessorGrouping:
+  Enabled: false
+Style/BisectedAttrAccessor:
+  Enabled: false
+Style/CaseLikeIf:
+  Enabled: false
+Style/CombinableLoops:
+  Enabled: false
+Style/ExplicitBlockArgument:
+  Enabled: false
+Style/ExponentialNotation:
+  Enabled: false
+Style/GlobalStdStream:
+  Enabled: false
+Style/HashAsLastArrayItem:
+  Enabled: false
+Style/HashEachMethods:
+  Enabled: false
+Style/HashLikeCase:
+  Enabled: false
+Style/HashTransformKeys:
+  Enabled: false
+Style/HashTransformValues:
+  Enabled: false
+Style/KeywordParametersOrder:
+  Enabled: false
+Style/OptionalBooleanParameter:
+  Enabled: false
+Style/RedundantAssignment:
+  Enabled: false
+Style/RedundantFetchBlock:
+  Enabled: false
+Style/RedundantFileExtensionInRequire:
+  Enabled: false
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+Style/RedundantRegexpEscape:
+  Enabled: false
+Style/RedundantSelfAssignment:
+  Enabled: false
+Style/SingleArgumentDig:
+  Enabled: false
+Style/SlicingWithRange:
+  Enabled: false
+Style/SoleNestedConditional:
+  Enabled: false
+Style/StringConcatenation:
+  Enabled: false
 Style/BlockComments:
   Enabled: false
 Style/ClassAndModuleChildren:
@@ -313,6 +409,36 @@ Rails/UnknownEnv:
 Style/SymbolArray:
   Enabled: false
 Rails/UniqueValidationWithoutIndex: # We use multiple unique validations where the uniqueness is scoped
+  Enabled: false
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: false
+Rails/AfterCommitOverride:
+  Enabled: false
+Rails/FindById:
+  Enabled: false
+Rails/Inquiry:
+  Enabled: false
+Rails/MailerName:
+  Enabled: false
+Rails/MatchRoute:
+  Enabled: false
+Rails/NegateInclude:
+  Enabled: false
+Rails/Pluck:
+  Enabled: false
+Rails/PluckInWhere:
+  Enabled: false
+Rails/RenderInline:
+  Enabled: false
+Rails/RenderPlainText:
+  Enabled: false
+Rails/ShortI18n:
+  Enabled: false
+Rails/SquishedSQLHeredocs:
+  Enabled: false
+Rails/WhereExists:
+  Enabled: false
+Rails/WhereNot:
   Enabled: false
 Lint/EnsureReturn: # The service objects return self in an ensure block. Not using an explicit return does not do correct behavior
   Enabled: false


### PR DESCRIPTION
Resolves #1902 

Added the list of missing new cops to .rubocop.yml config file.

All tests still pass!

<img width="857" alt="Screen Shot 2020-10-01 at 6 04 29 PM" src="https://user-images.githubusercontent.com/61627014/94871837-9a523a00-0410-11eb-8800-88874a20b177.png">
