### PR TITLE
add before_destroy callback to StorageLocation and dependent :destroy to InventoryItem

### DIFF
--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -70,8 +70,14 @@ class StorageLocationsController < ApplicationController
   end
 
   def destroy
-    current_organization.storage_locations.find(params[:id]).destroy
-    redirect_to storage_locations_path
+    @storage_location = current_organization.storage_locations.find(params[:id])
+
+    if @storage_location.destroy
+      redirect_to storage_locations_path, notice: "Storage Location deleted successfully"
+    else
+      flash[:error] = @storage_location.errors.full_messages.join(', ')
+      redirect_to storage_locations_path
+    end
   end
 
   def inventory

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -194,8 +194,6 @@ class StorageLocation < ApplicationRecord
   end
 
   def empty_inventory_items?
-    items_quantity = inventory_items.map(&:quantity).uniq
-
-    items_quantity.empty? || (items_quantity.length == 1 && items_quantity.first.zero?)
+    inventory_items.map(&:quantity).uniq.reject(&:zero?).empty?
   end
 end

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -180,7 +180,7 @@ class StorageLocation < ApplicationRecord
 
   def verify_inventory_items
     unless empty_inventory_items?
-      errors.add(:base, "Cannot delete storage location containing inventory items")
+      errors.add(:base, "Cannot delete storage location containing inventory items with non-zero quantities")
       throw(:abort)
     end
   end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -35,7 +35,6 @@ RSpec.describe StorageLocation, type: :model do
 
       it "deletes storage locations with no inventory items on it" do
         subject.inventory_items.destroy_all
-        expect(subject.destroy).to eq(true)
 
         expect(StorageLocation.count).to eq(0)
       end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -22,6 +22,19 @@ RSpec.describe StorageLocation, type: :model do
     end
   end
 
+  context "Callbacks >" do
+    describe "before_destroy" do
+      let!(:item) { create(:item) }
+      subject { create(:storage_location, :with_items, item_quantity: 10, item: item, organization: @organization) }
+
+      it "does not delete storage locations with inventory items on it" do
+        subject.destroy
+
+        expect(subject.errors.messages[:base]).to include("Cannot delete storage location containing inventory items")
+      end
+    end
+  end
+
   context "Filtering >" do
     it "->containing yields only inventories that have that item" do
       item = create(:item)

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe StorageLocation, type: :model do
 
       it "deletes storage locations with no inventory items on it" do
         subject.inventory_items.destroy_all
-        subject.destroy
+        expect(subject.destroy).to eq(true)
 
         expect(StorageLocation.count).to eq(0)
       end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -35,6 +35,7 @@ RSpec.describe StorageLocation, type: :model do
 
       it "deletes storage locations with no inventory items on it" do
         subject.inventory_items.destroy_all
+        subject.destroy
 
         expect(StorageLocation.count).to eq(0)
       end

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -32,6 +32,13 @@ RSpec.describe StorageLocation, type: :model do
 
         expect(subject.errors.messages[:base]).to include("Cannot delete storage location containing inventory items")
       end
+
+      it "deletes storage locations with no inventory items on it" do
+        subject.inventory_items.destroy_all
+        subject.destroy
+
+        expect(StorageLocation.count).to eq(0)
+      end
     end
   end
 

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe StorageLocation, type: :model do
 
   context "Callbacks >" do
     describe "before_destroy" do
-      let!(:item) { create(:item) }
+      let(:item) { create(:item) }
       subject { create(:storage_location, :with_items, item_quantity: 10, item: item, organization: @organization) }
 
       it "does not delete storage locations with inventory items on it" do
         subject.destroy
 
-        expect(subject.errors.messages[:base]).to include("Cannot delete storage location containing inventory items")
+        expect(subject.errors.messages[:base]).to include("Cannot delete storage location containing inventory items with non-zero quantities")
       end
 
       it "deletes storage locations with no inventory items on it" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2079 <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->
Adds `before_destroy` callback which verifies before deleting the storage location if said location does not have any inventory item with any quantity.

It also adds the `dependent :destroy` statement so it always deletes the inventory_items linked to it.
### Type of change

<!-- Please delete options that are not relevant. -->

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
Error warning when deleting the storage location:
![image](https://user-images.githubusercontent.com/33486409/103304769-3ed02200-49e8-11eb-97fd-3c6189c66664.png)
