### PR TITLE
2076 Adds Square Footage and Warehouse Type to Storage Location

### DIFF
--- a/app/controllers/storage_locations_controller.rb
+++ b/app/controllers/storage_locations_controller.rb
@@ -87,7 +87,7 @@ class StorageLocationsController < ApplicationController
   private
 
   def storage_location_params
-    params.require(:storage_location).permit(:name, :address)
+    params.require(:storage_location).permit(:name, :address, :square_footage, :warehouse_type)
   end
 
   helper_method \

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -40,6 +40,8 @@ class StorageLocation < ApplicationRecord
                           dependent: :destroy
 
   validates :name, :address, :organization, presence: true
+  validates :warehouse_type, inclusion: { in: WAREHOYSE_TYPES },
+                             allow_blank: true
 
   include Geocodable
   include Filterable

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -187,10 +187,10 @@ class StorageLocation < ApplicationRecord
   end
 
   def self.csv_export_headers
-    ["Name", "Address", "Total Inventory"]
+    ["Name", "Address", "Square Footage", "Warehouse Type", "Total Inventory"]
   end
 
   def csv_export_attributes
-    [name, address, size]
+    [name, address, square_footage, warehouse_type, size]
   end
 end

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -7,6 +7,8 @@
 #  latitude        :float
 #  longitude       :float
 #  name            :string
+#  square_footage  :integer
+#  warehouse_type  :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :integer
@@ -14,6 +16,13 @@
 
 class StorageLocation < ApplicationRecord
   require "csv"
+
+  WAREHOYSE_TYPES = [
+    'Residential space used',
+    'Consumer, self-storage or container space',
+    'Commercial/office/business space that includes storage space',
+    'Warehouse with loading bay'
+  ].freeze
 
   belongs_to :organization
   has_many :inventory_items, -> { includes(:item).order("items.name") },

--- a/app/models/storage_location.rb
+++ b/app/models/storage_location.rb
@@ -17,7 +17,7 @@
 class StorageLocation < ApplicationRecord
   require "csv"
 
