### PR TITLE
Distribution filter by storage location

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -46,10 +46,12 @@ class DistributionsController < ApplicationController
     @total_items_all_distributions = total_items(@distributions)
     @total_items_paginated_distributions = total_items(@paginated_distributions)
     @items = current_organization.items.alphabetized
+    @storage_locations = current_organization.storage_locations.alphabetized
     @partners = @distributions.collect(&:partner).uniq.sort_by(&:name)
     @selected_item = filter_params[:by_item_id]
     @selected_partner = filter_params[:by_partner]
     @selected_status = filter_params[:by_state]
+    @selected_location = filter_params[:by_location]
     # FIXME: one of these needs to be removed but it's unclear which at this point
     @statuses = Distribution.states.transform_keys(&:humanize)
 
@@ -200,7 +202,7 @@ class DistributionsController < ApplicationController
     def filter_params
     return {} unless params.key?(:filters)
 
-    params.require(:filters).permit(:by_item_id, :by_partner, :by_state)
+    params.require(:filters).permit(:by_item_id, :by_partner, :by_state, :by_location)
   end
 
   def perform_inventory_check

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -48,9 +48,9 @@ class Distribution < ApplicationRecord
   scope :by_item_id, ->(item_id) { joins(:items).where(items: { id: item_id }) }
   # partner scope to allow filtering by partner
   scope :by_partner, ->(partner_id) { where(partner_id: partner_id) }
-  # location scope to allow filtering by partner
+  # location scope to allow filtering distributions by location
   scope :by_location, ->(storage_location_id) { where(storage_location_id: storage_location_id) }
-  # state scope to allow filtering distributions by location
+  # state scope to allow filtering by state
   scope :by_state, ->(state) { where(state: state) }
   scope :recent, ->(count = 3) { order(issued_at: :desc).limit(count) }
   scope :future, -> { where("issued_at >= :tomorrow", tomorrow: Time.zone.tomorrow) }

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -48,7 +48,9 @@ class Distribution < ApplicationRecord
   scope :by_item_id, ->(item_id) { joins(:items).where(items: { id: item_id }) }
   # partner scope to allow filtering by partner
   scope :by_partner, ->(partner_id) { where(partner_id: partner_id) }
-  # state scope to allow filtering by state
+  # location scope to allow filtering by partner
+  scope :by_location, ->(storage_location_id) { where(storage_location_id: storage_location_id) }
+  # state scope to allow filtering distributions by location
   scope :by_state, ->(state) { where(state: state) }
   scope :recent, ->(count = 3) { order(issued_at: :desc).limit(count) }
   scope :future, -> { where("issued_at >= :tomorrow", tomorrow: Time.zone.tomorrow) }

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -47,7 +47,7 @@
                   </div>
                 <% end %>
                 <% if @storage_locations.present? %>
-                  <div class="form-group col-lg-2 col-md-2 col-sm-6 col-xs-12">
+                  <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
                     <%= filter_select(label: "Filter by Source Inventory", scope: :by_location, collection: @storage_locations, selected: @selected_location) %>
                   </div>
                 <% end %>

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -37,19 +37,24 @@
             <%= form_tag(distributions_path, method: :get) do |f| %>
               <div class="row">
                 <% if @items.present? %>
-                  <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
+                  <div class="form-group col-lg-2 col-md-2 col-sm-6 col-xs-12">
                     <%= filter_select(label: "Filter by item", scope: :by_item_id, collection: @items, selected: @selected_item) %>
                   </div>
                 <% end %>
                 <% if @partners.present? %>
-                  <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
+                  <div class="form-group col-lg-2 col-md-2 col-sm-6 col-xs-12">
                     <%= filter_select(scope: :by_partner, collection: @partners, selected: @selected_partner) %>
                   </div>
                 <% end %>
-                <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
+                <% if @storage_locations.present? %>
+                  <div class="form-group col-lg-2 col-md-2 col-sm-6 col-xs-12">
+                    <%= filter_select(label: "Filter by Source Inventory", scope: :by_location, collection: @storage_locations, selected: @selected_location) %>
+                  </div>
+                <% end %>
+                <div class="form-group col-lg-2 col-md-2 col-sm-6 col-xs-12">
                   <%= filter_select(label: "Filter by Status", scope: :by_state, collection: @statuses, key: :last, value: :first, selected: @selected_status) %>
                 </div>
-                <div class="form-group col-lg-3 col-md-3 col-sm-6 col-xs-12">
+                <div class="form-group col-lg-2 col-md-2 col-sm-6 col-xs-12">
                   <%= label_tag "Date Range" %>
                   <%= render partial: "shared/date_range_picker", locals: {css_class: "form-control"} %>
                 </div>

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -129,10 +129,11 @@ RSpec.describe Distribution, type: :model do
       let!(:location_2) { create(:storage_location) }
 
       it "only returns distributions with given location id" do
-        create(:distribution, storage_location: location_1)
-        create(:distribution, storage_location: location_2)
+        dist1 = create(:distribution, storage_location: location_1)
+        dist2 = create(:distribution, storage_location: location_2)
 
-        expect(Distribution.by_location(location_1.id).size).to eq(1)
+        expect(Distribution.by_location(location_1.id)).to include(dist1)
+        expect(Distribution.by_location(location_1.id)).not_to include(dist2)
       end
     end
   end

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -123,6 +123,18 @@ RSpec.describe Distribution, type: :model do
         expect(Distribution.by_partner(partner1.id).size).to eq(1)
       end
     end
+
+    describe "by_location >" do
+      let!(:location_1) { create(:storage_location) }
+      let!(:location_2) { create(:storage_location) }
+
+      it "only returns distributions with given location id" do
+        create(:distribution, storage_location: location_1)
+        create(:distribution, storage_location: location_2)
+
+        expect(Distribution.by_location(location_1.id).size).to eq(1)
+      end
+    end
   end
 
   context "Callbacks >" do


### PR DESCRIPTION
Resolves #2032  

### Description

This PR adds a new filter to the distributions list to filter by source inventory.

Add a new scope to `Distribution` model to list distributions of a storage location.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Go to the distributions list, select one `source inventory` on filter fields and click on `Filter` button.

After loading, the list must show just distributions with source inventory selected.

### Screenshots

![image](https://user-images.githubusercontent.com/20689519/102936009-07acbe80-4486-11eb-8ee2-65247196d541.png)

