### PR TITLE
[1923] | Adds distribution details to distribution export

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -55,7 +55,7 @@ class DistributionsController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.csv { send_data Distribution.generate_csv(@distributions), filename: "Distributions-#{Time.zone.today}.csv" }
+      format.csv { send_data Distribution.generate_csv(@distributions, @items.collect(&:name).sort), filename: "Distributions-#{Time.zone.today}.csv" }
     end
   end
 

--- a/app/models/concerns/exportable.rb
+++ b/app/models/concerns/exportable.rb
@@ -10,9 +10,9 @@ module Exportable
       [csv_export_headers] + data.map(&:csv_export_attributes)
     end
 
-    def generate_csv(data)
+    def generate_csv(data, additional_headers = [])
       CSV.generate(headers: true) do |csv|
-        ([csv_export_headers] + data.map(&:csv_export_attributes)).each do |row|
+        ([csv_export_headers + additional_headers] + data.map(&:csv_export_attributes)).each do |row|
           csv << row
         end
       end

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -67,6 +67,10 @@ module Itemizable
       def total
         sum(:quantity)
       end
+
+      def total_value
+        sum(&:value_per_line_item)
+      end
     end
     has_many :items, through: :line_items
     accepts_nested_attributes_for :line_items,

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -31,6 +31,7 @@ class Distribution < ApplicationRecord
   include Exportable
   include IssuedAt
   include Filterable
+  include ItemsHelper
 
   has_one :request, dependent: :nullify
   accepts_nested_attributes_for :request
@@ -112,7 +113,8 @@ class Distribution < ApplicationRecord
   end
 
   def self.csv_export_headers
-    ["Partner", "Date of Distribution", "Source Inventory", "Total items"]
+    ["Partner", "Date of Distribution", "Source Inventory", "Total items",
+     "Total Value (in $)", "Delivery Method", "State", "Agency Representative"]
   end
 
   def combine_distribution
@@ -124,8 +126,12 @@ class Distribution < ApplicationRecord
       partner.name,
       issued_at.strftime("%F"),
       storage_location.name,
-      line_items.total
-    ]
+      line_items.total,
+      cents_to_dollar(line_items.total_value),
+      delivery_method,
+      state,
+      agency_rep
+    ] + quantity_per_line_item
   end
 
   def future?
@@ -134,5 +140,15 @@ class Distribution < ApplicationRecord
 
   def past?
     issued_at < Time.zone.today
+  end
+
+  private
+
+  def quantity_per_line_item
+    item_hash = line_items.quantities_by_name
+    item_ids = item_hash.collect { |_, value| value[:item_id] }
+    filtered_items = organization.items.filter { |item| item.active && item.visible_to_partners && !item_ids.include?(item.id) }
+    filtered_items.each { |item| item_hash[item.id] = { item_id: item.id, name: item.name, quantity: 0 } }
+    item_hash.sort_by { |_, value| value[:name] }.to_h.collect { |_, value| value[:quantity] }
   end
 end

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -213,5 +213,21 @@ RSpec.describe Distribution, type: :model do
         expect(Distribution.for_csv_export(@organization, {}, 4.days.ago..2.days.ago)).to match_array [distribution_1]
       end
     end
+
+    describe "csv_export_attributes" do
+      let(:item) { create(:item) }
+      let!(:distribution) { create(:distribution, :with_items, item: item, organization: @organization, issued_at: 3.days.ago) }
+
+      it "returns the set of attributes which define a row in case of distribution export" do
+        distribution_details = [distribution].map(&:csv_export_attributes).first
+        expect(distribution_details[0]).to eq distribution.partner.name
+        expect(distribution_details[1]).to eq distribution.issued_at.strftime("%F")
+        expect(distribution_details[2]).to eq distribution.storage_location.name
+        expect(distribution_details[3]).to eq distribution.line_items.total
+        expect(distribution_details[5]).to eq distribution.delivery_method
+        expect(distribution_details[6]).to eq distribution.state
+        expect(distribution_details[7]).to eq distribution.agency_rep
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves #1923  

### Description
Adds distribution details to the distribution export in order to make it more meaningful. Total value, delivery method, state, agency representative along with the quantities for each product are added to the distribution csv.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Added test in distribution_spec.rb to verify if the csv export attributes are correct. Ran the code with seed data in order to export sample distribution and check the csv headers and corresponding values.

