### PR TITLE
Approve partners without using the legacy API approach

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ end
 group :development, :test do
   gem "awesome_print"
   gem "brakeman"
+  gem 'factory_bot_rails'
   gem "fakeredis", require: "fakeredis/rspec"
   gem "guard-rspec"
   gem "knapsack_pro"

--- a/Gemfile
+++ b/Gemfile
@@ -100,8 +100,8 @@ group :test do
   gem "capybara", "~> 3.35"
   gem "capybara-screenshot"
   gem "database_cleaner"
-  gem "factory_bot_rails"
   gem "launchy"
+  gem 'magic_test'
   gem "rails-controller-testing"
   gem "rspec-sidekiq"
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -265,6 +265,11 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.13)
+    magic_test (0.0.6)
+      capybara (~> 3.0)
+      pry
+      pry-stack_explorer
+      rails (~> 6.0)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (0.3.3)
@@ -327,6 +332,9 @@ GEM
     pry-remote (0.1.8)
       pry (~> 0.9)
       slop (~> 3.0)
+    pry-stack_explorer (0.4.9.3)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     public_suffix (4.0.6)
     puma (4.3.7)
       nio4r (~> 2.0)
@@ -593,6 +601,7 @@ DEPENDENCIES
   launchy
   letter_opener
   listen (~> 3.4.1)
+  magic_test
   mini_racer (~> 0.3.1)
   momentjs-rails
   newrelic_rpm

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -33,7 +33,7 @@ class PartnersController < ApplicationController
     if svc.errors.none?
       redirect_to partners_path, notice: "Partner approved!"
     else
-      redirect_to partners_path, error: svc.errors.full_messages
+      redirect_to partners_path, error: "Failed to approve partner because: #{svc.errors.full_messages}"
     end
   end
 

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -26,12 +26,12 @@ class PartnersController < ApplicationController
 
   def approve_application
     @partner = current_organization.partners.find(params[:id])
-    response = DiaperPartnerClient.put(partner_id: @partner.id, status: "approved")
-    if response.is_a?(Net::HTTPSuccess)
-      @partner.approved!
+    svc = PartnerApprovalService.new(partner: @partner)
+    svc.call
+    if svc.errors.none?
       redirect_to partners_path, notice: "Partner approved!"
     else
-      redirect_to partners_path, error: "Failed to update Partner data!"
+      redirect_to partners_path, error: svc.errors.full_messages
     end
   end
 

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -26,8 +26,10 @@ class PartnersController < ApplicationController
 
   def approve_application
     @partner = current_organization.partners.find(params[:id])
+
     svc = PartnerApprovalService.new(partner: @partner)
     svc.call
+
     if svc.errors.none?
       redirect_to partners_path, notice: "Partner approved!"
     else

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -56,7 +56,7 @@ class PartnersController < ApplicationController
   def approve_partner
     @partner = current_organization.partners.find(params[:id])
 
-    @partner_profile = partner.profile
+    @partner_profile = @partner.profile
     # Ensure that the ActiveStorage records associated with the
     # partner are available on the primary DB. If we do not do this,
     # partners would be uploading files that the diaperbase application

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -53,19 +53,17 @@ class PartnersController < ApplicationController
     @partner = current_organization.partners.new
   end
 
-  # NOTE(chaserx): this is confusing and could be renamed to reflect what it's returning/showing review_application
   def approve_partner
     @partner = current_organization.partners.find(params[:id])
 
-    # TODO: create a service that abstracts all of this from PartnersController, like PartnerDetailRetriever.call(id: params[:id])
+    @partner_profile = partner.profile
+    # Ensure that the ActiveStorage records associated with the
+    # partner are available on the primary DB. If we do not do this,
+    # partners would be uploading files that the diaperbase application
+    # cannot see.
+    @partner_profile.sync_attachments_from_partnerbase!
 
-    # TODO: move this code to new service,
-    # @diaper_partner = DiaperPartnerClient.get(id: params[:id])
-    # @diaper_partner = JSON.parse(@diaper_partner, symbolize_names: true) if @diaper_partner
-    @partners_partner = Partners::Partner.find_by(diaper_partner_id: @partner.id)
-    @partners_partner.sync_attachments_from_partnerbase!
-
-    @agency = @partners_partner.export_hash
+    @agency = @partner_profile.export_hash
   end
 
   def edit

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -58,13 +58,12 @@ class PartnersController < ApplicationController
     # TODO: create a service that abstracts all of this from PartnersController, like PartnerDetailRetriever.call(id: params[:id])
 
     # TODO: move this code to new service,
-    @diaper_partner = DiaperPartnerClient.get(id: params[:id])
-    @diaper_partner = JSON.parse(@diaper_partner, symbolize_names: true) if @diaper_partner
-    @agency = if @diaper_partner
-                @diaper_partner[:agency]
-              else
-                autovivifying_hash
-              end
+    # @diaper_partner = DiaperPartnerClient.get(id: params[:id])
+    # @diaper_partner = JSON.parse(@diaper_partner, symbolize_names: true) if @diaper_partner
+    @partners_partner = Partners::Partner.find_by(diaper_partner_id: @partner.id)
+    @partners_partner.sync_attachments_from_partnerbase!
+
+    @agency = @partners_partner.export_hash
   end
 
   def edit

--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -60,6 +60,21 @@ class Partner < ApplicationRecord
     status == 'deactivated'
   end
 
+  #
+  # Returns the Partners::Partner record which is stored in
+  # the partnerbase DB and contains mostly profile data of
+  # the partner user.
+  def profile
+    ::Partners::Partner.find_by(diaper_partner_id: id)
+  end
+
+  #
+  # Returns the primary Partners::User record which is the
+  # first & main user associated to a partner agency.
+  def primary_partner_user
+    profile&.user
+  end
+
   # better to extract this outside of the model
   def self.import_csv(csv, organization_id)
     csv.each do |row|

