### PR TITLE
fixes small typo preventing tabs from displaying correctly

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -75,7 +75,7 @@
         <!-- Default box -->
         <div class="card card-primary card-outline card-outline-tabs">
           <div class="card-header p-0 border-bottom-0">
-            <ul class="nav nav-tas" id="custom-tabs-three-tab" role="tablist">
+            <ul class="nav nav-tabs" id="custom-tabs-three-tab" role="tablist">
               <li class="nav-item" class="active">
                 <a class="nav-link active" id="custom-tabs-three-home-tab" data-toggle="pill" href="#custom-tabs-three-home" role="tab" aria-controls="custom-tabs-three-home" aria-selected="true">Item
                   List</a>


### PR DESCRIPTION
Resolves #2060

### Description

A small typo was preventing tabs from displaying correctly.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested visually on local environment.

### Screenshots
BEFORE:

![102679058-7f66aa80-4161-11eb-8996-5dc3fd4b61d1](https://user-images.githubusercontent.com/66537500/105390552-c885a080-5bde-11eb-9d09-474606586c6c.png)

AFTER:

<img width="576" alt="Screen Shot 2021-01-21 at 11 37 39 AM" src="https://user-images.githubusercontent.com/66537500/105390802-100c2c80-5bdf-11eb-985d-57f6e085218b.png">
