### PR TITLE
Remove extraneous reference to landing_page.css in manifest.js

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,4 @@
 //= link filterrific/filterrific-spinner.gif
 //= link_tree ../images
-//= link landing_page.css
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css


### PR DESCRIPTION
### Description

It looks like we were including a `landing_page.css` reference in manifest.js without it being neccessary. I believe this was causing the issue experienced by developers to booting up the application. I saw this error:
![Screen Shot 2020-10-31 at 10 27 00 AM](https://user-images.githubusercontent.com/11335191/97784065-dd1b4500-1b69-11eb-936b-ba013e4fe6c7.png)

Removing this line in `manifest.js` seems to address the issue.

### Type of change
* Bug fix (non-breaking change which fixes an issue)
