### PR TITLE
[2035] Avoid failing in the NotifyPartnerJob because of deleted requests

### DIFF
--- a/app/jobs/notify_partner_job.rb
+++ b/app/jobs/notify_partner_job.rb
@@ -2,8 +2,6 @@ class NotifyPartnerJob < ApplicationJob
   def perform(request_id)
     request = Request.find_by(id: request_id)
 
-    return unless request
-
-    RequestsConfirmationMailer.confirmation_email(request).deliver_later
+    RequestsConfirmationMailer.confirmation_email(request).deliver_later if request
   end
 end

--- a/app/jobs/notify_partner_job.rb
+++ b/app/jobs/notify_partner_job.rb
@@ -1,6 +1,8 @@
 class NotifyPartnerJob < ApplicationJob
   def perform(request_id)
-    request = Request.find(request_id)
+    request = Request.find_by(id: request_id)
+
+    return unless request
 
     RequestsConfirmationMailer.confirmation_email(request).deliver_later
   end

--- a/spec/jobs/notify_partner_job_spec.rb
+++ b/spec/jobs/notify_partner_job_spec.rb
@@ -8,6 +8,12 @@ RSpec.describe NotifyPartnerJob, job: true do
       allow(mailer).to receive(:deliver_later)
     end
 
+    it "avoids exception when request doesn't exist" do
+      expect do
+        NotifyPartnerJob.perform_now(123)
+      end.not_to raise_error(StandardError)
+    end
+
     it "is expected to call RequestsConfirmationMailer" do
       NotifyPartnerJob.perform_now(request.id)
       expect(RequestsConfirmationMailer).to have_received(:confirmation_email).with(request)


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/diaper/issues/2035

### Description

Handles the case when the request is deleted before the job is run to notify partners about it.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Rspec
