### PR TITLE
Prevent failing tests on forked branch CI

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -85,4 +85,4 @@ jobs:
           KNAPSACK_PRO_RSPEC_SPLIT_BY_TEST_EXAMPLES: true
           KNAPSACK_PRO_LOG_LEVEL: info
         run: |
-          RUBYOPT='-W:no-deprecated -W:no-experimental' bundle exec rake knapsack_pro:queue:rspec
+          RUBYOPT='-W:no-deprecated -W:no-experimental' bin/knapsack_pro_rspec

--- a/bin/knapsack_pro_rspec
+++ b/bin/knapsack_pro_rspec
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [ "$KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC" = "" ]; then
+  KNAPSACK_PRO_ENDPOINT=https://api-disabled-for-fork.knapsackpro.com \
+    KNAPSACK_PRO_TEST_SUITE_TOKEN_RSPEC=disabled-for-fork \
+    KNAPSACK_PRO_MAX_REQUEST_RETRIES=0 \
+    bundle exec rake knapsack_pro:rspec # use Regular Mode here always
+else
+    # Regular Mode
+    bundle exec rake knapsack_pro:rspec
+
+    # or you can use Queue Mode instead of Regular Mode if you like
+    # bundle exec rake knapsack_pro:queue:rspec
+fi


### PR DESCRIPTION
Knapsack was failing on PRs that came from forked branches. This is because the forked branch doesn't have the knapsack secret. Refer to https://knapsackpro.com/faq/question/how-to-make-knapsack_pro-works-for-forked-repositories-of-my-project for more details