### PR TITLE
Refactor line items forms

### DIFF
--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -12,7 +12,7 @@ module UiHelper
                             data: {
                               association_insertion_node: node,
                               association_insertion_method: "append"
-                            }, id: "__add_line_item", class: "btn btn-#{size} btn-#{type}", partial: partial do
+                            }, render_options: { locals: options[:partial_locals] } , id: "__add_line_item", class: "btn btn-#{size} btn-#{type}", partial: partial do
       fa_icon "plus", text: text
     end
   end

--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -12,7 +12,7 @@ module UiHelper
                             data: {
                               association_insertion_node: node,
                               association_insertion_method: "append"
-                            }, render_options: { locals: options[:partial_locals] } , id: "__add_line_item", class: "btn btn-#{size} btn-#{type}", partial: partial do
+                            }, render_options: { locals: options[:partial_locals] }, id: "__add_line_item", class: "btn btn-#{size} btn-#{type}", partial: partial do
       fa_icon "plus", text: text
     end
   end

--- a/app/helpers/ui_helper.rb
+++ b/app/helpers/ui_helper.rb
@@ -12,7 +12,7 @@ module UiHelper
                             data: {
                               association_insertion_node: node,
                               association_insertion_method: "append"
-                            }, id: "__add_line_item", class: "btn btn-#{size} btn-#{type}", style: "margin-top: 1rem;", partial: partial do
+                            }, id: "__add_line_item", class: "btn btn-#{size} btn-#{type}", partial: partial do
       fa_icon "plus", text: text
     end
   end
@@ -22,7 +22,7 @@ module UiHelper
     size = options[:text] || "sm"
     type = options[:type] || "danger"
 
-    link_to_remove_association form, class: "btn btn-#{size} btn-#{type}" do
+    link_to_remove_association form, class: "btn btn-#{size} btn-#{type}", style: "width: 100px;" do
       fa_icon "trash", text: text
     end
   end

--- a/app/views/adjustments/new.html.erb
+++ b/app/views/adjustments/new.html.erb
@@ -49,20 +49,18 @@
 
                     <%= f.input :comment %>
 
-                    <fieldset style="margin-bottom: 2rem;" class="form-inline">
+                    <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="adjustment_line_items_container">
                       <legend>Items in this adjustment</legend>
                       <%= f.simple_fields_for :line_items do |item| %>
-                        <div id="adjustment_line_items" class="line-item-fields" data-capture-barcode="true">
-                          <%= render 'line_items/line_item_fields', f: item %>
-                        </div>
+                        <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "adjustment_line_items" } %>
                       <% end %>
-                      <div class="row links">
-                        <div class="col-xs-12">
-                          <%= add_line_item_button f, "#adjustment_line_items" %>
-                        </div>
-                      </div>
-
                     </fieldset>
+
+                    <div class="row links align-items-center mb-3 mr-3">
+                      <div class="col-xs-12 ml-auto">
+                        <%= add_line_item_button f, "#adjustment_line_items_container", { partial_locals: { div_id: "adjustment_line_items" }} %>
+                      </div>
+                    </div>
 
                     </div>
                     <div class="card-footer">

--- a/app/views/adjustments/new.html.erb
+++ b/app/views/adjustments/new.html.erb
@@ -49,18 +49,7 @@
 
                     <%= f.input :comment %>
 
-                    <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="adjustment_line_items_container">
-                      <legend>Items in this adjustment</legend>
-                      <%= f.simple_fields_for :line_items do |item| %>
-                        <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "adjustment_line_items" } %>
-                      <% end %>
-                    </fieldset>
-
-                    <div class="row links align-items-center mb-3 mr-3">
-                      <div class="col-xs-12 ml-auto">
-                        <%= add_line_item_button f, "#adjustment_line_items_container", { partial_locals: { div_id: "adjustment_line_items" }} %>
-                      </div>
-                    </div>
+                    <%= render partial: 'line_items/line_items_form', locals: { f: f, form_id: "adjustment" } %>
 
                     </div>
                     <div class="card-footer">

