### PR TITLE
2134 Update invitation instructions email

### DIFF
--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -332,7 +332,7 @@
       <div class="content">
 
         <!-- START CENTERED WHITE CONTAINER -->
-        <span class="preheader">This is preheader text. Some clients will show this text as a preview.</span>
+        <span class="preheader">Diaperbase inventory management system account invitation.</span>
         <table role="presentation" class="main">
 
           <!-- START MAIN CONTENT AREA -->
@@ -343,8 +343,8 @@
                   <td>
                     <p>Hi there!</p>
 
-                    <p>You've been invited to become a user of the Diaperbase inventory management system!</p>
-                    <p>Please click the link below to accept your invitation and create create an account.</p>
+                    <p>Your request has been approved and you're invited to become an user of the Diaperbase inventory management system!</p>
+                    <p>Please, click the button below to accept this invitation and create a password to access your account.</p>
                     <table role="presentation" border="0" cellpadding="0" cellspacing="0" class="btn btn-primary">
                       <tbody>
                       <tr>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'accounts@diaper.app'
+  config.mailer_sender = '"Diaper App" <accounts@diaper.app>'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -17,7 +17,7 @@ en:
         submit_button: "Set my password"
     mailer:
       invitation_instructions:
-        subject: "Invitation instructions"
+        subject: "Your Diaper App Account Approval"
         hello: "Hello %{email}"
         someone_invited_you: "Someone has invited you to %{url}, you can accept it through the link below."
         accept: "Accept invitation"


### PR DESCRIPTION
Resolves #2134 

### Description
Updates invitation email to make the registration process more clear for new users.

### Type of change

* Enhancement

### How Has This Been Tested?
* Go to **Users > New User** and register a new user, then you will receive the updated email.

### Screenshots

![Screenshot from 2021-01-26 19-52-54](https://user-images.githubusercontent.com/12713965/105916712-2582bb80-6010-11eb-8973-d3dc34da0db9.png)

