### PR TITLE
2091-Flag for virtual diaper drives

### DIFF
--- a/app/controllers/diaper_drives_controller.rb
+++ b/app/controllers/diaper_drives_controller.rb
@@ -75,7 +75,7 @@ class DiaperDrivesController < ApplicationController
 
   def diaper_drive_params
     params.require(:diaper_drive)
-          .permit(:name, :start_date, :end_date)
+          .permit(:name, :start_date, :end_date, :virtual)
   end
 
   def date_range_filter

--- a/app/helpers/diaper_drive_helper.rb
+++ b/app/helpers/diaper_drive_helper.rb
@@ -1,0 +1,7 @@
+module DiaperDriveHelper
+  def is_virtual(diaper_drive)
+    return 'No' if diaper_drive.blank?
+
+    diaper_drive.virtual? ? 'Yes' : 'No'
+  end
+end

--- a/app/helpers/diaper_drive_helper.rb
+++ b/app/helpers/diaper_drive_helper.rb
@@ -1,6 +1,6 @@
 module DiaperDriveHelper
-  def is_virtual(diaper_drive)
-    return 'No' if diaper_drive.blank?
+  def is_virtual(diaper_drive:)
+    raise StandardError, 'No diaper drive was provided' if diaper_drive.blank?
 
     diaper_drive.virtual? ? 'Yes' : 'No'
   end

--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -6,6 +6,7 @@
 #  end_date        :date
 #  name            :string
 #  start_date      :date
+#  virtual         :boolean
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :bigint

--- a/app/models/diaper_drive.rb
+++ b/app/models/diaper_drive.rb
@@ -6,7 +6,7 @@
 #  end_date        :date
 #  name            :string
 #  start_date      :date
-#  virtual         :boolean
+#  virtual         :boolean          default(FALSE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :bigint

--- a/app/views/diaper_drives/_form.html.erb
+++ b/app/views/diaper_drives/_form.html.erb
@@ -24,6 +24,12 @@
                             as: :date,
                             html5: true %>
               </div>
+
+              <div class="form-group">
+                <%= f.input :virtual, label: "Diaper Drive is Virtual?", wrapper: :input_group do %>
+                  <%= f.check_box :virtual, {class: "input-group-text", id: "virtual"}, "true" %>
+                <% end %>
+              </div>
             </div>
             <!-- /.card-body -->
             <div class="card-footer">

--- a/app/views/diaper_drives/index.html.erb
+++ b/app/views/diaper_drives/index.html.erb
@@ -79,7 +79,7 @@
                 <th>Diaper Drive Name</th>
                 <th>Start Date</th>
                 <th>End Date</th>
-                <th>Virtual?<th>
+                <th>Held Virtually?<th>
                 <th class="numeric">Quantity of Items</th>
                 <th class="numeric">Variety of Items</th>
                 <th class="numeric">In Kind Value</th>
@@ -92,7 +92,7 @@
                   <td><%= diaper_drive.name %></td>
                   <td><%= diaper_drive.start_date.strftime("%m-%d-%Y") %></td>
                   <td><%= diaper_drive.end_date.strftime("%m-%d-%Y") %></td>
-                  <td><%= is_virtual(diaper_drive) %></td>
+                  <td><%= is_virtual(diaper_drive: diaper_drive) %></td>
                   <td class="text-right"><%= diaper_drive.donation_quantity %></td>
                   <td class="text-right"><%= diaper_drive.distinct_items %></td>
                   <td class="text-right"><strong><%= dollar_value(diaper_drive.in_kind_value) %></strong></td>

--- a/app/views/diaper_drives/index.html.erb
+++ b/app/views/diaper_drives/index.html.erb
@@ -79,6 +79,7 @@
                 <th>Diaper Drive Name</th>
                 <th>Start Date</th>
                 <th>End Date</th>
+                <th>Virtual?<th>
                 <th class="numeric">Quantity of Items</th>
                 <th class="numeric">Variety of Items</th>
                 <th class="numeric">In Kind Value</th>