--- a/app/views/audits/_form.html.erb
+++ b/app/views/audits/_form.html.erb
@@ -16,18 +16,7 @@
                 <%= simple_form_for @audit, html: {class: "storage-location-required"} do |f| %>
                   <%= render partial: "storage_locations/source", object: f, locals: {include_inactive_items: true} %>
 
-                  <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="audit_line_items_container">
-                    <legend>Items in this audit</legend>
-                    <%= f.simple_fields_for :line_items do |item| %>
-                      <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "audit_line_items" } %>
-                    <% end %>
-                  </fieldset>
-
-                  <div class="row links align-items-center mb-3 mr-3">
-                    <div class="col-xs-12 ml-auto">
-                      <%= add_line_item_button f, "#audit_line_items_container", { partial_locals: { div_id: "audit_line_items" }} %>
-                    </div>
-                  </div>
+                  <%= render partial: 'line_items/line_items_form', locals: { f: f, form_id: "audit" } %>
 
                   </div>
                   <div class="card-footer">

--- a/app/views/audits/_form.html.erb
+++ b/app/views/audits/_form.html.erb
@@ -15,20 +15,19 @@
               <div class="box-body">
                 <%= simple_form_for @audit, html: {class: "storage-location-required"} do |f| %>
                   <%= render partial: "storage_locations/source", object: f, locals: {include_inactive_items: true} %>
-                  <fieldset style="margin-bottom: 2rem;" class="form-inline">
+
+                  <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="audit_line_items_container">
                     <legend>Items in this audit</legend>
                     <%= f.simple_fields_for :line_items do |item| %>
-                      <div id="audit_line_items" class="line-item-fields" data-capture-barcode="true">
-                        <%= render 'line_items/line_item_fields', f: item %>
-                      </div>
+                      <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "audit_line_items" } %>
                     <% end %>
-                    <div class="row links">
-                      <div class="col-xs-12 p-3">
-                        <%= add_line_item_button f, "#audit_line_items" %>
-                      </div>
-                    </div>
-
                   </fieldset>
+
+                  <div class="row links align-items-center mb-3 mr-3">
+                    <div class="col-xs-12 ml-auto">
+                      <%= add_line_item_button f, "#audit_line_items_container", { partial_locals: { div_id: "audit_line_items" }} %>
+                    </div>
+                  </div>
 
                   </div>
                   <div class="card-footer">

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -66,20 +66,19 @@
 
                   <%= f.input :comment, label: "Comment" %>
 
-                  <fieldset class="form-inline justify-content-around">
+                  <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="distribution_line_items_container">
                     <legend>Items in this distribution</legend>
                     <%= f.simple_fields_for :line_items do |item| %>
-                      <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
-                        <%= render 'line_items/line_item_fields', f: item %>
-                      </div>
+                      <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "distribution_line_items" } %>
                     <% end %>
-
                   </fieldset>
+
                   <div class="row links align-items-center mb-3 mr-3">
                     <div class="col-xs-12 ml-auto">
-                      <%= add_line_item_button f, "#distribution_line_items" %>
+                      <%= add_line_item_button f, "#distribution_line_items_container", { partial_locals: { div_id: "distribution_line_items" }} %>
                     </div>
                   </div>
+
                   </div>
                   <div class="card-footer">
                     <%= submit_button %>

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -66,18 +66,7 @@
 
                   <%= f.input :comment, label: "Comment" %>
 
-                  <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="distribution_line_items_container">
-                    <legend>Items in this distribution</legend>
-                    <%= f.simple_fields_for :line_items do |item| %>
-                      <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "distribution_line_items" } %>
-                    <% end %>
-                  </fieldset>
-
-                  <div class="row links align-items-center mb-3 mr-3">
-                    <div class="col-xs-12 ml-auto">
-                      <%= add_line_item_button f, "#distribution_line_items_container", { partial_locals: { div_id: "distribution_line_items" }} %>
-                    </div>
-                  </div>
+                  <%= render partial: 'line_items/line_items_form', locals: { f: f, form_id: "distribution" } %>
 
                   </div>
                   <div class="card-footer">

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -66,20 +66,20 @@
 
                   <%= f.input :comment, label: "Comment" %>
 