-  WAREHOYSE_TYPES = [
+  WAREHOUSE_TYPES = [
     'Residential space used',
     'Consumer, self-storage or container space',
     'Commercial/office/business space that includes storage space',
@@ -40,7 +40,7 @@ class StorageLocation < ApplicationRecord
                           dependent: :destroy
 
   validates :name, :address, :organization, presence: true
-  validates :warehouse_type, inclusion: { in: WAREHOYSE_TYPES },
+  validates :warehouse_type, inclusion: { in: WAREHOUSE_TYPES },
                              allow_blank: true
 
   include Geocodable

--- a/app/views/storage_locations/_form.html.erb
+++ b/app/views/storage_locations/_form.html.erb
@@ -21,11 +21,11 @@
                 <% end %>
 
                 <%= f.input :square_footage, label: "Square Footage", wrapper: :input_group do %>
-                  <span class="input-group-text"><i class="fa fa-address-card-o"></i></span>
+                  <span class="input-group-text"><i class="fa fa-th"></i></span>
                   <%= f.input_field :square_footage, class: "form-control" %>
                 <% end %>
 
-                <%= f.input :warehouse_type, label: "Warehouse Type", wrapper: :input_group, collection: StorageLocation::WAREHOYSE_TYPES %>
+                <%= f.input :warehouse_type, label: "Warehouse Type", wrapper: :input_group, collection: StorageLocation::WAREHOUSE_TYPES %>
                 </div>
                 <!-- /.card-body -->
                 <div class="card-footer">

--- a/app/views/storage_locations/_form.html.erb
+++ b/app/views/storage_locations/_form.html.erb
@@ -19,6 +19,13 @@
                   <span class="input-group-text"><i class="fa fa-address-card-o"></i></span>
                   <%= f.input_field :address, class: "form-control" %>
                 <% end %>
+
+                <%= f.input :square_footage, label: "Square Footage", wrapper: :input_group do %>
+                  <span class="input-group-text"><i class="fa fa-address-card-o"></i></span>
+                  <%= f.input_field :square_footage, class: "form-control" %>
+                <% end %>
+
+                <%= f.input :warehouse_type, label: "Warehouse Type", wrapper: :input_group, collection: StorageLocation::WAREHOYSE_TYPES %>
                 </div>
                 <!-- /.card-body -->
                 <div class="card-footer">

--- a/app/views/storage_locations/_storage_location_row.html.erb
+++ b/app/views/storage_locations/_storage_location_row.html.erb
@@ -1,6 +1,8 @@
 <tr>
   <td><%= storage_location.name %></td>
   <td><%= storage_location.address %></td>
+  <td><%= storage_location.square_footage %></td>
+  <td><%= storage_location.warehouse_type %></td>
   <td><%= storage_location.size %></td>
   <td><%= number_to_currency(storage_location.inventory_total_value_in_dollars) %></td>
   <td class="text-right">

--- a/app/views/storage_locations/index.html.erb
+++ b/app/views/storage_locations/index.html.erb
@@ -71,6 +71,8 @@
               <tr>
                 <th>Name</th>
                 <th>Address</th>
+                <th>Square Footage</th>
+                <th>Warehouse Type</th>
                 <th>Total Inventory</th>
                 <th>Fair Market Value</th>
                 <th class="text-center">Actions</th>

--- a/app/views/storage_locations/show.html.erb
+++ b/app/views/storage_locations/show.html.erb
@@ -34,12 +34,16 @@
               <tr>
                 <th>Storage Location</th>
                 <th>Address</th>
+                <th>Square Footage</th>
+                <th>Warehouse Type</th>
               </tr>
               </thead>
               <tbody>
               <tr>
                 <td><%= @storage_location.name %></td>
                 <td><%= @storage_location.address %></td>
+                <td><%= @storage_location.square_footage %></td>
+                <td><%= @storage_location.warehouse_type %></td>
               </tr>
               </tbody>
             </table>

--- a/db/migrate/20201230203200_add_square_footage_and_warehouse_type_to_storage_locations.rb
+++ b/db/migrate/20201230203200_add_square_footage_and_warehouse_type_to_storage_locations.rb
@@ -1,0 +1,9 @@
+# Organizations can remind Partners when their deadlines are for putting in their requests
+class AddSquareFootageAndWarehouseTypeToStorageLocations < ActiveRecord::Migration[5.2]
+  def change
+    change_table :storage_locations, bulk: true do |t|
+      t.integer :square_footage
+      t.string :warehouse_type
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_04_124133) do
-
+ActiveRecord::Schema.define(version: 20_201_230_203_200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -33,7 +32,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.bigint "record_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+    t.index %w(record_type record_id name), name: "index_action_text_rich_texts_uniqueness", unique: true
   end
 
   create_table "active_storage_attachments", force: :cascade do |t|
@@ -43,7 +42,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
     t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+    t.index %w(record_type record_id name blob_id), name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
   create_table "active_storage_blobs", force: :cascade do |t|
@@ -91,7 +90,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.datetime "updated_at", null: false
     t.integer "organization_id"
     t.string "barcodeable_type", default: "Item"
-    t.index ["barcodeable_type", "barcodeable_id"], name: "index_barcode_items_on_barcodeable_type_and_barcodeable_id"
+    t.index %w(barcodeable_type barcodeable_id), name: "index_barcode_items_on_barcodeable_type_and_barcodeable_id"
     t.index ["organization_id"], name: "index_barcode_items_on_organization_id"
   end
 
@@ -118,7 +117,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.string "business_name"
     t.float "latitude"
     t.float "longitude"
-    t.index ["latitude", "longitude"], name: "index_diaper_drive_participants_on_latitude_and_longitude"
+    t.index %w(latitude longitude), name: "index_diaper_drive_participants_on_latitude_and_longitude"
   end
 
   create_table "diaper_drives", force: :cascade do |t|
@@ -156,7 +155,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.integer "organization_id"
     t.float "latitude"
     t.float "longitude"
-    t.index ["latitude", "longitude"], name: "index_donation_sites_on_latitude_and_longitude"
+    t.index %w(latitude longitude), name: "index_donation_sites_on_latitude_and_longitude"
     t.index ["organization_id"], name: "index_donation_sites_on_organization_id"
   end
 
@@ -203,7 +202,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.string "value"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["feature_key", "key", "value"], name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
+    t.index %w(feature_key key value), name: "index_flipper_gates_on_feature_key_and_key_and_value", unique: true
   end
 
   create_table "inventory_items", id: :serial, force: :cascade do |t|
@@ -243,7 +242,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.boolean "active", default: true
     t.boolean "visible_to_partners", default: true, null: false
     t.integer "value_in_cents", default: 0
-    t.index ["name", "organization_id"], name: "index_kits_on_name_and_organization_id", unique: true
+    t.index %w(name organization_id), name: "index_kits_on_name_and_organization_id", unique: true
     t.index ["organization_id"], name: "index_kits_on_organization_id"
   end
 
@@ -254,7 +253,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.string "itemizable_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["itemizable_id", "itemizable_type"], name: "index_line_items_on_itemizable_id_and_itemizable_type"
+    t.index %w(itemizable_id itemizable_type), name: "index_line_items_on_itemizable_id_and_itemizable_type"
   end
 
   create_table "manufacturers", force: :cascade do |t|
@@ -285,7 +284,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.integer "default_storage_location"
     t.text "partner_form_fields", default: [], array: true
     t.integer "account_request_id"
-    t.index ["latitude", "longitude"], name: "index_organizations_on_latitude_and_longitude"
+    t.index %w(latitude longitude), name: "index_organizations_on_latitude_and_longitude"
     t.index ["short_name"], name: "index_organizations_on_short_name"
   end
 
@@ -338,7 +337,9 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.integer "organization_id"
     t.float "latitude"
     t.float "longitude"
-    t.index ["latitude", "longitude"], name: "index_storage_locations_on_latitude_and_longitude"
+    t.integer "square_footage"
+    t.string "warehouse_type"
+    t.index %w(latitude longitude), name: "index_storage_locations_on_latitude_and_longitude"
     t.index ["organization_id"], name: "index_storage_locations_on_organization_id"
   end
 
@@ -384,7 +385,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
     t.index ["invitations_count"], name: "index_users_on_invitations_count"
     t.index ["invited_by_id"], name: "index_users_on_invited_by_id"
-    t.index ["invited_by_type", "invited_by_id"], name: "index_users_on_invited_by_type_and_invited_by_id"
+    t.index %w(invited_by_type invited_by_id), name: "index_users_on_invited_by_type_and_invited_by_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
@@ -400,7 +401,7 @@ ActiveRecord::Schema.define(version: 2020_10_04_124133) do
     t.float "longitude"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["latitude", "longitude"], name: "index_vendors_on_latitude_and_longitude"
+    t.index %w(latitude longitude), name: "index_vendors_on_latitude_and_longitude"
   end
 
   add_foreign_key "adjustments", "organizations"

--- a/spec/factories/storage_locations.rb
+++ b/spec/factories/storage_locations.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     address { "1500 Remount Road, Front Royal, VA 22630" }
     organization { Organization.try(:first) || create(:organization) }
     square_footage { 100 }
-    warehouse_type { StorageLocation::WAREHOYSE_TYPES.sample }
+    warehouse_type { StorageLocation::WAREHOUSE_TYPES.sample }
 
     trait :with_items do
       transient do

--- a/spec/factories/storage_locations.rb
+++ b/spec/factories/storage_locations.rb
@@ -7,6 +7,8 @@
 #  latitude        :float
 #  longitude       :float
 #  name            :string
+#  square_footage  :integer
+#  warehouse_type  :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :integer
@@ -17,6 +19,8 @@ FactoryBot.define do
     name { "Smithsonian Conservation Center" }
     address { "1500 Remount Road, Front Royal, VA 22630" }
     organization { Organization.try(:first) || create(:organization) }
+    square_footage { 100 }
+    warehouse_type { StorageLocation::WAREHOYSE_TYPES.sample }
 
     trait :with_items do
       transient do

--- a/spec/models/storage_location_spec.rb
+++ b/spec/models/storage_location_spec.rb
@@ -7,6 +7,8 @@
 #  latitude        :float
 #  longitude       :float
 #  name            :string
+#  square_footage  :integer
+#  warehouse_type  :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :integer
@@ -14,12 +16,9 @@
 
 RSpec.describe StorageLocation, type: :model do
   context "Validations >" do
-    it "requires a name" do
-      expect(build(:storage_location, name: nil)).not_to be_valid
-    end
-    it "requires an address" do
-      expect(build(:storage_location, address: nil)).not_to be_valid
-    end
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:address) }
+    it { is_expected.to validate_presence_of(:organization) }
   end
 
   context "Filtering >" do

