### PR TITLE
Rebecarancan/request confirmation email#1952

### DIFF
--- a/app/controllers/api/v1/family_requests_controller.rb
+++ b/app/controllers/api/v1/family_requests_controller.rb
@@ -13,6 +13,7 @@ class API::V1::FamilyRequestsController < ApplicationController
     partner_request = parse_request
 
     if partner_request.save
+      NotifyPartnerJob.perform_now(partner_request.id)
       render json: partner_request.family_request_reply, status: :created
     else
       render json: partner_request.errors, status: :bad_request

--- a/app/controllers/api/v1/partner_requests_controller.rb
+++ b/app/controllers/api/v1/partner_requests_controller.rb
@@ -11,6 +11,7 @@ class API::V1::PartnerRequestsController < ApplicationController
     request = Request.new(request_params)
 
     if request.save
+      NotifyPartnerJob.perform_now(request.id)
       render json: request, status: :created
     else
       render json: request.errors, status: :bad_request

--- a/app/jobs/notify_partner_job.rb
+++ b/app/jobs/notify_partner_job.rb
@@ -1,0 +1,7 @@
+class NotifyPartnerJob < ApplicationJob
+  def perform(request_id)
+    request = Request.find(request_id)
+
+    RequestsConfirmationMailer.confirmation_email(request).deliver_now
+  end
+end

--- a/app/jobs/notify_partner_job.rb
+++ b/app/jobs/notify_partner_job.rb
@@ -2,6 +2,6 @@ class NotifyPartnerJob < ApplicationJob
   def perform(request_id)
     request = Request.find(request_id)
 
-    RequestsConfirmationMailer.confirmation_email(request).deliver_now
+    RequestsConfirmationMailer.confirmation_email(request).deliver_later
   end
 end

--- a/app/mailers/requests_confirmation_mailer.rb
+++ b/app/mailers/requests_confirmation_mailer.rb
@@ -1,0 +1,20 @@
+class RequestsConfirmationMailer < ApplicationMailer
+  def confirmation_email(request)
+    @organization = request.organization
+    @partner = request.partner
+    @request_items = fetch_items(request)
+
+    mail(from: @organization.from_email, to: @partner.email, subject: "#{@organization.name} - Requests Confirmation")
+  end
+
+  private
+
+  def fetch_items(request)
+    items_sorted = request.request_items.sort_by { |k| k['item_id'] }
+    item_ids = items_sorted&.map { |item| item['item_id'] }
+    items_names = Item.where(id: item_ids).order(:id).pluck(:name)
+    names_hash = items_names.map { |name| { 'name' => name } }
+
+    items_sorted.zip(names_hash).map { |items, names| items.merge(names) }
+  end
+end

--- a/app/views/requests_confirmation_mailer/confirmation_email.html.erb
+++ b/app/views/requests_confirmation_mailer/confirmation_email.html.erb
@@ -1,0 +1,13 @@
+<p>Hello <%= @partner.name %>,</p>
+
+<p>This is an email confirmation that the <%= @organization.name %> has received your request of:</p>
+<ul>
+  <% @request_items.each do |item| %>
+  <li><%= item['name'] %> - <%= item['quantity'] || item['person_count'] %></li>
+  <% end %>
+</ul>
+
+<p>You will receive a notification when a distribution has been created of the pick-up time and date.</p>
+
+<p>Your friends at,</p>
+<p><%= @organization.name %></p>

--- a/app/views/requests_confirmation_mailer/confirmation_email.html.erb
+++ b/app/views/requests_confirmation_mailer/confirmation_email.html.erb
@@ -3,7 +3,7 @@
 <p>This is an email confirmation that the <%= @organization.name %> has received your request of:</p>
 <ul>
   <% @request_items.each do |item| %>
-  <li><%= item['name'] %> - <%= item['quantity'] || item['person_count'] %></li>
+    <li><%= item['name'] %> - <%= item['quantity'] || item['person_count'] %></li>
   <% end %>
 </ul>
 

--- a/app/views/requests_confirmation_mailer/confirmation_email.text.erb
+++ b/app/views/requests_confirmation_mailer/confirmation_email.text.erb
@@ -1,0 +1,12 @@
+Hello <%= @partner.name %>,
+
+This is an email confirmation that the <%= @organization.name %> has received your request of:
+<% @request_items.each do |item| %>
+  <%= item['name'] %> - <%= item['quantity'] %>
+<% end %>
+
+
+You will receive a notification when a distribution has been created of the pick-up time and date.
+
+Your friends at,
+<%= @organization.name %>

--- a/app/views/requests_confirmation_mailer/confirmation_email.text.erb
+++ b/app/views/requests_confirmation_mailer/confirmation_email.text.erb
@@ -2,7 +2,7 @@ Hello <%= @partner.name %>,
 
 This is an email confirmation that the <%= @organization.name %> has received your request of:
 <% @request_items.each do |item| %>
