### PR TITLE
feat: show total qty & pkgs on distribution#show page

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -97,7 +97,7 @@ class DistributionsController < ApplicationController
     @distribution = Distribution.includes(:line_items).includes(:storage_location).find(params[:id])
     @line_items = @distribution.line_items
 
-    @total_quantity = @line_items.sum(&:quantity)
+    @total_quantity = @distribution.total_quantity
     @total_package_count = @line_items.sum { |item| item.has_packages || 0 }
     if @total_package_count.zero?
       @total_package_count = nil

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -96,6 +96,12 @@ class DistributionsController < ApplicationController
   def show
     @distribution = Distribution.includes(:line_items).includes(:storage_location).find(params[:id])
     @line_items = @distribution.line_items
+
+    @total_quantity = @line_items.sum(&:quantity)
+    @total_package_count = @line_items.sum { |item| item.has_packages&.ceil || 0 }
+    if @total_package_count.zero?
+      @total_package_count = nil
+    end
   end
 
   def edit

--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -98,7 +98,7 @@ class DistributionsController < ApplicationController
     @line_items = @distribution.line_items
 
     @total_quantity = @line_items.sum(&:quantity)
-    @total_package_count = @line_items.sum { |item| item.has_packages&.ceil || 0 }
+    @total_package_count = @line_items.sum { |item| item.has_packages || 0 }
     if @total_package_count.zero?
       @total_package_count = nil
     end

--- a/app/models/concerns/itemizable.rb
+++ b/app/models/concerns/itemizable.rb
@@ -85,6 +85,10 @@ module Itemizable
     line_items.sum(&:value_per_line_item)
   end
 
+  def total_quantity
+    line_items.total
+  end
+
   def to_a
     line_items.map do |l|
       # When the item isn't found, it's probably just inactive. This ensures it's available.

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -128,7 +128,7 @@ class Distribution < ApplicationRecord
       partner.name,
       issued_at.strftime("%F"),
       storage_location.name,
-      line_items.total,
+      total_quantity,
       cents_to_dollar(line_items.total_value),
       delivery_method,
       state,

--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -145,10 +145,6 @@ class Donation < ApplicationRecord
     storage_location.nil? ? "N/A" : storage_location.name
   end
 
-  def total_quantity
-    line_items.sum(:quantity)
-  end
-
   def self.csv_export_headers
     ["Source", "Date", "Donation Site", "Storage Location", "Quantity of Items", "Variety of Items"]
   end

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -51,10 +51,6 @@ class Purchase < ApplicationRecord
     vendor.nil? ? purchased_from : vendor.business_name
   end
 
-  def total_quantity
-    line_items.sum(:quantity)
-  end
-
   def amount_spent_in_dollars
     amount_spent_in_cents.to_d / 100
   end

--- a/app/views/distributions/_distribution_item_total.html.erb
+++ b/app/views/distributions/_distribution_item_total.html.erb
@@ -2,6 +2,6 @@
   <td><strong>Total:</strong></td>
   <td></td>
   <td><strong><%= dollar_value(@distribution.value_per_itemizable) %></strong></td>
-  <td></td>
-  <td></td>
+  <td><strong><%= @total_quantity %></strong></td>
+  <td><strong><%= @total_package_count %></strong></td>
 </tr>

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -90,6 +90,26 @@ RSpec.describe "Distributions", type: :request do
         get distribution_path(default_params.merge(id: create(:distribution).id))
         expect(response).to be_successful
       end
+
+      it "sums distribution totals accurately" do
+        distribution = create(:distribution, :with_items, item_quantity: 0)
+
+        item_quantity = 6
+        package_size = 2
+
+        item = create(:item, package_size: package_size)
+        create(
+          :line_item,
+          :distribution,
+          itemizable_id: distribution.id,
+          item_id: item.id,
+          quantity: item_quantity
+        )
+        get distribution_path(default_params.merge(id: distribution.id))
+
+        expect(assigns(:total_quantity)).to eq(item_quantity)
+        expect(assigns(:total_package_count)).to eq(item_quantity / package_size)
+      end
     end
 
     describe "GET #schedule" do


### PR DESCRIPTION
Resolves #2066

### Description

Show total quantity & packages on distribution#show page.

Note: The `has_packages` and `package_count` method names aren't ideal. Per their current output, I use `has_packages` to return a (possibly `nil`) numeric that I sum up, whereas `package_count` is unusable for that as it has already formatted the number as a string.

Further note: I used `ceil` when adding up the package counts. My reasoning was that, e.g., 2½ packages of item A and 2½ packages of item B means we're working with 6 physical packages, since there's no guarantee that it's possible to consolidate partial packages of different item types. My understanding might be incorrect though. Happy to make changes to calculation method.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Adds associated test for the value of the 2 new instance variables.

### Screenshots

Since there aren't Capybara view tests, I included screenshots showing a rendering of the distribution#show page using seed data (and another screenshot highlighting the `strong` element that, for the local seed I was using, happens to be empty for the package count total (since none of the items has a `package_size` in that seed)).

Before:
![before](https://user-images.githubusercontent.com/934707/104111045-e7656800-52ab-11eb-9bf9-82942bae6417.png)

After:
![after (with total quantity)](https://user-images.githubusercontent.com/934707/104111050-f0eed000-52ab-11eb-8679-f9c227ffb04c.png)

After (highlighted empty `strong` element where package count total would be):
![after (with package count total element highlighted)](https://user-images.githubusercontent.com/934707/104111061-082dbd80-52ac-11eb-9884-9ec0ab37278a.png)