-                  <fieldset style="margin-bottom: 2rem;" class="form-inline">
+                  <fieldset class="form-inline justify-content-around">
                     <legend>Items in this distribution</legend>
                     <%= f.simple_fields_for :line_items do |item| %>
                       <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
                         <%= render 'line_items/line_item_fields', f: item %>
                       </div>
                     <% end %>
-                    <div class="row links">
-                      <div class="col-xs-12">
-                        <%= add_line_item_button f, "#distribution_line_items" %>
-                      </div>
-                    </div>
 
                   </fieldset>
+                  <div class="row links align-items-center mb-3 mr-3">
+                    <div class="col-xs-12 ml-auto">
+                      <%= add_line_item_button f, "#distribution_line_items" %>
+                    </div>
+                  </div>
                   </div>
                   <div class="card-footer">
                     <%= submit_button %>

--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -57,18 +57,7 @@
 
                   <%= f.input :comment, label: "Comment" %>
 
-                  <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="distribution_line_items_container">
-                    <legend>Items in this distribution</legend>
-                    <%= f.simple_fields_for :line_items do |item| %>
-                      <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "distribution_line_items" } %>
-                    <% end %>
-                  </fieldset>
-
-                  <div class="row links align-items-center mb-3 mr-3">
-                    <div class="col-xs-12 ml-auto">
-                      <%= add_line_item_button f, "#distribution_line_items_container", { partial_locals: { div_id: "distribution_line_items" }} %>
-                    </div>
-                  </div>
+                  <%= render partial: 'line_items/line_items_form', locals: { f: f, form_id: "distribution" } %>
 
                   </div>
                   <div class="card-footer">

--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -57,20 +57,19 @@
 
                   <%= f.input :comment, label: "Comment" %>
 
-                  <fieldset style="margin-bottom: 2rem;" class="form-inline">
+                  <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="distribution_line_items_container">
                     <legend>Items in this distribution</legend>
                     <%= f.simple_fields_for :line_items do |item| %>
-                      <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
-                        <%= render 'line_items/line_item_fields', f: item %>
-                      </div>
+                      <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "distribution_line_items" } %>
                     <% end %>
-                    <div class="row links">
-                      <div class="col-xs-12 p-3">
-                        <%= add_line_item_button f, "#distribution_line_items" %>
-                      </div>
-                    </div>
-
                   </fieldset>
+
+                  <div class="row links align-items-center mb-3 mr-3">
+                    <div class="col-xs-12 ml-auto">
+                      <%= add_line_item_button f, "#distribution_line_items_container", { partial_locals: { div_id: "distribution_line_items" }} %>
+                    </div>
+                  </div>
+
                   </div>
                   <div class="card-footer">
                     <%= submit_button %>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -89,21 +89,18 @@
       </div>
     </div>
 
-    <fieldset style="margin-bottom: 2rem;" class="form-inline">
+    <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="donation_line_items_container">
       <legend>Items in this donation</legend>
-      <div id="donation_line_items" data-capture-barcode="true">
-
-        <%= f.simple_fields_for :line_items do |item| %>
-          <%= render 'line_items/line_item_fields', f: item %>
-        <% end %>
-      </div>
-
-      <div class="row links">
-        <div class="col-xs-12 p-3">
-          <%= add_line_item_button f, "#donation_line_items", {} %>
-        </div>
-      </div>
+      <%= f.simple_fields_for :line_items do |item| %>
+        <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "donation_line_items" } %>
+      <% end %>
     </fieldset>
+
+    <div class="row links align-items-center mb-3 mr-3">
+      <div class="col-xs-12 ml-auto">
+        <%= add_line_item_button f, "#donation_line_items_container", { partial_locals: { div_id: "donation_line_items" }} %>
+      </div>
+    </div>
 
     <div class="card-footer">
       <%= submit_button %>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -89,18 +89,7 @@
       </div>
     </div>
 