-  <%= item['name'] %> - <%= item['quantity'] %>
+  <%= item['name'] %> - <%= item['quantity'] || item['person_count'] %>
 <% end %>
 
 

--- a/spec/jobs/notify_partner_job_spec.rb
+++ b/spec/jobs/notify_partner_job_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe NotifyPartnerJob, job: true do
 
     before do
       allow(RequestsConfirmationMailer).to receive(:confirmation_email).and_return(mailer)
-      allow(mailer).to receive(:deliver_now)
+      allow(mailer).to receive(:deliver_later)
     end
 
     it "is expected to call RequestsConfirmationMailer" do
       NotifyPartnerJob.perform_now(request.id)
       expect(RequestsConfirmationMailer).to have_received(:confirmation_email).with(request)
-      expect(mailer).to have_received(:deliver_now)
+      expect(mailer).to have_received(:deliver_later)
     end
   end
 end

--- a/spec/jobs/notify_partner_job_spec.rb
+++ b/spec/jobs/notify_partner_job_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe NotifyPartnerJob, job: true do
+  describe "#perform" do
+    let(:request) { create(:request) }
+    let(:mailer) { double(:mailer) }
+
+    before do
+      allow(RequestsConfirmationMailer).to receive(:confirmation_email).and_return(mailer)
+      allow(mailer).to receive(:deliver_now)
+    end
+
+    it "is expected to call RequestsConfirmationMailer" do
+      NotifyPartnerJob.perform_now(request.id)
+      expect(RequestsConfirmationMailer).to have_received(:confirmation_email).with(request)
+      expect(mailer).to have_received(:deliver_now)
+    end
+  end
+end

--- a/spec/mailers/requests_confirmation_mailer_spec.rb
+++ b/spec/mailers/requests_confirmation_mailer_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe RequestsConfirmationMailer, type: :mailer do
+  let(:request) { create(:request) }
+
+  describe "#confirmation_email" do
+    let(:mail) { RequestsConfirmationMailer.confirmation_email(request) }
+
+    it 'renders the headers' do
+      expect(mail.subject).to eq("#{request.organization.name} - Requests Confirmation")
+      expect(mail.to).to include(request.partner.email)
+      expect(mail.from).to include(request.organization.email)
+    end
+
+    it 'renders the body' do
+      expect(mail.body.encoded).to match('This is an email confirmation')
+    end
+  end
+end

--- a/spec/requests/api/v1/api_v1_family_requests_spec.rb
+++ b/spec/requests/api/v1/api_v1_family_requests_spec.rb
@@ -32,6 +32,10 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
         post api_v1_family_requests_path, params: params, headers: headers
       end
 
+      before do
+        allow(NotifyPartnerJob).to receive(:perform_now)
+      end
+
       it "returns HTTP created" do
         subject
         expect(response).to have_http_status(:created)
@@ -53,6 +57,11 @@ RSpec.describe "API::V1::FamilyRequests", type: :request do
         end
         expect(returned_body['requested_items'])
           .to eq(expected_items.sort_by { |item| item['item_id'] })
+      end
+
+      it "is expected to call the NotifyPartnerJob" do
+        subject
+        expect(NotifyPartnerJob).to have_received(:perform_now).with(Request.last.id)
       end
 
       it "returns bad request if there is an item ids mismatch" do

--- a/spec/requests/api/v1/api_v1_partner_requests_spec.rb
+++ b/spec/requests/api/v1/api_v1_partner_requests_spec.rb
@@ -24,6 +24,10 @@ RSpec.describe "API::V1::PartnerRequests", type: :request do
         post api_v1_partner_requests_path, params: params, headers: headers
       end
 
+      before do
+        allow(NotifyPartnerJob).to receive(:perform_now)
+      end
+
       it "returns HTTP created" do
         subject
         expect(response).to have_http_status(:created)
@@ -31,6 +35,11 @@ RSpec.describe "API::V1::PartnerRequests", type: :request do
 
       it "creates a new Reqeust" do
         expect { subject }.to change { Request.count }.by(1)
+      end
+
+      it "is expected to call the NotifyPartnerJob" do
+        subject
+        expect(NotifyPartnerJob).to have_received(:perform_now).with(Request.last.id)
       end
     end
 


### PR DESCRIPTION
Resolves #1952

### Description
Adds a confirmation email to be sent to the partner on each successful request that they make.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Adds tests for `NotifyPartnerJob`, `RequestsConfirmationMailer` and expectations in `PartnerRequestsController` and `FamilyRequestsController`

### Screenshots
![Captura de tela de 2020-10-06 09-03-58](https://user-images.githubusercontent.com/42655535/95199236-e572a100-07b2-11eb-8223-061d2da12336.png)