@@ -91,6 +92,7 @@
                   <td><%= diaper_drive.name %></td>
                   <td><%= diaper_drive.start_date.strftime("%m-%d-%Y") %></td>
                   <td><%= diaper_drive.end_date.strftime("%m-%d-%Y") %></td>
+                  <td><%= is_virtual(diaper_drive) %></td>
                   <td class="text-right"><%= diaper_drive.donation_quantity %></td>
                   <td class="text-right"><%= diaper_drive.distinct_items %></td>
                   <td class="text-right"><strong><%= dollar_value(diaper_drive.in_kind_value) %></strong></td>

--- a/db/migrate/20210107175100_add_virtual_to_diaper_drives.rb
+++ b/db/migrate/20210107175100_add_virtual_to_diaper_drives.rb
@@ -1,0 +1,8 @@
+# Organizations can remind Partners when their deadlines are for putting in their requests
+class AddVirtualToDiaperDrives < ActiveRecord::Migration[5.2]
+  def change
+    change_table :diaper_drives do |t|
+      t.boolean :virtual
+    end
+  end
+end

--- a/db/migrate/20210107175100_add_virtual_to_diaper_drives.rb
+++ b/db/migrate/20210107175100_add_virtual_to_diaper_drives.rb
@@ -2,7 +2,7 @@
 class AddVirtualToDiaperDrives < ActiveRecord::Migration[5.2]
   def change
     change_table :diaper_drives do |t|
-      t.boolean :virtual
+      t.boolean :virtual, default: false, null: false
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_201_230_203_200) do
+ActiveRecord::Schema.define(version: 20_210_107_175_100) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 20_201_230_203_200) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "organization_id"
+    t.boolean "virtual"
     t.index ["organization_id"], name: "index_diaper_drives_on_organization_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -127,7 +127,7 @@ ActiveRecord::Schema.define(version: 20_210_107_175_100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "organization_id"
-    t.boolean "virtual"
+    t.boolean "virtual", default: false, null: false
     t.index ["organization_id"], name: "index_diaper_drives_on_organization_id"
   end
 

--- a/spec/factories/diaper_drive.rb
+++ b/spec/factories/diaper_drive.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     name { "Test Drive" }
     start_date { Time.current }
     end_date { Time.current }
+    virtual { [true, false].sample }
     organization { Organization.try(:first) || create(:organization) }
   end
 end

--- a/spec/helpers/diaper_driver_helper_spec.rb
+++ b/spec/helpers/diaper_driver_helper_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe DiaperDriveHelper, type: :helper do
   describe '#is_virtual' do
-    context 'when diaper drive was held virtually' do
+    context 'when the diaper drive was held virtually' do
       let(:diaper_drive) { build(:diaper_drive, virtual: true) }
       subject { helper.is_virtual(diaper_drive: diaper_drive) }
 

--- a/spec/helpers/diaper_driver_helper_spec.rb
+++ b/spec/helpers/diaper_driver_helper_spec.rb
@@ -4,23 +4,27 @@ RSpec.describe DiaperDriveHelper, type: :helper do
   describe '#is_virtual' do
     context 'when diaper drive was held virtually' do
       let(:diaper_drive) { build(:diaper_drive, virtual: true) }
-      subject { helper.is_virtual(diaper_drive) }
+      subject { helper.is_virtual(diaper_drive: diaper_drive) }
 
       it { is_expected.to eq('Yes') }
     end
 
-    context 'when diaper drive wasn\'t held virtually' do
+    context 'when the diaper drive wasn\'t held virtually' do
       let(:diaper_drive) { build(:diaper_drive, virtual: false) }
-      subject { helper.is_virtual(diaper_drive) }
+      subject { helper.is_virtual(diaper_drive: diaper_drive) }
 
       it { is_expected.to eq('No') }
     end
 
-    context 'when diaper drive is not informed' do
-      let(:diaper_drive) { nil }
-      subject { helper.is_virtual(diaper_drive) }
+    context 'when a diaper drive is was not provided' do
+      it 'without argument' do
+        expect { helper.is_virtual }.to raise_error(ArgumentError, 'missing keyword: :diaper_drive')
+      end
 