--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -105,6 +105,163 @@ module Partners
     def organization
       Organization.find_by!(id: diaper_bank_id)
     end
+
+    def export_hash
+      {
+        name: name,
+        distributor_type: distributor_type,
+        agency_type: agency_type,
+        other_agency_type: other_agency_type,
+        agency_mission: agency_mission,
+        address: {
+          address1: address1,
+          address2: address2,
+          city: city,
+          state: state,
+          zip_code: zip_code
+        },
+        media: {
+          website: website,
+          facebook: facebook,
+          twitter: twitter
+        },
+        stability: {
+          founded: founded,
+          form_990: form_990,
+          form_990_link: nil,
+          program_name: program_name,
+          program_description: program_description,
+          program_age: program_age,
+          case_management: case_management,
+          evidence_based: evidence_based,
+          evidence_based_description: evidence_based_description,
+          program_client_improvement: program_client_improvement,
+          diaper_use: diaper_use,
+          other_diaper_use: other_diaper_use,
+          currently_provide_diapers: currently_provide_diapers,
+          turn_away_child_care: turn_away_child_care
+        },
+        program_address: {
+          program_address1: program_address1,
+          program_address2: program_address2,
+          program_city: program_city,
+          program_state: program_state,
+          program_zip_code: program_zip_code
+        },
+        capacity: {
+          max_serve: max_serve,
+          incorporate_plan: incorporate_plan,
+          responsible_staff_position: responsible_staff_position,
+          storage_space: storage_space,
+          storage_space_description: describe_storage_space
+        },
+        population_served: {
+          income_requirement_description: income_requirement_desc,
+          serve_income_circumstances: serve_income_circumstances,
+          income_verification: income_verification,
+          internal_db: internal_db,
+          maac: maac,
+          enthnic_composition: {
+            african_american: population_black,
+            caucasian: population_white,
+            hispanic: population_hispanic,
+            asian: population_asian,
+            american_indain: population_american_indian,
+            pacific_island: population_island,
+            multi_racial: population_multi_racial,
+            other: population_other
+          },
+          zip_codes_served: zips_served,
+          poverty_information: {
+            at_fpl_or_below: at_fpl_or_below,
+            above_1_2_times_fpl: above_1_2_times_fpl,
+            greater_2_times_fpl: greater_2_times_fpl,
+            poverty_unknown: poverty_unknown
+          },
+          ages_served: ages_served
+        },
+        executive_director: {
+          name: executive_director_name,
+          phone: executive_director_phone,
+          email: executive_director_email
+        },
+        contact_person: {
+          name: program_contact_name,
+          phone: program_contact_phone,
+          mobile: program_contact_mobile,
+          email: program_contact_email
+        },
+        pick_up_person: {
+          method: pick_up_method,
+          name: pick_up_name,
+          phone: pick_up_phone,
+          email: pick_up_email
+        },
+        distribution: {
+          distribution_times: distribution_times,
+          new_client_times: new_client_times,
+          more_docs_required: more_docs_required
+        },
+        funding: {
+          source: sources_of_funding,
+          diapers: sources_of_diapers,
+          budget: diaper_budget,
+          diaper_funding_source: diaper_funding_source
+        },
+        documents: []
+      }
+    end
+
+    #
+    # Creates the neccessary ActiveStorage records to be able to
+    # fetch files uploaded on Partnerbase (legacy seperate app).
+    # This is due to the fact that ActiveStorage does not support
+    # multiple databases and is not built to be able to fetch
+    # files from the `partner_*` databases.
+    #
+    # NOTE: This should be deprecated or removed once Partnerbase
+    # users are uploading files directly in the partnerbase app
+    # hosted within diaperbase.
+    #
+    def sync_attachments_from_partnerbase!
+      ActiveRecord::Base.transaction do
+        attachment_records = Partners::Base.connection.execute(
+          <<-SQL
+            SELECT asb.*, asa.* filename FROM active_storage_blobs asb
+              LEFT JOIN active_storage_attachments asa ON asa.blob_id = asb.id
+              WHERE record_type = 'Partner'
+              AND record_id = '#{id}'
+          SQL
+        )
+
+        old_acs_attachments = ActiveStorage::Attachment.where(
+          record_type: self.class.name,
+          record_id: id
+        )
+        old_blob_ids = old_acs_attachments.map(&:blob_id)
+
+        # Using `delete_all` to avoid purging the actual file from the storage.
+        # The purpose of this code is not to purge but to just copy over records.
+        old_acs_attachments.delete_all
+        ActiveStorage::Blob.where(id: old_blob_ids).delete_all
+
+        attachment_records.each do |record|
+          acs_blob = ActiveStorage::Blob.new(record.slice(*ActiveStorage::Blob.attribute_names).except('id'))
+          acs_blob.metadata = JSON.parse(record['metadata'])
+          acs_blob.save!
+
+          ActiveStorage::Attachment.create!({
+                                              name: record['name'],
+                                              record_type: self.class.name,
+                                              record_id: id,
+                                              blob_id: acs_blob.id
+                                            })
+        end
+      rescue StandardError => e
+        Bugsnag.notify("Failed to import attachments from partnerbase on Partners::Partner record #{id} due to #{e.message}")
+        raise ActiveRecord::Rollback
+      end
+    end
   end
 end
 

--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -106,6 +106,10 @@ module Partners
       Organization.find_by!(id: diaper_bank_id)
     end
 
+    #
+    # TODO - deprecated this export_hash method and instead
+    # directly expose columns in the approve_partner.html.erb page
+    #
     def export_hash
       {
         name: name,

--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -106,6 +106,10 @@ module Partners
       Organization.find_by!(id: diaper_bank_id)
     end
 
+    def partner
+      ::Partner.find_by!(id: diaper_partner_id)
+    end
+
     #
     # TODO - deprecated this export_hash method and instead
     # directly expose columns in the approve_partner.html.erb page

--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -246,7 +246,7 @@ module Partners
           record_type: self.class.name,
           record_id: id
         )
