### PR TITLE
Prevent raising error if an asset is not precompiled 

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,6 +55,10 @@ Rails.application.configure do
   # number of complex assets.
   config.assets.debug = false
 
+  # Prevent raising error if an asset is not precompiled
+  # Error example: Sprockets::rails::Helper::AssetNotPrecompiled
+  config.assets.check_precompiled_asset = false
+
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 


### PR DESCRIPTION
### Description
  - Prevent raising error if an asset is not precompiled
  - Error example: Sprockets::rails::Helper::AssetNotPrecompiled
   
### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested locally working with @edwinthinks 

### Screenshots
Here is an example of the error:
<img width="845" alt="Screen Shot 2020-12-26 at 1 51 31 PM" src="https://user-images.githubusercontent.com/66537500/103158280-86a14000-4781-11eb-9188-e5edb962f41a.png">
