### PR TITLE
Prevent raising error if item_found is nil

### DIFF
--- a/app/services/requests_total_items_service.rb
+++ b/app/services/requests_total_items_service.rb
@@ -39,6 +39,6 @@ class RequestsTotalItemsService
 
   def item_name(id)
     item_found = items_names.find { |item| item["id"] == id }
-    item_found["name"].presence || "*Unknown Item*"
+    item_found&.fetch('name') || '*Unknown Item*'
   end
 end


### PR DESCRIPTION
Resolves an issue discovered from a user complaint that their requst page wasn't working. We also noticed that this came up on bugsnag - https://app.bugsnag.com/ruby-for-good/diaperbase/errors/5fbac6f67306b60019306407?filters[event.since][0]=30d&filters[error.status][0]=open


### Description
We ran into an issue where the request page was crashing because of an item_id provided that doesn't match any Item. Normally this would be okay, but we weren't properly falling back to the coded case. That is we were trying to access ["name"] on `nil`. 

This PR fixes it by using `&` safe operator and `fetch`

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested locally and rspec passing
