### PR TITLE
Disable asset debug in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true


### PR DESCRIPTION
### Description

We've been getting complaints that the initial request to local diaper servers takes an extremely long time and can sometimes just 'hang'. This makes it appear that the server isn't working.

I've found that the assets are the primary reason why this is happening. To address this I've set `assets.debug=false`.



### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Test trying to access http://localhost:3000/ before and after this PR. Make sure to clear your assets via:
```
rm -rf tmp
rails assets:clean
```

You should see that before this option the server just hangs and then after it should be very fast.