--- a/spec/system/storage_location_system_spec.rb
+++ b/spec/system/storage_location_system_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Storage Locations", type: :system, js: true do
       fill_in "Name", with: storage_location_traits[:name]
       fill_in "Address", with: storage_location_traits[:address]
       fill_in "Square Footage", with: storage_location_traits[:square_footage]
-      select StorageLocation::WAREHOYSE_TYPES.sample, from: 'Warehouse Type'
+      select StorageLocation::WAREHOUSE_TYPES.sample, from: 'Warehouse Type'
       click_on "Save"
 
       expect(page.find(".alert")).to have_content "added"
@@ -45,7 +45,7 @@ RSpec.describe "Storage Locations", type: :system, js: true do
       visit subject
       fill_in "Address", with: storage_location.name + " new"
       fill_in "Square Footage", with: storage_location.square_footage + 50
-      select (StorageLocation::WAREHOYSE_TYPES - [storage_location.warehouse_type]).sample, from: 'Warehouse Type'
+      select (StorageLocation::WAREHOUSE_TYPES - [storage_location.warehouse_type]).sample, from: 'Warehouse Type'
 
       click_on "Save"
 

--- a/spec/system/storage_location_system_spec.rb
+++ b/spec/system/storage_location_system_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe "Storage Locations", type: :system, js: true do
       expect(page.find(".alert")).to have_content "added"
     end
 