-        old_blob_ids = old_acs_attachments.map(&:blob_id)
+        old_blob_ids = old_acs_attachments.pluck(:blob_id)
 
         # Using `delete_all` to avoid purging the actual file from the storage.
         # The purpose of this code is not to purge but to just copy over records.
@@ -272,4 +272,3 @@ module Partners
     end
   end
 end
-

--- a/app/services/partner_approval_service.rb
+++ b/app/services/partner_approval_service.rb
@@ -9,7 +9,7 @@ class PartnerApprovalService
     return self unless valid?
 
     Partners::Base.transaction do
-      partners_partner.update!(partner_status: 'approval')
+      partner.profile.update!(partner_status: 'approval')
       partner.approved!
     rescue StandardError => e
       errors.add(:base, e.message)
@@ -29,9 +29,5 @@ class PartnerApprovalService
     end
 
     errors.none?
-  end
-
-  def partners_partner
-    Partners::Partner.find_by!(diaper_partner_id: partner.id)
   end
 end

--- a/app/services/partner_approval_service.rb
+++ b/app/services/partner_approval_service.rb
@@ -1,0 +1,37 @@
+class PartnerApprovalService
+  include ServiceObjectErrorsMixin
+
+  def initialize(partner:)
+    @partner = partner
+  end
+
+  def call
+    return self unless valid?
+
+    Partners::Base.transaction do
+      partners_partner.update!(partner_status: 'approval')
+      partner.approved!
+    rescue StandardError => e
+      errors.add(:base, e.message)
+      raise ActiveRecord::Rollback
+    end
+
+    self
+  end
+
+  private
+
+  attr_reader :partner
+
+  def valid?
+    unless partner.awaiting_review?
+      errors.add(:partner, 'is not waiting for approval')
+    end
+
+    errors.none?
+  end
+
+  def partners_partner
+    Partners::Partner.find_by!(diaper_partner_id: partner.id)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
   <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
   <link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
-
+  <%= render 'magic_test/support' if Rails.env.test? %>
 </head>
 <body id="<%= params.fetch(:controller, '').gsub(/[^\w\d]+/,'_') %>" class="<%= params.fetch(:action, '') %> hold-transition sidebar-mini layout-fixed">
 <!-- Site wrapper -->

--- a/app/views/partners/approve_partner.html.erb
+++ b/app/views/partners/approve_partner.html.erb
@@ -44,7 +44,7 @@
                 <p>Proof of Agency Status
                   <% if @partners_partner.proof_of_partner_status.attached? %>
                     <!-- NOTE: The actual download link may not work in local storage mode due to file locations being seperate locally. -->
-                    (Link): <%= link_to @partners_partner.proof_of_partner_status.filename, @partners_partner.proof_of_partner_status.service_url %>
+                    (Link): <%= link_to @partners_partner.proof_of_partner_status.filename, rails_blob_path(@partners_partner.proof_of_partner_status, disposition: 'attachment') %>
                   <% end %>
                 </p>
                 <p>Agency Mission: <%= @agency[:agency_mission] %></p>
@@ -68,7 +68,7 @@
                   <p>Form 990
                   <% if @partners_partner.proof_of_form_990.attached? %>
                     <!-- NOTE: The actual download link may not work in local storage mode due to file locations being seperate locally. -->
-                    (Link): <%= link_to @partners_partner.proof_of_form_990.filename, @partners_partner.proof_of_form_990.service_url %>
+                    (Link): <%= link_to @partners_partner.proof_of_form_990.filename, rails_blob_path(@partners_partner.proof_of_form_990, disposition: 'attachment') %>
                   <% end %>
                   </p>
                   <p>Program Name <%= @agency[:stability][:program_name] %></p>
@@ -178,7 +178,7 @@
                   <h2>Other Documents</h2>
                   <ul>
                     <% @partners_partner.documents.each do |document| %>
-                      <li><%= link_to document.filename, document.service_url, target: :_blank %></li>
+                      <li><%= link_to document.filename, rails_blob_path(document, disposition: 'attachment') %></li>
                     <% end %>
                   </ul>
                   </div>

--- a/app/views/partners/approve_partner.html.erb
+++ b/app/views/partners/approve_partner.html.erb
@@ -42,9 +42,9 @@
                 <p>Distributor Type <%= @agency[:distributor_type] %></p>
                 <p>Agency Type: <%= @agency[:agency_type] %></p>
                 <p>Proof of Agency Status
-                  <% if @partners_partner.proof_of_partner_status.attached? %>
+                  <% if @partner_profile.proof_of_partner_status.attached? %>
                     <!-- NOTE: The actual download link may not work in local storage mode due to file locations being seperate locally. -->
-                    (Link): <%= link_to @partners_partner.proof_of_partner_status.filename, rails_blob_path(@partners_partner.proof_of_partner_status, disposition: 'attachment') %>
+                    (Link): <%= link_to @partner_profile.proof_of_partner_status.filename, rails_blob_path(@partner_profile.proof_of_partner_status, disposition: 'attachment') %>
                   <% end %>
                 </p>
                 <p>Agency Mission: <%= @agency[:agency_mission] %></p>
@@ -64,11 +64,11 @@
                 <% if @fields.include?('agency_stability') || @fields.empty? %>
                   <h2>Agency Stability</h2>
                   <p>Founded <%= @agency[:stability][:founded] %></p>
-                  <p>Form 990: <%= @partners_partner.proof_of_form_990.attached? ? 'Yes' : 'No' %></p>
+                  <p>Form 990: <%= @partner_profile.proof_of_form_990.attached? ? 'Yes' : 'No' %></p>
                   <p>Form 990
-                  <% if @partners_partner.proof_of_form_990.attached? %>
+                  <% if @partner_profile.proof_of_form_990.attached? %>
                     <!-- NOTE: The actual download link may not work in local storage mode due to file locations being seperate locally. -->
