### PR TITLE
[2082] | Adds bullet gem for development env to identify n+1 queries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ group :development do
   gem "annotate"
   gem "binding_of_caller"
   gem "better_errors"
+  gem "bullet"
   gem "capistrano-rails"
   gem "capistrano-rvm"
   gem "capistrano-bundler"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,9 @@ GEM
     bugsnag (6.18.0)
       concurrent-ruby (~> 1.0)
     builder (3.2.4)
+    bullet (6.1.3)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capistrano (3.14.1)
       airbrussh (>= 1.0.0)
       i18n
@@ -482,6 +485,7 @@ GEM
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.7.0)
+    uniform_notifier (1.13.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.1.0)
@@ -524,6 +528,7 @@ DEPENDENCIES
   bootstrap-select-rails
   brakeman
   bugsnag
+  bullet
   capistrano-bundler
   capistrano-rails
   capistrano-rails-console

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,13 @@
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = false
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Verifies that versions and hashed value of the package contents in the project's package.json
   config.webpacker.check_yarn_integrity = true
   # Settings specified here will take precedence over those in config/application.rb.


### PR DESCRIPTION
Resolves #2082 

### Description
 * Adds bullet gem for development environment which will help in identifying n+1 queries and eager loading for contributors.

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested manually by running the application and observing bullet logs in log/bullet.log and also footers of the webpage.

### Screenshots
<img width="1439" alt="Screen Shot 2021-02-15 at 10 31 10 PM" src="https://user-images.githubusercontent.com/12405566/107976445-94d04780-6fdf-11eb-92fd-60d1151330d2.png">

