### PR TITLE
Adjust styling of line items conform to existing format /w modification

### DIFF
--- a/app/views/adjustments/new.html.erb
+++ b/app/views/adjustments/new.html.erb
@@ -49,17 +49,15 @@
 
                     <%= f.input :comment %>
 
-                    <fieldset style="margin-bottom: 2rem;">
+                    <fieldset style="margin-bottom: 2rem;" class='w-50'>
                       <legend>Items in this adjustment</legend>
                       <%= f.simple_fields_for :line_items do |item| %>
                         <div id="adjustment_line_items" class="line-item-fields" data-capture-barcode="true">
                           <%= render 'line_items/line_item_fields', f: item %>
                         </div>
                       <% end %>
-                      <div class="row links">
-                        <div class="col-xs-12">
-                          <%= add_line_item_button f, "#adjustment_line_items" %>
-                        </div>
+                      <div class="row links justify-content-end">
+                        <%= add_line_item_button f, "#adjustment_line_items" %>
                       </div>
 
                     </fieldset>

--- a/app/views/distributions/edit.html.erb
+++ b/app/views/distributions/edit.html.erb
@@ -66,21 +66,17 @@
 
                   <%= f.input :comment, label: "Comment" %>
 
-                  <fieldset class="form-inline justify-content-around">
+                  <fieldset class='w-50'>
                     <legend>Items in this distribution</legend>
                     <%= f.simple_fields_for :line_items do |item| %>
                       <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
                         <%= render 'line_items/line_item_fields', f: item %>
                       </div>
                     <% end %>
-
-                  </fieldset>
-                  <div class="row links justify-content-center mb-3">
-                    <div class="col-xs-12">
+                    <div class="row links justify-content-end">
                       <%= add_line_item_button f, "#distribution_line_items" %>
                     </div>
-                  </div>
-                  </div>
+                  </fieldset>
                   <div class="card-footer">
                     <%= submit_button %>
                   </div>

--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -57,17 +57,15 @@
 
                   <%= f.input :comment, label: "Comment" %>
 
-                  <fieldset style="margin-bottom: 2rem;">
+                  <fieldset style="margin-bottom: 2rem">
                     <legend>Items in this distribution</legend>
                     <%= f.simple_fields_for :line_items do |item| %>
                       <div id="distribution_line_items" data-capture-barcode="true" class="line-item-fields">
                         <%= render 'line_items/line_item_fields', f: item %>
                       </div>
                     <% end %>
-                    <div class="row links">
-                      <div class="col-xs-12 p-3">
-                        <%= add_line_item_button f, "#distribution_line_items" %>
-                      </div>
+                    <div class="row links justify-content-end">
+                      <%= add_line_item_button f, "#distribution_line_items" %>
                     </div>
 
                   </fieldset>

--- a/app/views/donations/_donation_form.html.erb
+++ b/app/views/donations/_donation_form.html.erb
@@ -89,7 +89,7 @@
       </div>
     </div>
 
-    <fieldset style="margin-bottom: 2rem;">
+    <fieldset style="margin-bottom: 2rem;" class='w-50'>
       <legend>Items in this donation</legend>
       <div id="donation_line_items" data-capture-barcode="true">
 
@@ -98,10 +98,8 @@
         <% end %>
       </div>
 
-      <div class="row links">
-        <div class="col-xs-12 p-3">
-          <%= add_line_item_button f, "#donation_line_items", {} %>
-        </div>
+      <div class="row links justify-content-end">
+        <%= add_line_item_button f, "#donation_line_items", {} %>
       </div>
     </fieldset>
 

--- a/app/views/kits/_form.html.erb
+++ b/app/views/kits/_form.html.erb
@@ -19,14 +19,14 @@
                 <%= f.input_field :value_in_dollars, class: "form-control", min: 0 %>
               <% end %>
 
-              <fieldset style="margin-bottom: 2rem;">
+              <fieldset style="margin-bottom: 2rem;" class='w-50'>
                 <legend>Items in this Kit</legend>
                 <%= f.simple_fields_for :line_items do |item| %>
                   <div id="kit_line_items" class="line-item-fields" data-capture-barcode="true">
                     <%= render 'line_items/line_item_fields', f: item %>
                   </div>
                 <% end %>