-                    (Link): <%= link_to @partners_partner.proof_of_form_990.filename, rails_blob_path(@partners_partner.proof_of_form_990, disposition: 'attachment') %>
+                    (Link): <%= link_to @partner_profile.proof_of_form_990.filename, rails_blob_path(@partner_profile.proof_of_form_990, disposition: 'attachment') %>
                   <% end %>
                   </p>
                   <p>Program Name <%= @agency[:stability][:program_name] %></p>
@@ -177,7 +177,7 @@
                 <% if @fields.include?('attached_documents') || @fields.empty? %>
                   <h2>Other Documents</h2>
                   <ul>
-                    <% @partners_partner.documents.each do |document| %>
+                    <% @partner_profile.documents.each do |document| %>
                       <li><%= link_to document.filename, rails_blob_path(document, disposition: 'attachment') %></li>
                     <% end %>
                   </ul>

--- a/app/views/partners/approve_partner.html.erb
+++ b/app/views/partners/approve_partner.html.erb
@@ -44,11 +44,7 @@
                 <p>Proof of Agency Status
                   <% if @partners_partner.proof_of_partner_status.attached? %>
                     <!-- NOTE: The actual download link may not work in local storage mode due to file locations being seperate locally. -->
-                    (Link): <%=
-                      link_to @partners_partner.proof_of_partner_status.filename,
-                        Rails.application.config.active_storage.service == :azure ?
-                        @partners_partner.proof_of_partner_status.service_url : Rails.application.routes.url_helpers.rails_blob_url(@partners_partner.proof_of_partner_status, only_path: true)
-                    %>
+                    (Link): <%= link_to @partners_partner.proof_of_partner_status.filename, @partners_partner.proof_of_partner_status.service_url %>
                   <% end %>
                 </p>
                 <p>Agency Mission: <%= @agency[:agency_mission] %></p>
@@ -72,11 +68,7 @@
                   <p>Form 990
                   <% if @partners_partner.proof_of_form_990.attached? %>
                     <!-- NOTE: The actual download link may not work in local storage mode due to file locations being seperate locally. -->
-                    (Link): <%=
-                      link_to @partners_partner.proof_of_form_990.filename,
-                        Rails.application.config.active_storage.service == :azure ?
-                        @partners_partner.proof_of_form_990.service_url : Rails.application.routes.url_helpers.rails_blob_url(@partners_partner.proof_of_form_990, only_path: true)
-                    %>
+                    (Link): <%= link_to @partners_partner.proof_of_form_990.filename, @partners_partner.proof_of_form_990.service_url %>
                   <% end %>
                   </p>
                   <p>Program Name <%= @agency[:stability][:program_name] %></p>
@@ -186,11 +178,7 @@
                   <h2>Other Documents</h2>
                   <ul>
                     <% @partners_partner.documents.each do |document| %>
-                      <li><%= link_to document.filename,
-                        Rails.application.config.active_storage.service == :azure ?
-                          document.service_url : Rails.application.routes.url_helpers.rails_blob_url(document, only_path: true),
-                        target: :_blank
-                      %></li>
+                      <li><%= link_to document.filename, document.service_url, target: :_blank %></li>
                     <% end %>
                   </ul>
                   </div>

--- a/app/views/partners/approve_partner.html.erb
+++ b/app/views/partners/approve_partner.html.erb
@@ -42,7 +42,15 @@
                 <p>Distributor Type <%= @agency[:distributor_type] %></p>
                 <p>Agency Type: <%= @agency[:agency_type] %></p>
                 <p>Proof of Agency Status
-                  (Link): <%= link_to File.basename(@agency[:proof_of_agency_status]), documentation_url(@agency[:proof_of_agency_status]), target: :_blank %></p>
+                  <% if @partners_partner.proof_of_partner_status.attached? %>
+                    <!-- NOTE: The actual download link may not work in local storage mode due to file locations being seperate locally. -->
+                    (Link): <%=
+                      link_to @partners_partner.proof_of_partner_status.filename,
+                        Rails.application.config.active_storage.service == :azure ?
+                        @partners_partner.proof_of_partner_status.service_url : Rails.application.routes.url_helpers.rails_blob_url(@partners_partner.proof_of_partner_status, only_path: true)
+                    %>
+                  <% end %>
+                </p>
                 <p>Agency Mission: <%= @agency[:agency_mission] %></p>
                 <p>Address Line 1: <%= @agency[:address][:address1] %></p>
                 <p>Address Line 2: <%= @agency[:address][:address2] %></p>
@@ -60,9 +68,17 @@
                 <% if @fields.include?('agency_stability') || @fields.empty? %>
                   <h2>Agency Stability</h2>
                   <p>Founded <%= @agency[:stability][:founded] %></p>
-                  <p>Form 990: <%= @agency[:stability][:form_990] ? 'Yes' : 'No' %></p>
+                  <p>Form 990: <%= @partners_partner.proof_of_form_990.attached? ? 'Yes' : 'No' %></p>
                   <p>Form 990
-                    Link: <%= link_to File.basename(@agency[:stability][:form_990_link]), documentation_url(@agency[:stability][:form_990_link]), target: :_blank %></p>
+                  <% if @partners_partner.proof_of_form_990.attached? %>
+                    <!-- NOTE: The actual download link may not work in local storage mode due to file locations being seperate locally. -->
+                    (Link): <%=
+                      link_to @partners_partner.proof_of_form_990.filename,
+                        Rails.application.config.active_storage.service == :azure ?
+                        @partners_partner.proof_of_form_990.service_url : Rails.application.routes.url_helpers.rails_blob_url(@partners_partner.proof_of_form_990, only_path: true)
+                    %>
+                  <% end %>
+                  </p>
                   <p>Program Name <%= @agency[:stability][:program_name] %></p>
                   <p>Program Description <%= @agency[:stability][:program_description] %></p>
                   <p>Program Age <%= @agency[:stability][:program_age] %></p>
@@ -169,8 +185,12 @@
                 <% if @fields.include?('attached_documents') || @fields.empty? %>
                   <h2>Other Documents</h2>
                   <ul>