-    <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="donation_line_items_container">
-      <legend>Items in this donation</legend>
-      <%= f.simple_fields_for :line_items do |item| %>
-        <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "donation_line_items" } %>
-      <% end %>
-    </fieldset>
-
-    <div class="row links align-items-center mb-3 mr-3">
-      <div class="col-xs-12 ml-auto">
-        <%= add_line_item_button f, "#donation_line_items_container", { partial_locals: { div_id: "donation_line_items" }} %>
-      </div>
-    </div>
+    <%= render partial: 'line_items/line_items_form', locals: { f: f, form_id: "donation" } %>
 
     <div class="card-footer">
       <%= submit_button %>

--- a/app/views/kits/_form.html.erb
+++ b/app/views/kits/_form.html.erb
@@ -19,18 +19,7 @@
                 <%= f.input_field :value_in_dollars, class: "form-control", min: 0 %>
               <% end %>
 
-              <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="kit_line_items_container">
-                <legend>Items in this Kit</legend>
-                <%= f.simple_fields_for :line_items do |item| %>
-                  <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "kit_line_items" } %>
-                <% end %>
-              </fieldset>
-
-              <div class="row links align-items-center mb-3 mr-3">
-                <div class="col-xs-12 ml-auto">
-                  <%= add_line_item_button f, "#kit_line_items_container", { partial_locals: { div_id: "kit_line_items" }} %>
-                </div>
-              </div>
+              <%= render partial: 'line_items/line_items_form', locals: { f: f, form_id: "kit" } %>
 
             </div>
             <div class="card-footer">

--- a/app/views/kits/_form.html.erb
+++ b/app/views/kits/_form.html.erb
@@ -19,19 +19,18 @@
                 <%= f.input_field :value_in_dollars, class: "form-control", min: 0 %>
               <% end %>
 
-              <fieldset style="margin-bottom: 2rem;" class="form-inline">
+              <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="kit_line_items_container">
                 <legend>Items in this Kit</legend>
                 <%= f.simple_fields_for :line_items do |item| %>
-                  <div id="kit_line_items" class="line-item-fields" data-capture-barcode="true">
-                    <%= render 'line_items/line_item_fields', f: item %>
-                  </div>
+                  <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "kit_line_items" } %>
                 <% end %>
-                <div class="row links">
-                  <div class="col-xs-12">
-                    <%= add_line_item_button f, "#kit_line_items" %>
-                  </div>
-                </div>
               </fieldset>
+
+              <div class="row links align-items-center mb-3 mr-3">
+                <div class="col-xs-12 ml-auto">
+                  <%= add_line_item_button f, "#kit_line_items_container", { partial_locals: { div_id: "kit_line_items" }} %>
+                </div>
+              </div>
 
             </div>
             <div class="card-footer">

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,23 +1,30 @@
-<section class="nested-fields">
-  <div class="row align-items-center mt-2">
-    <span class="col">
-      <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
-    </span>
-    <span class="col">
-      <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner"> </div>
-    </span>
-    <span class="col">
-      <label>OR</label>
-    </span>
-    <span class="col li-name">
-      <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
-    </span>
-    <div class="col li-quantity">
-      <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity", style: "width: 100px;" } %>
+<%
+  div_id ||= "default_line_items"
+  data_capture_barcode ||= "true"
+  div_class ||= "line-items-fields"
+%>
+<div id="<%= div_id %>" data-capture-barcode="<%= data_capture_barcode %>" class="<%= div_class %>">
+  <section class="nested-fields">
+    <div class="row align-items-center mt-2">
+      <span class="col">
+        <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
+      </span>
+      <span class="col">
+        <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner"> </div>
+      </span>
+      <span class="col">
+        <label>OR</label>
+      </span>
+      <span class="col li-name">
+        <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
+      </span>
+      <div class="col li-quantity">
+        <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity", style: "width: 100px;" } %>
+      </div>
+      <div class="col">
+        <%= delete_line_item_button f %>
+      </div>
     </div>
