### PR TITLE
Prevent incomplete Kit creation due to silent failure

### DIFF
--- a/app/services/kit_create_service.rb
+++ b/app/services/kit_create_service.rb
@@ -30,7 +30,10 @@ class KitCreateService
         }
       )
 
-      item_creation.call
+      item_creation_result = item_creation.call
+      unless item_creation_result.success?
+        raise item_creation_result.error
+      end
     rescue StandardError => e
       errors.add(:base, e.message)
       raise ActiveRecord::Rollback

--- a/spec/services/kit_create_service_spec.rb
+++ b/spec/services/kit_create_service_spec.rb
@@ -60,6 +60,27 @@ describe KitCreateService do
           expect(subject.errors[:base]).to eq([raised_error])
         end
       end
+
+      context 'but the ItemCreationService is unsuccesful' do
+        let(:fake_error_struct) { OpenStruct.new(success?: false, error: error) }
+        let(:error) { Faker::Name.name }
+
+        before do
+          allow_any_instance_of(ItemCreateService).to receive(:call).and_return(fake_error_struct)
+        end
+
+        it 'should not create the Kit' do
+          expect { subject }.not_to change { Kit.all.count }
+        end
+
+        it 'should not create a Item' do
+          expect { subject }.not_to change { Item.all.count }
+        end
+
+        it 'should have an error that includes the error' do
+          expect(subject.errors[:base]).to eq([error])
+        end
+      end
     end
 
     context 'when the parameters provided are invalid' do


### PR DESCRIPTION

Resolves an issue discovered in bugsnag https://app.bugsnag.com/ruby-for-good/diaperbase/errors/5fbac79ca284fb001873c34a?event_id=5fbac79c0063f1443a2f0000&i=sk&m=nw

### Description

The problem stems from attempting to create a `Kit` with the same name of a `Item`. This causes problems because the `ItemCreateService` will fail silently. This PR catches the error and rollsback in case of situations like this.

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Tested with RSpec & locally.