-                    <% @agency[:documents].each do |document| %>
-                      <li><%= link_to File.basename(document[:document_link]), documentation_url(document[:document_link]), target: :_blank %></li>
+                    <% @partners_partner.documents.each do |document| %>
+                      <li><%= link_to document.filename,
+                        Rails.application.config.active_storage.service == :azure ?
+                          document.service_url : Rails.application.routes.url_helpers.rails_blob_url(document, only_path: true),
+                        target: :_blank
+                      %></li>
                     <% end %>
                   </ul>
                   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -165,7 +165,7 @@ note = [
   # **We have two seperate database. One for diaperbase and the other for partnerbase**
   # ----------------------------------------------------------------------------
 
-  partner = Partners::Partner.create!(
+  partner = Partners::Partner.create!({
     executive_director_name: Faker::Name.name,
     program_contact_name: Faker::Name.name,
     name: p.name,
@@ -181,7 +181,7 @@ note = [
     executive_director_email: p.email,
     partner_status: partner_status_map[partner_option[:status]] || "pending",
     status_in_diaper_base: partner_option[:status]
-  )
+  })
 
   Partners::User.create!(
     name: Faker::Name.name,

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -19,14 +19,23 @@ FactoryBot.define do
     sequence(:name) { |n| "Leslie Sue, the #{n}" }
     sequence(:email) { |n| "leslie#{n}@gmail.com" }
     send_reminders { true }
-    organization { Organization.try(:first) || create(:organization) }
-  end
+    organization_id { Organization.try(:first).try(:id) || create(:organization).id }
 
-  trait :approved do
-    status { :approved }
-  end
+    trait :approved do
+      status { :approved }
+    end
 
-  trait :uninvited do
-    status { :uninvited }
+    trait :uninvited do
+      status { :uninvited }
+    end
+
+    trait :awaiting_review do
+      status { :awaiting_review }
+    end
+
+    after(:create) do |partner, evaluator|
+      # Create associated records on partnerbase DB
+      create(:partners_partner, diaper_bank_id: partner.organization_id, diaper_partner_id: partner.id, name: partner.name)
+    end
   end
 end

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -33,9 +33,10 @@ FactoryBot.define do
       status { :awaiting_review }
     end
 
-    after(:create) do |partner, evaluator|
+    after(:create) do |partner, _evaluator|
       # Create associated records on partnerbase DB
-      create(:partners_partner, diaper_bank_id: partner.organization_id, diaper_partner_id: partner.id, name: partner.name)
+      partners_partner = create(:partners_partner, diaper_bank_id: partner.organization_id, diaper_partner_id: partner.id, name: partner.name)
+      create(:partners_user, partner_id: partners_partner.id)
     end
   end
 end

--- a/spec/factories/partners.rb
+++ b/spec/factories/partners.rb
@@ -36,7 +36,11 @@ FactoryBot.define do
     after(:create) do |partner, _evaluator|
       # Create associated records on partnerbase DB
       partners_partner = create(:partners_partner, diaper_bank_id: partner.organization_id, diaper_partner_id: partner.id, name: partner.name)
-      create(:partners_user, partner_id: partners_partner.id)
+      Partners::User.create!(
+        email: partner.email,
+        partner: partners_partner,
+        password: 'password'
+      )
     end
   end
 end

--- a/spec/factories/partners/partner.rb
+++ b/spec/factories/partners/partner.rb
@@ -1,11 +1,5 @@
 FactoryBot.define do
   factory :partners_partner, class: Partners::Partner do
     diaper_bank_id { Organization.try(:first).id || create(:organization).id }
-
-    after(:build) do |partners_partner, _option|
-      org_partner = FactoryBot.create(:partner)
-      partners_partner.name = org_partner.name
-      partners_partner.diaper_partner_id = org_partner.id
-    end
   end
 end

--- a/spec/factories/partners/partner.rb
+++ b/spec/factories/partners/partner.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
 
     after(:build) do |partners_partner, _option|
       org_partner = FactoryBot.create(:partner)
+      partners_partner.name = org_partner.name
       partners_partner.diaper_partner_id = org_partner.id
     end
   end

--- a/spec/factories/partners/user.rb
+++ b/spec/factories/partners/user.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :partners_user, class: Partners::User do
     email { Faker::Internet.email }
     password { 'password' }
+    associaton { :partners_partner }
   end
 end
 

--- a/spec/factories/partners/user.rb
+++ b/spec/factories/partners/user.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :partners_user, class: Partners::User do
     email { Faker::Internet.email }
     password { 'password' }
-    associaton { :partners_partner }
+    association :partner
   end
 end
 

--- a/spec/factories/partners/user.rb
+++ b/spec/factories/partners/user.rb
@@ -2,11 +2,6 @@ FactoryBot.define do
   factory :partners_user, class: Partners::User do
     email { Faker::Internet.email }
     password { 'password' }
-
-    after(:build) do |partner_user, _option|
-      partner = FactoryBot.create(:partners_partner, name: partner_user.email)
-      partner_user.partner_id = partner.id
-    end
   end
 end
 

--- a/spec/factories/partners/user.rb
+++ b/spec/factories/partners/user.rb
@@ -1,9 +1,0 @@
-FactoryBot.define do
-  factory :partners_user, class: Partners::User do
-    email { Faker::Internet.email }
-    password { 'password' }
-    association :partner
-  end
-end
-
-

--- a/spec/models/partner_spec.rb
+++ b/spec/models/partner_spec.rb
@@ -63,30 +63,6 @@ RSpec.describe Partner, type: :model do
       end
     end
   end
-  # context "Callbacks >" do
-  #   describe "when DIAPER_PARTNER_URL is present" do
-  #     let(:diaper_partner_url) { "http://diaper.partner.io" }
-  #     let(:callback_url) { "#{diaper_partner_url}/partners" }
-  #
-  #     before do
-  #       stub_env "DIAPER_PARTNER_URL", diaper_partner_url
-  #       stub_env "DIAPER_PARTNER_SECRET_KEY", "secretkey123"
-  #       stub_request :post, callback_url
-  #     end
-  #
-  #     it "notifies the Diaper Partner app" do
-  #       partner = create :partner
-  #       headers = {
-  #         "Authorization" => /APIAuth diaperbase:.*/,
-  #         "Content-Type" => "application/x-www-form-urlencoded"
-  #       }
-  #       body = URI.encode_www_form partner.attributes
-  #       expect(WebMock).to have_requested(:post, callback_url)
-  #         .with(headers: headers, body: body).once
-  #     end
-  #
-  #   end
-  # end
 
   describe '#deactivated?' do
     subject { partner.deactivated? }
@@ -110,6 +86,25 @@ RSpec.describe Partner, type: :model do
       it 'should return false' do
         expect(subject).to eq(false)
       end
+    end
+  end
+
+  describe '#profile' do
+    subject { partner.profile }
+    let(:partner) { create(:partner) }
+
+    it 'should return the associated Partners::Partner record' do
+      expect(subject).to eq(Partners::Partner.find_by(diaper_partner_id: partner.id))
+    end
+  end
+
+  describe '#primary_partner_user' do
+    subject { partner.primary_partner_user }
+    let(:partner) { create(:partner) }
+
+    it 'should return the asssociated primary Partners::User' do
+      primary_partner_user = Partners::User.find_by(partner_id: partner.profile.id)
+      expect(subject).to eq(primary_partner_user)
     end
   end
 

--- a/spec/requests/partners/requests_spec.rb
+++ b/spec/requests/partners/requests_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe "/partners/requests", type: :request do
   describe "GET #index" do
     subject { -> { get partners_requests_path } }
-    let(:partner_user) { FactoryBot.create(:partners_user) }
+    let(:partner_user) { Partners::Partner.find_by(diaper_partner_id: partner.id).user }
+    let(:partner) { create(:partner) }
 
     before do
       sign_in(partner_user, scope: :partner_user)
@@ -17,7 +18,8 @@ RSpec.describe "/partners/requests", type: :request do
 
   describe "GET #new" do
     subject { -> { get new_partners_request_path } }
-    let(:partner_user) { FactoryBot.create(:partners_user) }
+    let(:partner_user) { Partners::Partner.find_by(diaper_partner_id: partner.id).user }
+    let(:partner) { create(:partner) }
 
     before do
       sign_in(partner_user, scope: :partner_user)
@@ -49,7 +51,8 @@ RSpec.describe "/partners/requests", type: :request do
         }
       }
     end
-    let(:partner_user) { FactoryBot.create(:partners_user) }
+    let(:partner_user) { Partners::Partner.find_by(diaper_partner_id: partner.id).user }
+    let(:partner) { create(:partner) }
 
     before do
       sign_in(partner_user, scope: :partner_user)

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe "Partners", type: :request do
   end
 
   describe "GET #approve_partner" do
-    subject { -> { get approve_partner_partner_path(id: partner.diaper_partner_id, organization_id: partner.diaper_bank_id) } }
-    let(:partner) { FactoryBot.create(:partners_user).partner }
+    subject { -> { get approve_partner_partner_path(id: partner.id, organization_id: partner.organization_id) } }
+    let(:partner) { create(:partner) }
 
     it 'should contain the proper page header' do
       subject.call
@@ -97,9 +97,9 @@ RSpec.describe "Partners", type: :request do
       expect(response.body).to include("#{partner.name} - Application Details")
     end
 
-    context 'when the partner is awaiting approval' do
+    context 'when the partner is awaiting review' do
       before do
-        Partner.find(partner.diaper_partner_id).update!(status: 2)
+        partner.awaiting_review!
         subject.call
       end
 
@@ -108,9 +108,9 @@ RSpec.describe "Partners", type: :request do
       end
     end
 
-    context 'when the partner is not awaiting approval' do
+    context 'when the partner is not awaiting review' do
       before do
-        Partner.find(partner.diaper_partner_id).update!(status: 0)
+        partner.invited!
         subject.call
       end
 

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -319,7 +319,7 @@ RSpec.describe "Partners", type: :request do
 
       it 'should redirect to the partners index page with a failure flash message' do
         expect(response).to redirect_to(partners_path(organization_id: @organization.to_param))
-        expect(flash[:error]).to eq(fake_error_msg)
+        expect(flash[:error]).to eq("Failed to approve partner because: #{fake_error_msg}")
       end
     end
   end

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -87,6 +87,39 @@ RSpec.describe "Partners", type: :request do
     end
   end
 
+  describe "GET #approve_partner" do
+    subject { -> { get approve_partner_partner_path(id: partner.diaper_partner_id, organization_id: partner.diaper_bank_id) } }
+    let(:partner) { FactoryBot.create(:partners_user).partner }
+
+    it 'should contain the proper page header' do
+      subject.call
+      expect(response.body).to include("Partner Approval Request")
+      expect(response.body).to include("#{partner.name} - Application Details")
+    end
+
+    context 'when the partner is awaiting approval' do
+      before do
+        Partner.find(partner.diaper_partner_id).update!(status: 2)
+        subject.call
+      end
+
+      it 'should show the Approve Partner button' do
+        expect(response.body).to include("Approve Partner")
+      end
+    end
+
+    context 'when the partner is not awaiting approval' do
+      before do
+        Partner.find(partner.diaper_partner_id).update!(status: 0)
+        subject.call
+      end
+
+      it 'should not show the Approve Partner button' do
+        expect(response.body).not_to include("Approve Partner")
+      end
+    end
+  end
+
   describe "GET #new" do
     it "returns http success" do
       get new_partner_path(default_params)

--- a/spec/services/partner_approval_service_spec.rb
+++ b/spec/services/partner_approval_service_spec.rb
@@ -33,6 +33,9 @@ describe PartnerApprovalService do
 
       it 'should change the partner status to approved' do
         expect { subject }.to change { partner.reload.approved? }.from(false).to(true)
+      end
+
+      it 'should change the partners_partner partner_status' do
         expect { subject }.to change { partners_partner.reload.partner_status }.to('approval')
       end
 
@@ -50,6 +53,9 @@ describe PartnerApprovalService do
 
           it 'should not change the partner status to approved' do
             expect { subject }.not_to change { partner.reload.approved? }
+          end
+
+          it 'should not change the partners_partner partner_status' do
             expect { subject }.not_to change { partners_partner.reload.partner_status }
           end
         end

--- a/spec/services/partner_approval_service_spec.rb
+++ b/spec/services/partner_approval_service_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+describe PartnerApprovalService do
+  describe '#call' do
+    subject { described_class.new(partner: partner).call }
+    let(:partner) { partners_partner.partner }
+    let(:partners_partner) { create(:partners_partner, partner_status: partner_status) }
+    let(:partner_status) { 'pending' }
+
+    before do
+      partner.awaiting_review!
+    end
+
+    context 'when the arguments are incorrect' do
+      context 'because the partner is not awaiting_review' do
+        before do
+          partner.invited!
+        end
+
+        it 'should return the PartnerApprovalService object with an error' do
+          result = subject
+
+          expect(result).to be_a_kind_of(PartnerApprovalService)
+          expect(result.errors[:partner]).to eq(["is not waiting for approval"])
+        end
+      end
+    end
+
+    context 'when the arguments are correct' do
+      it 'should have no errors' do
+        expect(subject.errors).to be_empty
+      end
+
+      it 'should change the partner status to approved' do
+        expect { subject }.to change { partner.reload.approved? }.from(false).to(true)
+        expect { subject }.to change { partners_partner.reload.partner_status }.to('approval')
+      end
+
+      context 'but a unexpected error occured during the save' do
+        let(:error_message) { 'boom' }
+
+        context 'for partner approval' do
+          before do
+            allow(partner).to receive(:approved!).and_raise(error_message)
+          end
+
+          it 'should have an error with the raised error' do
+            expect(subject.errors[:base]).to eq([error_message])
+          end
+
+          it 'should not change the partner status to approved' do
+            expect { subject }.not_to change { partner.reload.approved? }
+            expect { subject }.not_to change { partners_partner.reload.partner_status }
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/services/partner_approval_service_spec.rb
+++ b/spec/services/partner_approval_service_spec.rb
@@ -4,8 +4,7 @@ describe PartnerApprovalService do
   describe '#call' do
     subject { described_class.new(partner: partner).call }
     let(:partner) { create(:partner) }
-    let(:partners_partner) { Partners::Partner.find_by(diaper_partner_id: partner.id) }
-    let(:partner_status) { 'pending' }
+    let(:partner_profile) { partner.profile }
 
     before do
       partner.awaiting_review!
@@ -35,8 +34,8 @@ describe PartnerApprovalService do
         expect { subject }.to change { partner.reload.approved? }.from(false).to(true)
       end
 
-      it 'should change the partners_partner partner_status' do
-        expect { subject }.to change { partners_partner.reload.partner_status }.to('approval')
+      it 'should change the partner profile partner_status' do
+        expect { subject }.to change { partner_profile.reload.partner_status }.to('approval')
       end
 
       context 'but a unexpected error occured during the save' do
@@ -55,8 +54,8 @@ describe PartnerApprovalService do
             expect { subject }.not_to change { partner.reload.approved? }
           end
 
-          it 'should not change the partners_partner partner_status' do
-            expect { subject }.not_to change { partners_partner.reload.partner_status }
+          it 'should not change the partner_profile partner_status' do
+            expect { subject }.not_to change { partner_profile.reload.partner_status }
           end
         end
       end

--- a/spec/services/partner_approval_service_spec.rb
+++ b/spec/services/partner_approval_service_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 describe PartnerApprovalService do
   describe '#call' do
     subject { described_class.new(partner: partner).call }
-    let(:partner) { partners_partner.partner }
-    let(:partners_partner) { create(:partners_partner, partner_status: partner_status) }
+    let(:partner) { create(:partner) }
+    let(:partners_partner) { Partners::Partner.find_by(diaper_partner_id: partner.id) }
     let(:partner_status) { 'pending' }
 
     before do

--- a/spec/services/partners/request_create_service_spec.rb
+++ b/spec/services/partners/request_create_service_spec.rb
@@ -10,7 +10,7 @@ describe Partners::RequestCreateService do
         item_requests_attributes: item_requests_attributes
       }
     end