-    <div class="col">
-      <%= delete_line_item_button f %>
-    </div>
-  </div>
-  <hr class="line-item-separator">
-</section>
+    <hr class="line-item-separator">
+  </section>
+</div>

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -9,10 +9,10 @@
     <span class="col">
       <label>OR</label>
     </span>
-    <span class="col">
+    <span class="col li-name">
       <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
     </span>
-    <div class="col">
+    <div class="col li-quantity">
       <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity", style: "width: 100px;" } %>
     </div>
     <div class="col">

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -13,7 +13,7 @@
       <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
     </span>
     <div class="col">
-      <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity", style: "width: 95px;" } %>
+      <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity", style: "width: 100px;" } %>
     </div>
     <div class="col">
       <%= delete_line_item_button f %>

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -5,7 +5,7 @@
 %>
 <div id="<%= div_id %>" data-capture-barcode="<%= data_capture_barcode %>" class="<%= div_class %>">
   <section class="nested-fields">
-    <div class="row align-items-center mt-2">
+    <div class="row align-items-start mt-2">
       <span class="col">
         <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
       </span>

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,19 +1,21 @@
 <section class="nested-fields">
-  <div class="row">
-    <span class='col-md-3 col-10'>
+  <div class="row align-items-center mt-2">
+    <span class="col">
       <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
+    </span>
+    <span class="col">
       <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner"> </div>
     </span>
-    <span class="col-xs-6 col-md-12 col-sm-12">
-      <label class="pull-left">OR</label>
+    <span class="col">
+      <label>OR</label>
     </span>
-    <span class="col-md-4 col-10 li-name">
+    <span class="col">
       <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
     </span>
-    <div class='col-md-4 col-12 li-quantity'>
-      <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity" } %>
+    <div class="col">
+      <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity", style: "width: 95px;" } %>
     </div>
-    <div class='col-md-2 col-12'>
+    <div class="col">
       <%= delete_line_item_button f %>
     </div>
   </div>

--- a/app/views/line_items/_line_items_form.html.erb
+++ b/app/views/line_items/_line_items_form.html.erb
@@ -8,8 +8,8 @@
   <% end %>
 </fieldset>
 
-<div class="row links align-items-center mb-3 mr-3">
-  <div class="col-xs-12 ml-auto">
+<div class="row links justify-content-center mb-3">
+  <div class="col-xs-12">
     <%= add_line_item_button f, "##{ form_id }_line_items_container", { partial_locals: { div_id: "#{ form_id }_line_items" }} %>
   </div>
 </div>

--- a/app/views/line_items/_line_items_form.html.erb
+++ b/app/views/line_items/_line_items_form.html.erb
@@ -1,0 +1,15 @@
+<%
+  form_id ||= "default"
+%>
+<fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="<%= form_id %>_line_items_container">
+  <legend>Items in this <%= form_id %></legend>
+  <%= f.simple_fields_for :line_items do |item| %>
+    <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "#{ form_id }_line_items" } %>
+  <% end %>
+</fieldset>
+
+<div class="row links align-items-center mb-3 mr-3">
+  <div class="col-xs-12 ml-auto">
+    <%= add_line_item_button f, "##{ form_id }_line_items_container", { partial_locals: { div_id: "#{ form_id }_line_items" }} %>
+  </div>
+</div>

--- a/app/views/purchases/_purchase_form.html.erb
+++ b/app/views/purchases/_purchase_form.html.erb
@@ -48,21 +48,18 @@
       </div>
     </div>
 
-    <fieldset style="margin-bottom: 2rem;" class="form-inline">
+    <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="purchase_line_items_container">
       <legend>Items in this purchase</legend>
-      <div id="purchase_line_items" data-capture-barcode="true">
-
-        <%= f.simple_fields_for :line_items do |item| %>
-          <%= render 'line_items/line_item_fields', f: item %>
-        <% end %>
-      </div>
-
-      <div class="row links">
-        <div class="col-xs-12 p-3">
-          <%= add_line_item_button f, "#purchase_line_items" %>
-        </div>
-      </div>
+      <%= f.simple_fields_for :line_items do |item| %>
+        <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "purchase_line_items" } %>
+      <% end %>
     </fieldset>
