### PR TITLE
Utilize Azure Blob to store files instead of on the VM machine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 ruby "2.7.2"
 
 gem "api-auth", "~> 2.4"
+gem 'azure-storage', '~> 0.15.0.preview', require: false
 gem 'bootstrap', '~> 4.6.0'
 gem 'bootstrap-daterangepicker-rails'
 gem 'bootstrap-select-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,15 @@ GEM
     autoprefixer-rails (10.2.0.0)
       execjs
     awesome_print (1.8.0)
+    azure-core (0.1.15)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.10)
+      nokogiri (~> 1.6)
+    azure-storage (0.15.0.preview)
+      azure-core (~> 0.1)
+      faraday (~> 0.9)
+      faraday_middleware (~> 0.10)
+      nokogiri (~> 1.6, >= 1.6.8)
     bcrypt (3.1.16)
     better_errors (2.9.1)
       coderay (>= 1.0.0)
@@ -168,6 +177,10 @@ GEM
       i18n (>= 1.6, < 2)
     fakeredis (0.8.0)
       redis (~> 4.1)
+    faraday (0.17.4)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.14.0)
+      faraday (>= 0.7.4, < 1.0)
     ffi (1.14.2)
     filterrific (5.2.1)
     flipper (0.20.3)
@@ -269,6 +282,7 @@ GEM
     minitest (5.14.3)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
+    multipart-post (2.1.1)
     nenv (0.3.0)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
@@ -532,6 +546,7 @@ DEPENDENCIES
   annotate
   api-auth (~> 2.4)
   awesome_print
+  azure-storage (~> 0.15.0.preview)
   better_errors
   binding_of_caller
   bootstrap (~> 4.6.0)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -193,14 +193,6 @@ class Organization < ApplicationRecord
     reload
   end
 
-  def logo_path
-    if logo.attached?
-      logo.service_url
-    else
-      Organization::DIAPER_APP_LOGO.to_s
-    end
-  end
-
   def valid_items
     items.active.visible.map do |item|
       {

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -195,7 +195,7 @@ class Organization < ApplicationRecord
 
   def logo_path
     if logo.attached?
-      ActiveStorage::Blob.service.send(:path_for, logo.key).to_s
+      logo.service_url
     else
       Organization::DIAPER_APP_LOGO.to_s
     end

--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -9,7 +9,13 @@ class DistributionPdf
     font "OpenSans"
     font_size 10
 
-    image StringIO.open(organization.logo.download), fit: [325, 110]
+    logo_image = if organization.logo.attached?
+                   StringIO.open(organization.logo.download)
+                 else
+                   Organization::DIAPER_APP_LOGO
+                 end
+
+    image logo_image, fit: [325, 110]
 
     bounding_box [bounds.right - 225, bounds.top], width: 225, height: 50 do
       text organization.name, align: :right

--- a/app/pdfs/distribution_pdf.rb
+++ b/app/pdfs/distribution_pdf.rb
@@ -9,7 +9,7 @@ class DistributionPdf
     font "OpenSans"
     font_size 10
 
-    image organization.logo_path, fit: [325, 110]
+    image StringIO.open(organization.logo.download), fit: [325, 110]
 
     bounding_box [bounds.right - 225, bounds.top], width: 225, height: 50 do
       text organization.name, align: :right

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Store files locally.
-  config.active_storage.service = :local
+  config.active_storage.service = :azure
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -78,7 +78,7 @@ Rails.application.configure do
   config.log_formatter = ::Logger::Formatter.new
 
   # Store files locally.
-  config.active_storage.service = :local
+  config.active_storage.service = :azure
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -6,3 +6,9 @@ local:
 test:
   service: Disk
   root: <%= Rails.root.join("tmp/storage") %>
+
+azure:
+  service: AzureStorage
+  storage_account_name: <%= ENV['AZURE_STORAGE_ACCOUNT_NAME'] %>
+  storage_access_key: <%= ENV['AZURE_STORAGE_ACCESS_KEY'] %>
+  container: <%= ENV['AZURE_STORAGE_CONTAINER'] %>

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -278,21 +278,6 @@ RSpec.describe Organization, type: :model do
     end
   end
 
-  describe "logo_path" do
-    it "returns the the default logo path when no logo attached" do
-      org = build(:organization, logo: nil)
-      expect(org.logo_path).to include("/img/diaperbase-logo-full.png")
-    end
-
-    it "returns the logo path attached for the organization" do
-      org = build(:organization,
-                  logo: Rack::Test::UploadedFile.new(Rails.root.join("spec/fixtures/logo.jpg"),
-                                                     "image/jpeg"))
-
-      expect(org.logo_path).to include(Rails.root.join("tmp/storage").to_s)
-    end
-  end
-
   describe "geocode" do
     it "adds coordinates to the database" do
       expect(organization.latitude).to be_a(Float)


### PR DESCRIPTION
Resolves #2115

### Description
This PR updates the application to utilize a dedicated service like Azure Storage to store files rather than keeping them in the VM. Here are some main reasons why this is being done:
- Prevent situations where we lose files if the VM goes down
- Enables diaperbase to fetch images directly from partnerbase (will setup partnerbase to use the same Azure Storage container)

We will need to run this code in the console to transfer local files to azure:
```
module AsDownloadPatch
  # define a blob.open method
  def open(tempdir: nil, &block)
    ActiveStorage::Downloader.new(self, tempdir: tempdir).download_blob_to_tempfile(&block)
  end
end

ActiveStorage::Blob.send(:include, AsDownloadPatch)

def migrate(from, to)
  configs = Rails.configuration.active_storage.service_configurations
  from_service = ActiveStorage::Service.configure from, configs
  to_service   = ActiveStorage::Service.configure to, configs
  ActiveStorage::Blob.service = from_service
  puts "#{ActiveStorage::Blob.count} Blobs to go..."
  ActiveStorage::Blob.find_each do |blob|
    print '.'
    begin
      blob.open do |tf|
        checksum = blob.checksum
        to_service.upload(blob.key, tf, checksum: checksum)
      end
    rescue => e
      puts("Failed to migrate #{blob.key} due to #{e.message}")
    end
  end
end

migrate(:local, :azure)
```

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Tested on staging

### Screenshots
N/A
