### PR TITLE
Update staging deployment so that it recogonizes itself as staging

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -61,11 +61,10 @@
   </div>
 <% end %>
 <script>
-  $(document).ready(function () {
-
-    if (document.URL == "https://diaperbase.org/users/sign_in") {
+  $(document).ready(function() {
+    <% if Rails.env.staging? %>
       $('#exampleModal').modal('show');
-    }
+    <% end %>
   });
 </script>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,6 +16,14 @@ test:
   database: diaper_test
   timeout: 5000
 
+staging:
+  <<: *default
+  # This is really staging! However, we inherit the
+  # same configurations as production because staging
+  # use to run through environments/production.rb configuration
+  database: diaper_production
+  password: <%= ENV['DIAPER_DATABASE_PASSWORD'] %>
+
 production:
   <<: *default
   database: diaper_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,16 +16,6 @@ test:
   database: diaper_test
   timeout: 5000
 
-staging:
-  <<: *default
-  # This is really staging! However, we inherit the
-  # same configurations as production because staging
-  # use to run through environments/production.rb configuration
-  #
-  # TODO - update database name in staging
-  database: diaper_production
-  password: <%= ENV['DIAPER_DATABASE_PASSWORD'] %>
-
 production:
   <<: *default
   database: diaper_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,6 +21,8 @@ staging:
   # This is really staging! However, we inherit the
   # same configurations as production because staging
   # use to run through environments/production.rb configuration
+  #
+  # TODO - update database name in staging
   database: diaper_production
   password: <%= ENV['DIAPER_DATABASE_PASSWORD'] %>
 

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -27,7 +27,7 @@
 # http://capistranorb.com/documentation/getting-started/configuration/
 # Feel free to add new variables to customise your setup.
 set :stage, :staging
-set :rails_env, :production
+set :rails_env, :staging
 
 role :app, "deploy@45.79.146.211"
 

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,96 @@
+Rails.application.configure do
+  # Verifies that versions and hashed value of the package contents in the project's package.json
+  config.webpacker.check_yarn_integrity = false
+  # Settings specified here will take precedence over those in config/application.rb.
+
+  # Code is not reloaded between requests.
+  config.cache_classes = true
+
+  config.require_master_key = true
+
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
+
+  config.action_mailer.default_url_options = { host: "diaper.app" }
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local = false
+  config.action_controller.perform_caching = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+
+  # Compress JavaScripts and CSS.
+  config.assets.js_compressor = Uglifier.new(harmony: true)
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = 'http://assets.example.com'
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Mount Action Cable outside main process or domain
+  # config.action_cable.mount_path = nil
+  # config.action_cable.url = 'wss://example.com/cable'
+  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  config.force_ssl = true
+  config.ssl_options = { hsts: false }
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [:request_id]
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "diaper_#{Rails.env}"
+  config.action_mailer.perform_caching = false
+
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = false
+
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = [I18n.default_locale]
+
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
+
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
+
+  # Store files locally.
+  config.active_storage.service = :local
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
+end
+

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
   # Rake tasks automatically ignore this option for performance.
   config.eager_load = true
 
-  config.action_mailer.default_url_options = { host: "diaper.app" }
+  config.action_mailer.default_url_options = { host: "diaperbase.org" }
   # Full error reports are disabled and caching is turned on.
   config.consider_all_requests_local = false
   config.action_controller.perform_caching = true

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -58,6 +58,15 @@ test:
   # Compile test packs to a separate directory
   public_output_path: packs-test
 
+staging:
+  <<: *default
+
+  # Staging depends on precompilation of packs prior to booting for performance.
+  compile: false
+
+  # Cache manifest.json for performance
+  cache_manifest: true
+
 production:
   <<: *default
 

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -8,7 +8,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  resolved_paths: []
+  additional_paths: []
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -60,6 +60,7 @@ test:
 
 staging:
   <<: *default
+  public_root_path: public
 
   # Staging depends on precompilation of packs prior to booting for performance.
   compile: false

--- a/lib/capistrano/templates/database.yml.erb
+++ b/lib/capistrano/templates/database.yml.erb
@@ -23,12 +23,7 @@ default: &default
 
 staging:
   <<: *default
-  # This is really staging! However, we inherit the
-  # same configurations as production because staging
-  # use to run through environments/production.rb configuration
-  #
-  # TODO - update database name in staging
-  database: diaper_base_production
+  database: diaper_base_staging
   username: diaper_base
   password: <%= ENV['DIAPER_BASE_DATABASE_PASSWORD'] %>
 

--- a/lib/capistrano/templates/database.yml.erb
+++ b/lib/capistrano/templates/database.yml.erb
@@ -21,6 +21,17 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
+staging:
+  <<: *default
+  # This is really staging! However, we inherit the
+  # same configurations as production because staging
+  # use to run through environments/production.rb configuration
+  #
+  # TODO - update database name in staging
+  database: diaper_base_production
+  username: diaper_base
+  password: <%= ENV['DIAPER_BASE_DATABASE_PASSWORD'] %>
+
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
 # ever seen by anyone, they now have access to your database.


### PR DESCRIPTION
Resolves #2064

### Description

This PR makes it so that the staging environment is properly recognized as `staging`. For example, in the past, `Rails.env` would yield `production` in staging deployments; and now it yields `staging`. The benefits of this are:
- You no longer need to check the URL to know you are in staging. `Rails.env.staging?` can be used to distinguish if the current environment is staging. (See code change in session/new.html in the PR)
- Bugsnag caught errors in staging will now appear as they were in staging and not in production. This reduces confusion since we won't be thinking errors on experimental staging code is happening in production.


### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Deployed to staging. And I ensured we could still deploy to production without problem.