-      it { is_expected.to eq('No') }
+      it 'with blank argument' do
+        argument = [nil, '', {}].sample
+        expect { helper.is_virtual(diaper_drive: argument) }.to raise_error(StandardError, 'No diaper drive was provided')
+      end
     end
   end
 end

--- a/spec/helpers/diaper_driver_helper_spec.rb
+++ b/spec/helpers/diaper_driver_helper_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DiaperDriveHelper, type: :helper do
       it { is_expected.to eq('No') }
     end
 
-    context 'when a diaper drive is was not provided' do
+    context 'when a diaper drive was not provided' do
       it 'without argument' do
         expect { helper.is_virtual }.to raise_error(ArgumentError, 'missing keyword: :diaper_drive')
       end

--- a/spec/helpers/diaper_driver_helper_spec.rb
+++ b/spec/helpers/diaper_driver_helper_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe DiaperDriveHelper, type: :helper do
+  describe '#is_virtual' do
+    context 'when diaper drive was held virtually' do
+      let(:diaper_drive) { build(:diaper_drive, virtual: true) }
+      subject { helper.is_virtual(diaper_drive) }
+
+      it { is_expected.to eq('Yes') }
+    end
+
+    context 'when diaper drive wasn\'t held virtually' do
+      let(:diaper_drive) { build(:diaper_drive, virtual: false) }
+      subject { helper.is_virtual(diaper_drive) }
+
+      it { is_expected.to eq('No') }
+    end
+
+    context 'when diaper drive is not informed' do
+      let(:diaper_drive) { nil }
+      subject { helper.is_virtual(diaper_drive) }
+
+      it { is_expected.to eq('No') }
+    end
+  end
+end

--- a/spec/models/diaper_drive_spec.rb
+++ b/spec/models/diaper_drive_spec.rb
@@ -6,6 +6,7 @@
 #  end_date        :date
 #  name            :string
 #  start_date      :date
+#  virtual         :boolean
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :bigint
@@ -16,7 +17,7 @@ require 'rails_helper'
 RSpec.describe DiaperDrive, type: :model do
   let!(:diaper_drive) { create(:diaper_drive) }
   let!(:donation) { create(:donation, :with_items, item_quantity: 7, diaper_drive: diaper_drive) }
-  let!(:donation_2) { create(:donation, :with_items, item_quantity: 9, diaper_drive: diaper_drive) }
+  let!(:donation2) { create(:donation, :with_items, item_quantity: 9, diaper_drive: diaper_drive) }
   let!(:extra_line_item) { create(:line_item, itemizable: donation, quantity: 4) }
 
   it "calculates donation quantity" do

--- a/spec/models/diaper_drive_spec.rb
+++ b/spec/models/diaper_drive_spec.rb
@@ -6,7 +6,7 @@
 #  end_date        :date
 #  name            :string
 #  start_date      :date
-#  virtual         :boolean
+#  virtual         :boolean          default(FALSE), not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #  organization_id :bigint

--- a/spec/system/diaper_drive_system_spec.rb
+++ b/spec/system/diaper_drive_system_spec.rb
@@ -35,4 +35,73 @@ RSpec.describe "Diaper Drives", type: :system, js: true do
       end
     end
   end
