### PR TITLE
Add new relic gem to production group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,6 @@ gem "jwt"
 gem "kaminari"
 gem "mini_racer", "~> 0.3.1"
 gem "momentjs-rails"
-gem "newrelic_rpm"
 gem "nokogiri", ">= 1.10.4"
 gem "paperclip" # needed for legacy migrations
 gem "pg", "~> 1.2.3"
@@ -53,6 +52,10 @@ gem "toastr-rails"
 gem "uglifier", ">= 1.3.0"
 gem "webpacker", "> 4.0"
 gem "yajl-ruby"
+
+group :production do
+  gem "newrelic_rpm"
+end
 
 group :development, :test do
   gem "awesome_print"


### PR DESCRIPTION
### Description

When the project is running in the development environment, it shows a console error:

![image](https://user-images.githubusercontent.com/20689519/102822906-aa970700-43b8-11eb-9120-26799016fd09.png)

Because we don't have a new relic key for development. So this fix changes the new relic gem to be present just in the production environment.

### Type of change

* Bug fix