-                <div class="row links">
+                <div class="row links col-xs-12 justify-content-end">
                   <div class="col-xs-12">
                     <%= add_line_item_button f, "#kit_line_items" %>
                   </div>

--- a/app/views/line_items/_line_item_fields.html.erb
+++ b/app/views/line_items/_line_item_fields.html.erb
@@ -1,23 +1,22 @@
 <section class="nested-fields">
-  <div class="row mt-2 d-flex align-items-start">
-    <span class="col">
-      <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
-    </span>
-    <span class="col">
-      <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner"> </div>
-    </span>
-    <span class="col">
-      <label>OR</label>
-    </span>
-    <span class="col li-name">
-      <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false %>
-    </span>
-    <div class="col li-quantity">
-      <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity", style: "width: 100px;" } %>
+  <div class="row mt-2 d-flex flex-row align-items-center justify-content-between">
+    <div class='d-flex flex-column justify-content-center'>
+      <div class='d-flex flex-row align-items-center'>
+        <%= render partial: "barcode_items/barcode_item_lookup", locals: {index: f.options[:child_index]} %>
+        <div id="barcode-scanner-btn" class="fa fa-barcode barcode-scanner mx-2"> </div>
+      </div>
+      <label class='my-1 mx-auto font-weight-normal'>OR</label>
+      <div class='d-flex flex-row'>
+        <span class="li-name">
+          <%= f.input :item_id, collection: @items, prompt: "Choose an item", include_blank: "", label: false, input_html: { class: "my-0" } %>
+        </span>
+        <div class="li-quantity mx-2">
+          <%= f.input :quantity, placeholder: "Quantity", label: false, input_html: { class: "quantity my-0"} %>
+        </div>
+      </div>
     </div>
-    <div class="col">
-      <%= delete_line_item_button f %>
-    </div>
+
+    <%= delete_line_item_button f %>
   </div>
   <hr class="line-item-separator">
 </section>

--- a/app/views/purchases/_purchase_form.html.erb
+++ b/app/views/purchases/_purchase_form.html.erb
@@ -48,7 +48,7 @@
       </div>
     </div>
 
-    <fieldset style="margin-bottom: 2rem;">
+    <fieldset style="margin-bottom: 2rem;" class='w-50'>
       <legend>Items in this purchase</legend>
       <div id="purchase_line_items" data-capture-barcode="true">
 
@@ -57,10 +57,8 @@
         <% end %>
       </div>
 
-      <div class="row links">
-        <div class="col-xs-12 p-3">
-          <%= add_line_item_button f, "#purchase_line_items" %>
-        </div>
+      <div class="row links justify-content-end">
+        <%= add_line_item_button f, "#purchase_line_items" %>
       </div>
     </fieldset>
 

--- a/app/views/transfers/new.html.erb
+++ b/app/views/transfers/new.html.erb
@@ -50,14 +50,14 @@
 
                     <%= f.input :comment %>
 
-                    <fieldset style="margin-bottom: 2rem;">
+                    <fieldset style="margin-bottom: 2rem;" class='w-50'>
                       <legend>Items in this donation</legend>
                       <%= f.simple_fields_for :line_items do |item| %>
                         <div id="transfer_line_items" class="line-item-fields" data-capture-barcode="true">
                           <%= render 'line_items/line_item_fields', f: item %>
                         </div>
                       <% end %>
-                      <div class="row links">
+                      <div class="row links justify-content-end">
                         <div class="col-xs-12">
                           <%= add_line_item_button f, "#transfer_line_items" %>
                         </div>


### PR DESCRIPTION

### Description

While testing, I noticed that the line items were being stretched to the full width of the page. This causes the 'OR' to take more space and make it a bit more difficult to read. This PR adjusts the styling so that the user doesn't need to scroll their eyeballs horizontally to read the line item content.

**Notably -- I am trying to keep the style to what the users are already use. I do think the line item form could use adjustments**

This is the before:
![Screen Shot 2020-11-07 at 11 12 45 AM](https://user-images.githubusercontent.com/11335191/98446322-c7b69580-20ea-11eb-9389-3052d95afff8.png)

And the after:
![Screen Shot 2020-11-07 at 11 13 18 AM](https://user-images.githubusercontent.com/11335191/98446323-cc7b4980-20ea-11eb-813d-c89530d04c31.png)

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
I manually tested through each page that has a line item form being used.

### Screenshots
See above in the description
