### PR TITLE
Line items alignment

### DIFF
--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -12,7 +12,7 @@ module UiHelper
                             data: {
                               association_insertion_node: node,
                               association_insertion_method: "append"
-                            }, id: "__add_line_item", class: "btn btn-#{size} btn-#{type}", style: "margin-top: 1rem;", partial: partial do
+                            }, id: "__add_line_item", class: "btn btn-#{size} btn-#{type}", partial: partial do
       fa_icon "plus", text: text
     end
   end
@@ -22,7 +22,7 @@ module UiHelper
     size = options[:text] || "sm"
     type = options[:type] || "danger"
 
-    link_to_remove_association form, class: "btn btn-#{size} btn-#{type}" do
+    link_to_remove_association form, class: "btn btn-#{size} btn-#{type}", style: "width: 100px;" do
       fa_icon "trash", text: text
     end
   end

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -66,20 +66,20 @@
 
                   <%= f.input :comment, label: "Comment" %>
 
-                  <fieldset style="margin-bottom: 2rem;" class="form-inline">
+                  <fieldset class="form-inline justify-content-around">
                     <legend>Items in this distribution</legend>
                     <%= f.simple_fields_for :line_items do |item| %>
                       <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
                         <%= render 'line_items/line_item_fields', f: item %>
                       </div>
                     <% end %>
-                    <div class="row links">
-                      <div class="col-xs-12">
-                        <%= add_line_item_button f, "#distribution_line_items" %>
-                      </div>
-                    </div>
 
                   </fieldset>
+                  <div class="row links align-items-center mb-3 mr-3">
+                    <div class="col-xs-12 ml-auto">
+                      <%= add_line_item_button f, "#distribution_line_items" %>
+                    </div>
+                  </div>
                   </div>
                   <div class="card-footer">
                     <%= submit_button %>

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -75,8 +75,8 @@
                     <% end %>
 
                   </fieldset>
-                  <div class="row links align-items-center mb-3 mr-3">
-                    <div class="col-xs-12 ml-auto">
+                  <div class="row links justify-content-center mb-3">
+                    <div class="col-xs-12">
                       <%= add_line_item_button f, "#distribution_line_items" %>
                     </div>
                   </div>

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -9,10 +9,10 @@
     <span class="col">
       <label>OR</label>
     </span>
-    <span class="col">
+    <span class="col li-name">
       <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
     </span>
-    <div class="col">
+    <div class="col li-quantity">
       <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity", style: "width: 100px;" } %>
     </div>
     <div class="col">

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -13,7 +13,7 @@
       <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
     </span>
     <div class="col">
-      <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity", style: "width: 95px;" } %>
+      <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity", style: "width: 100px;" } %>
     </div>
     <div class="col">
       <%= delete_line_item_button f %>

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,5 +1,5 @@
 <section class="nested-fields">
-  <div class="row align-items-center mt-2">
+  <div class="row mt-2 d-flex align-items-start">
     <span class="col">
       <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
     </span>

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,19 +1,21 @@
 <section class="nested-fields">
-  <div class="row">
-    <span class='col-md-3 col-10'>
+  <div class="row align-items-center mt-2">
+    <span class="col">
       <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
+    </span>
+    <span class="col">
       <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner"> </div>
     </span>
-    <span class="col-xs-6 col-md-12 col-sm-12">
-      <label class="pull-left">OR</label>
+    <span class="col">
+      <label>OR</label>
     </span>
-    <span class="col-md-4 col-10 li-name">
+    <span class="col">
       <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
     </span>
-    <div class='col-md-4 col-12 li-quantity'>
-      <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity" } %>
+    <div class="col">
+      <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity", style: "width: 95px;" } %>
     </div>
-    <div class='col-md-2 col-12'>
+    <div class="col">
       <%= delete_line_item_button f %>
     </div>
   </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,6 +55,8 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  config.assets.check_precompiled_asset = false
+
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,8 +55,6 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  config.assets.check_precompiled_asset = false
-
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #1979  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

The way that line items were rendering before was incorrect. There seemed to be multiple `col` classes per field in line items which is not standard for bootstrap. I also made a slight change to the distributions/edit page by adding the bootstrap class `justify-content-around`, see screenshots attached

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->

Before:
![Screen Shot 2020-10-20 at 9 53 00 AM](https://user-images.githubusercontent.com/48076414/96607401-542d1f80-12c6-11eb-8fdd-23f478f38d74.png)

After:
![image](https://user-images.githubusercontent.com/48076414/96607466-63ac6880-12c6-11eb-84bc-7ce97a66fb93.png)

### Notes

I noticed something else I don't think there's an issue for yet:
- When you click the "Add another item" button on the distributions/edit page, the new items are added towards the top and mess up the formatting of the page. This was not introduced with this branch and is addressed in #1985 