-    let(:partner_user) { Partners::Partner.find_by(diaper_partner_id: partner.id).user }
+    let(:partner_user) { partner.primary_partner_user }
     let(:partner) { create(:partner) }
     let(:comments) { Faker::Lorem.paragraph }
     let(:item_requests_attributes) do

--- a/spec/services/partners/request_create_service_spec.rb
+++ b/spec/services/partners/request_create_service_spec.rb
@@ -10,7 +10,8 @@ describe Partners::RequestCreateService do
         item_requests_attributes: item_requests_attributes
       }
     end
-    let(:partner_user) { FactoryBot.create(:partners_user) }
+    let(:partner_user) { partners.partner.find_by(diaper_partner_id: partner.id).user }
+    let(:partner) { create(:partner) }
     let(:comments) { Faker::Lorem.paragraph }
     let(:item_requests_attributes) do
       [

--- a/spec/services/partners/request_create_service_spec.rb
+++ b/spec/services/partners/request_create_service_spec.rb
@@ -10,7 +10,7 @@ describe Partners::RequestCreateService do
         item_requests_attributes: item_requests_attributes
       }
     end
-    let(:partner_user) { partners.partner.find_by(diaper_partner_id: partner.id).user }
+    let(:partner_user) { Partners::Partner.find_by(diaper_partner_id: partner.id).user }
     let(:partner) { create(:partner) }
     let(:comments) { Faker::Lorem.paragraph }
     let(:item_requests_attributes) do

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -4,6 +4,25 @@ RSpec.describe "Partner management", type: :system, js: true do
   end
   let!(:url_prefix) { "/#{@organization.to_param}" }
 
