### PR TITLE
[2034] Add safe navigation for checking that agency is in partnerbase response

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -110,7 +110,7 @@ class Partner < ApplicationRecord
   end
 
   def contact_person
-    if partnerbase_partner
+    if partnerbase_partner&.agency
       partnerbase_partner.agency.fetch(:contact_person)
     else
       {}

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Partner, type: :model do
     let(:partner) { create(:partner) }
 
     it "checks for agency in response before fetching contact info" do
-      allow(partner).to receive(:partnerbase_partner) { OpenStruct.new(agency: nil) }
+      allow(partner).to receive(:partnerbase_partner) { instance_double('partnerbase_partner', agency: nil) }
       expect(partner.contact_person).to eq({})
     end
   end

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -174,6 +174,15 @@ RSpec.describe Partner, type: :model do
     end
   end
 
+  describe '#contact_person' do
+    let(:partner) { create(:partner) }
+
+    it "checks for agency in response before fetching contact info" do
+      allow(partner).to receive(:partnerbase_partner) { OpenStruct.new(agency: nil) }
+      expect(partner.contact_person).to eq({})
+    end
+  end
+
   describe '#quantity_year_to_date' do
     let(:partner) { create(:partner) }
     before do


### PR DESCRIPTION
# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

Resolves #2034

### Description
This is trying to fix the bug recorded in https://github.com/rubyforgood/diaper/issues/2034, which reported `undefined method 'fetch' for nil:NilClass` when trying to get the contact person from the partnerbase response for a partner call.
  

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Rspec, red to green! I wasn't able to reproduce the issue with seeded data.
