### PR TITLE
Update server start instructions to use foreman to ensure webpack assest compilation

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+rails-web: bundle exec rails server -p 3000
+webpack: ./bin/webpack --watch --colors --progress
+

--- a/README.md
+++ b/README.md
@@ -58,8 +58,15 @@ Create a `database.yml` file on `config/` directory with your database configura
 ## Seed the database
 From the root of the app, run `bundle exec rails db:seed`. This will create some initial data to use while testing the app and developing new features, including setting up the default user.
 
+## Install Foreman
+Install [foreman](https://github.com/ddollar/foreman) by running:
+```
+gem install foreman
+```
+This gem assists in running both the rails server and webpack at the same time in development. Without this you may end up trying to run the rails server without neccessary compilation steps.
+
 ## Start the app
-Run `bundle exec rails s` and browse to http://localhost:3000/
+Run `foreman start` and browse to http://localhost:3000/
 
 ## Login
 To login to the web application, use these default credentials:


### PR DESCRIPTION
### Description

We've been running into issues where developers/volunteers encounter an extremely slow response when accessing pages locally. I've identified that this was caused by assets that should be compiled by webpack were not being compiled when running the usual `rails s` (and was trying to do it on-demand). I came to this conclusion because running `rake assets:precompile` before running the server removed the issue.

This PR simplifies this by running webpack development server with the rails server using the `foreman` library and the `Procfile` included in this PR. Now you don't need to remember to do `rake assets:precompile` anymore.


### Type of change
* New feature (non-breaking change which adds functionality)
* Documentation update

### How Has This Been Tested?
Ran this locally and worked fine. Will ask others to try this out as well.