+
+    <div class="row links align-items-center mb-3 mr-3">
+      <div class="col-xs-12 ml-auto">
+        <%= add_line_item_button f, "#purchase_line_items_container", { partial_locals: { div_id: "purchase_line_items" }} %>
+      </div>
+    </div>
 
     <div class="card-footer">
       <%= submit_button %>

--- a/app/views/purchases/_purchase_form.html.erb
+++ b/app/views/purchases/_purchase_form.html.erb
@@ -48,18 +48,7 @@
       </div>
     </div>
 
-    <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="purchase_line_items_container">
-      <legend>Items in this purchase</legend>
-      <%= f.simple_fields_for :line_items do |item| %>
-        <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "purchase_line_items" } %>
-      <% end %>
-    </fieldset>
-
-    <div class="row links align-items-center mb-3 mr-3">
-      <div class="col-xs-12 ml-auto">
-        <%= add_line_item_button f, "#purchase_line_items_container", { partial_locals: { div_id: "purchase_line_items" }} %>
-      </div>
-    </div>
+    <%= render partial: 'line_items/line_items_form', locals: { f: f, form_id: "purchase" } %>
 
     <div class="card-footer">
       <%= submit_button %>

--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -50,18 +50,7 @@
 
                     <%= f.input :comment %>
 
-                    <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="transfer_line_items_container">
-                      <legend>Items in this transfer</legend>
-                      <%= f.simple_fields_for :line_items do |item| %>
-                        <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "transfer_line_items" } %>
-                      <% end %>
-                    </fieldset>
-
-                    <div class="row links align-items-center mb-3 mr-3">
-                      <div class="col-xs-12 ml-auto">
-                        <%= add_line_item_button f, "#transfer_line_items_container", { partial_locals: { div_id: "transfer_line_items" }} %>
-                      </div>
-                    </div>
+                    <%= render partial: 'line_items/line_items_form', locals: { f: f, form_id: "transfer" } %>
 
                     </div>
                     <div class="card-footer">

--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -50,20 +50,18 @@
 
                     <%= f.input :comment %>
 
-                    <fieldset style="margin-bottom: 2rem;" class="form-inline">
-                      <legend>Items in this donation</legend>
+                    <fieldset style="margin-bottom: 2rem;" class="form-inline justify-content-around" id="transfer_line_items_container">
+                      <legend>Items in this transfer</legend>
                       <%= f.simple_fields_for :line_items do |item| %>
-                        <div id="transfer_line_items" class="line-item-fields" data-capture-barcode="true">
-                          <%= render 'line_items/line_item_fields', f: item %>
-                        </div>
+                        <%= render partial: 'line_items/line_item_fields', locals: { f: item, div_id: "transfer_line_items" } %>
                       <% end %>
-                      <div class="row links">
-                        <div class="col-xs-12">
-                          <%= add_line_item_button f, "#transfer_line_items" %>
-                        </div>
-                      </div>
-
                     </fieldset>
+
+                    <div class="row links align-items-center mb-3 mr-3">
+                      <div class="col-xs-12 ml-auto">
+                        <%= add_line_item_button f, "#transfer_line_items_container", { partial_locals: { div_id: "transfer_line_items" }} %>
+                      </div>
+                    </div>
 
                     </div>
                     <div class="card-footer">

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,6 +55,8 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
+  config.assets.check_precompiled_asset = false
+
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,8 +55,6 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = true
 
-  config.assets.check_precompiled_asset = false
-
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 

--- a/spec/system/donation_system_spec.rb
+++ b/spec/system/donation_system_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe "Donations", type: :system, js: true do
           select Item.alphabetized.first.name, from: "donation_line_items_attributes_0_item_id"
           fill_in "donation_line_items_attributes_0_quantity", with: "5"
           page.find(:css, "#__add_line_item").click
