### PR TITLE
Add suggested KnapsackPro::Adapters::RSpecAdapter.bind to optimize parallel testing

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,9 @@ require "capybara-screenshot/rspec"
 require "pry"
 require 'sidekiq/testing'
 require 'webdrivers'
+require 'knapsack_pro'
+
+KnapsackPro::Adapters::RSpecAdapter.bind
 
 Sidekiq::Testing.fake! # fake is the default mode
 


### PR DESCRIPTION

### Description

A founder of KnapsackPro emailed me to tell me that we weren't using KnapsackPro to it's full potential without its parallel testing/split optimization. This PR adds what they suggested. 


### Type of change
* New feature (non-breaking change which adds functionality)