+    it 'User creates a new storage location with optional fields' do
+      visit subject
+      storage_location_traits = attributes_for(:storage_location)
+      fill_in "Name", with: storage_location_traits[:name]
+      fill_in "Address", with: storage_location_traits[:address]
+      fill_in "Square Footage", with: storage_location_traits[:square_footage]
+      select StorageLocation::WAREHOYSE_TYPES.sample, from: 'Warehouse Type'
+      click_on "Save"
+
+      expect(page.find(".alert")).to have_content "added"
+    end
+
     it "User creates a new storage location with empty attributes" do
       visit subject
       click_on "Save"
@@ -32,6 +44,9 @@ RSpec.describe "Storage Locations", type: :system, js: true do
     it "User updates an existing storage location" do
       visit subject
       fill_in "Address", with: storage_location.name + " new"
+      fill_in "Square Footage", with: storage_location.square_footage + 50
+      select (StorageLocation::WAREHOYSE_TYPES - [storage_location.warehouse_type]).sample, from: 'Warehouse Type'
+
       click_on "Save"
 
       expect(page.find(".alert")).to have_content "updated"


### PR DESCRIPTION
Resolves #2076

### Description
Adds `Square Footage` and `Warehouse Type` fields to `Storage Location`
Adds these fields in Index, Show and Export CSV

### Type of change
* New feature

### How Has This Been Tested?
* Go to **Inventory > Storage Locations > New Storage Location/Edit** fill in all fields and a new Storage Location should be created/edited with `Square Footage` and `Warehouse Type`
* Go to **Inventory > Storage Locations > New Storage Location/Edit** fill only the required fields and a new Storage Location should be created/edited without `Square Footage` and `Warehouse Type`
* Go to **Inventory > Storage Locations** and these two Storage Locations should be visible on table (one with the new fields and another without them)
* Go to **Inventory > Storage Locations > Export Storage Locations** and these two fields should be visible and filled (when storage location has these information)

### Screenshots
![image](https://user-images.githubusercontent.com/4561599/103392633-b348b500-4afd-11eb-9e41-0b463e077b45.png)
![image](https://user-images.githubusercontent.com/4561599/103392636-b9d72c80-4afd-11eb-99a4-c378b180a16c.png)
![image](https://user-images.githubusercontent.com/4561599/103392660-c8bddf00-4afd-11eb-8022-67b4a47b6b6b.png)