+  describe 'approving a partner that is awaiting approval' do
+    let!(:partner_awaiting_approval) { create(:partner, :awaiting_review) }
+
+    it 'should approve the partner' do
+      visit url_prefix + "/partners"
+
+      assert page.has_content? partner_awaiting_approval.name
+      click_on 'Review Application'
+      assert page.has_content? "Partner Approval Request for #{partner_awaiting_approval.name}"
+      assert page.has_content? "#{partner_awaiting_approval.name} - Application Details - #{partner_awaiting_approval.email}"
+
+      click_on 'Approve Partner'
+      assert page.has_content? 'Partner approved!'
+
+      expect(partner_awaiting_approval.reload.approved?).to eq(true)
+      expect(Partners::Partner.find_by(diaper_partner_id: partner_awaiting_approval.id).partner_status).to eq('approval')
+    end
+  end
+
   describe "#index" do
     before(:each) do
       @uninvited = create(:partner, name: "Bcd", status: :uninvited)

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "Partner management", type: :system, js: true do
         allow_any_instance_of(PartnerApprovalService).to receive_message_chain(:errors, :full_messages).and_return(fake_error_msg)
       end
 
-      it 'should show an errror message and not approve the partner' do
+      it 'should show an error message and not approve the partner' do
         visit url_prefix + "/partners"
 
         assert page.has_content? partner_awaiting_approval.name

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -7,6 +7,10 @@ RSpec.describe "Partner management", type: :system, js: true do
   describe 'approving a partner that is awaiting approval' do
     let!(:partner_awaiting_approval) { create(:partner, :awaiting_review) }
 