-          select_id = page.find(:xpath, '//*[@id="donation_line_items"]/section[2]//select')[:id]
+          select_id = page.find(:xpath, '//*[@id="donation_line_items_container"]/div[2]/section/div/span[4]/div/select')[:id]
           select Item.alphabetized.first.name, from: select_id
           text_id = page.find_all('.donation_line_items_quantity > input').last[:id]
           fill_in text_id, with: "10"
@@ -404,15 +404,15 @@ RSpec.describe "Donations", type: :system, js: true do
         end
 
         it "Updates the line item when the same barcode is scanned twice", :js do
-          within "#donation_line_items" do
-            expect(page).to have_xpath("//input[@id='_barcode-lookup-0']")
+          within "#donation_line_items_container" do
+            expect(page).to have_xpath("//div[1]//input[@id='_barcode-lookup-0']")
             Barcode.boop(@existing_barcode.value)
           end
 
           expect(page).to have_field "donation_line_items_attributes_0_quantity", with: @existing_barcode.quantity.to_s
 
-          within "#donation_line_items" do
-            expect(page).to have_xpath("//input[@id='_barcode-lookup-1']")
+          within "#donation_line_items_container" do
+            expect(page).to have_xpath("//div[2]//input[@id='_barcode-lookup-1']")
             Barcode.boop(@existing_barcode.value)
           end
 
@@ -438,8 +438,8 @@ RSpec.describe "Donations", type: :system, js: true do
             click_on "Save"
           end
 
-          within "#donation_line_items" do
-            barcode_field = page.find(:xpath, "//input[@id='_barcode-lookup-0']").value
+          within "#donation_line_items_container" do
+            barcode_field = page.find(:xpath, "//div[1]//input[@id='_barcode-lookup-0']").value
             expect(barcode_field).to eq(new_barcode)
             qty_field = page.find(:xpath, "//input[@id='donation_line_items_attributes_0_quantity']").value
             expect(qty_field).to eq("10")

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe "Purchases", type: :system, js: true do
 
           expect(page).to have_field "purchase_line_items_attributes_0_quantity", with: @existing_barcode.quantity.to_s
 
-          within "#purchase_line_items" do
+          within "#purchase_line_items_container" do
             expect(page).to have_css('.__barcode_item_lookup', count: 2)
             Barcode.boop(@existing_barcode.value, "new_line_items")
           end


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves < no issue made for this >

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

_**NOTE:** This branched is based off of #1983_

I noticed when working on #1983 that when you pushed the "add another item" button it would place the new line item in a really weird spot (screenshot 1). This was because of code like this: 
```
<fieldset class="form-inline justify-content-around">
  <%= f.simple_fields_for :line_items do |item| %>
   <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
      <%= render 'line_items/line_item_fields', f: item %>
    </div>
  <% end %>
</fieldset>
<div class="row links align-items-center mb-3 mr-3">
  <div class="col-xs-12 ml-auto">
    <%= add_line_item_button f, "#distribution_line_items" %>
  </div>
</div>
```
The `add_line_item_button` function was being told to add the new line item into the first occurrence of `#distribution_line_items`, but each line item in the loop gets that same id so it wasn't appending the new item to the end as expected, it was adding it to the first every single time. I added an id onto the fieldset that wraps this code so that we can pass the appropriate id to the `add_line_item_button` function.

I also moved the div on line 3 of the above code into the _line_item_fields partial so that we have less repeated code _and_ so that the new line items added also have that div wrapping them.

Because this same pattern is repeated so many times across the app I put all of the code to achieve these fixes in the new _line_items_form partial to reduce repeated code.

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
screenshot 1
![image](https://user-images.githubusercontent.com/48076414/96767512-a21b5380-13aa-11eb-9c01-b08b3be21f00.png)
Now new line items are appended to the bottom
![image](https://user-images.githubusercontent.com/48076414/96768539-f2df7c00-13ab-11eb-9eb5-0a981ea9ce89.png)