+
+  context 'when creating a normal Diaper Drive' do
+    let(:subject) { @url_prefix + "/diaper_drives/new" }
+
+    before { visit subject }
+
+    it 'must create a new Diaper Drive' do
+      expect do
+        fill_in 'Name', with: 'Normal 1'
+        fill_in 'Start Date', with: Time.zone.today
+        fill_in 'End Date', with: Time.zone.today + 4.hours
+        click_button 'Create Diaper drive'
+      end.to change(DiaperDrive, :count).by(1)
+    end
+
+    it 'must have correct attributes' do
+      fill_in 'Name', with: 'Normal 1'
+      fill_in 'Start Date', with: Time.zone.today
+      fill_in 'End Date', with: Time.zone.today + 1.day
+      click_button 'Create Diaper drive'
+
+      expect(DiaperDrive.last).to have_attributes({ name: 'Normal 1', start_date: Time.zone.today, end_date: Time.zone.today + 1.day, virtual: false })
+    end
+
+    it 'must have the success message' do
+      fill_in 'Name', with: 'Virtual 1'
+      fill_in 'Start Date', with: Time.zone.today
+      fill_in 'End Date', with: Time.zone.today + 4.hours
+      click_button 'Create Diaper drive'
+
+      expect(page.find('.alert')).to have_content('added')
+    end
+  end
+
+  context 'when creating a Virtual Diaper Drive' do
+    let(:subject) { @url_prefix + "/diaper_drives/new" }
+
+    before { visit subject }
+
+    it 'must create a new virtual Diaper Drive' do
+      expect do
+        fill_in 'Name', with: 'Virtual 1'
+        fill_in 'Start Date', with: Time.zone.today
+        fill_in 'End Date', with: Time.zone.today + 4.hours
+        check 'virtual'
+        click_button 'Create Diaper drive'
+      end.to change(DiaperDrive, :count).by(1)
+    end
+
+    it 'must have correct attributes' do
+      fill_in 'Name', with: 'Virtual 1'
+      fill_in 'Start Date', with: Time.zone.today
+      fill_in 'End Date', with: Time.zone.today + 1.day
+      check 'virtual'
+      click_button 'Create Diaper drive'
+
+      expect(DiaperDrive.last).to have_attributes({ name: 'Virtual 1', start_date: Time.zone.today, end_date: Time.zone.today + 1.day, virtual: true })
+    end
+
+    it 'must have the success message' do
+      fill_in 'Name', with: 'Virtual 1'
+      fill_in 'Start Date', with: Time.zone.today
+      fill_in 'End Date', with: Time.zone.today + 4.hours
+      check 'virtual'
+      click_button 'Create Diaper drive'
+
+      expect(page.find('.alert')).to have_content('added')
+    end
+  end
 end

--- a/spec/system/diaper_drive_system_spec.rb
+++ b/spec/system/diaper_drive_system_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "Diaper Drives", type: :system, js: true do
 
     before(:each) do
       @diaper_drives = [
-        create(:diaper_drive, name: "Test name 1", start_date: 3.weeks.ago, end_date: 2.weeks.ago),
-        create(:diaper_drive, name: "Test name 2", start_date: 2.weeks.ago, end_date: 1.week.ago)
+        create(:diaper_drive, name: "Test name 1", start_date: 3.weeks.ago, end_date: 2.weeks.ago, virtual: true),
+        create(:diaper_drive, name: "Test name 2", start_date: 2.weeks.ago, end_date: 1.week.ago, virtual: false)
       ]
       visit subject
     end
@@ -33,6 +33,14 @@ RSpec.describe "Diaper Drives", type: :system, js: true do
         expect(page).to have_xpath('//table/tbody/tr/td', text: d.name)
         expect(page).to have_xpath('//table/tbody/tr/td', text: d.name)
       end
+    end
+
+    it 'shows only one virtual diaper drive' do
+      expect(page).to have_text(/Yes/, maximum: 1)
+    end
+
+    it 'shows only one presential diaper drive' do
+      expect(page).to have_text(/No/, maximum: 1)
     end
   end
 

--- a/spec/system/diaper_drive_system_spec.rb
+++ b/spec/system/diaper_drive_system_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Diaper Drives", type: :system, js: true do
       expect(page).to have_text(/Yes/, maximum: 1)
     end
 
-    it 'shows only one presential diaper drive' do
+    it 'shows only one non-virtual diaper drive' do
       expect(page).to have_text(/No/, maximum: 1)
     end
   end


### PR DESCRIPTION
Resolves #2091

### Description
Create new fields on a diaper drive to denote if it was held virtually.


### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

* Migration to create the flag/field on database/model DiaperDrive
* Added the field on Diaper Drive form
* Specs to ensure that nothing was broke

### Screenshots
![image](https://user-images.githubusercontent.com/4561599/104070413-925f1e80-51e5-11eb-898b-d5b5c0509c8b.png)
![image](https://user-images.githubusercontent.com/4561599/104070422-9ab75980-51e5-11eb-96a6-bdceef6315d6.png)

