### PR TITLE
Prevent raising NotFound error if bad item_id is specified

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -49,7 +49,13 @@ class RequestsController < ApplicationController
     request_items = []
 
     requests.pluck(:request_items).each do |items|
-      items.map { |json| request_items << [Item.find(json['item_id']).name, json['quantity']] }
+      items.map do |json|
+        item = Item.find_by(id: json['item_id'])
+        request_items << [
+          item&.name || '*Unknown Item*',
+          json['quantity']
+        ]
+      end
     end
 
     request_items.inject({}) do |item, (quantity, total)|


### PR DESCRIPTION
### Description

We were notified that the request page for a Diaperbank was not working. Upon closer inspection, this is because some `item_id` specified in `Request` match no `Item`. And as a result of using `.find` it would trigger an active record `NotFound` error that made it appear like a 404 error.

For now, we'll consider any Item that has no matching item to be *Unknown Item* in the product totals. **Note we still need to fix loading specified requests for example: http://diaper.test/austin/requests/1781**


### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested locally

### Screenshots
<img width="805" alt="Screen Shot 2020-10-06 at 7 02 13 PM" src="https://user-images.githubusercontent.com/11335191/95273098-bc303000-0807-11eb-82ef-6df44d9058f5.png">