+    before do
+      expect(partner_awaiting_approval.profile.partner_status).not_to eq('approval')
+    end
+
     it 'should approve the partner' do
       visit url_prefix + "/partners"
 
@@ -19,7 +23,7 @@ RSpec.describe "Partner management", type: :system, js: true do
       assert page.has_content? 'Partner approved!'
 
       expect(partner_awaiting_approval.reload.approved?).to eq(true)
-      expect(Partners::Partner.find_by(diaper_partner_id: partner_awaiting_approval.id).partner_status).to eq('approval')
+      expect(partner_awaiting_approval.profile.reload.partner_status).to eq('approval')
     end
   end
 

--- a/spec/system/partners/log_in_system_spec.rb
+++ b/spec/system/partners/log_in_system_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Authentication", type: :system, js: true do
   describe 'logging in as a partner user' do
     let(:partner_user) do
-      user = Partners::Partner.find_by(diaper_partner_id: partner.id).user
+      user = create(:partner).primary_partner_user
       user.password = password
       user.save
       user

--- a/spec/system/partners/log_in_system_spec.rb
+++ b/spec/system/partners/log_in_system_spec.rb
@@ -1,6 +1,13 @@
 RSpec.describe "Authentication", type: :system, js: true do
   describe 'logging in as a partner user' do
-    let!(:partner_user) { FactoryBot.create(:partners_user, password: password) }
+    let(:partner_user) do
+      user = Partners::Partner.find_by(diaper_partner_id: partner.id).user
+      user.password = password
+      user.save
+      user
+    end
+
+    let(:partner) { create(:partner) }
     let(:password) { Faker::Alphanumeric.alpha(number: 10) }
 
     context 'successfully through the partner user login page' do

--- a/spec/system/partners/managing_requests_system_spec.rb
+++ b/spec/system/partners/managing_requests_system_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Managing requests", type: :system, js: true do
   describe 'creating a request' do
-    let!(:partner_user) { FactoryBot.create(:partners_user) }
+    let(:partner_user) { Partners::Partner.find_by(diaper_partner_id: partner.id).user }
+    let!(:partner) { FactoryBot.create(:partner) }
 
     context 'GIVEN a partner user is permitted to make a request' do
       before do

--- a/spec/system/partners/managing_requests_system_spec.rb
+++ b/spec/system/partners/managing_requests_system_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe "Managing requests", type: :system, js: true do
   describe 'creating a request' do
-    let(:partner_user) { Partners::Partner.find_by(diaper_partner_id: partner.id).user }
+    let(:partner_user) { partner.primary_partner_user }
     let!(:partner) { FactoryBot.create(:partner) }
 
     context 'GIVEN a partner user is permitted to make a request' do


### PR DESCRIPTION
Resolves #2164 (Partly)

### Description

As we are moving away from having 2 applications, we want to rely less and less on the Partnerbase API. This PR takes a step in that direction, by removing the need for an API connection to approve a partner agency. In summary, it achieves this by retrieving & altering data directly in the Partner's DB. 

**Notably, this PR adds a "syncing" mechanism to ensure that the approval page has access to documents uploaded by partners via the legacy Partnerbase application. This syncing mechanism would be replaced once we've gotten closer to merging the applications together**

Summary Of Changes:
- Replaced the need for the Partnerbase API to approve partners.
- Added useful instance methods `profile` (the `partners` table in partnerbase) and `primary_partner_user` on the `Partner` record to help associate partner data in the Diaper DB /w those in the Partner DB.
- Updated `partners` Factory to also create the necessary `partner_user` and etc. So now when you need to create example partner user, you can do this:
```
partner = create(:partner)
partner_user = partner.primary_partner_user
```
- Added [magic_test](https://github.com/bullet-train-co/magic_test) gem! (Thanks @albertchae for sharing this!)
- Added FactoryBot into the development group to be able to take advantage of the factories

### Type of change

* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?
Added specs, but also tested this in staging

### Screenshots
![partner_approval](https://user-images.githubusercontent.com/11335191/110205731-cb171f00-7e47-11eb-8f17-975fd994193d.gif)
