### PR TITLE
2165 - Refactor impact_metrics to use local Partner database

### DIFF
--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -39,8 +39,7 @@ class PartnersController < ApplicationController
 
   def show
     @partner = current_organization.partners.find(params[:id])
-
-    @impact_metrics = JSON.parse(DiaperPartnerClient.get({ id: params[:id] }, query_params: { impact_metrics: true })) unless @partner.uninvited?
+    @impact_metrics = @partner.profile.impact_metrics unless @partner.uninvited?
     @partner_distributions = @partner.distributions.order(created_at: :desc)
 
     respond_to do |format|

--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -272,5 +272,32 @@ module Partners
         raise ActiveRecord::Rollback
       end
     end
+
+    def impact_metrics
+      {
+        families_served: families_served_count,
+        children_served: children_served_count,
+        family_zipcodes: family_zipcodes_count,
+        family_zipcodes_list: family_zipcodes_list
+      }
+    end
+
+    private
+
+    def families_served_count
+      families.count
+    end
+
+    def children_served_count
+      children.count
+    end
+
+    def family_zipcodes_count
+      families.pluck(:guardian_zip_code).uniq.count
+    end
+
+    def family_zipcodes_list
+      families.pluck(:guardian_zip_code).uniq
+    end
   end
 end

--- a/app/views/partners/_show_header.html.erb
+++ b/app/views/partners/_show_header.html.erb
@@ -6,7 +6,7 @@
     <div class="row">
       <div class="<%= show_header_column_class(partner) %>">
         <div class="description-block border-right">
-          <h1 style="color:purple"><%= total_on_hand(impact_metrics.dig("agency", "families_served") || 0) %> </h1>
+          <h1 style="color:purple"><%= total_on_hand(impact_metrics[:families_served] || 0) %> </h1>
           <h5>Families served</h5>
         </div>
         <!-- /.description-block -->
@@ -14,7 +14,7 @@
       <!-- /.col -->
       <div class="<%= show_header_column_class(partner) %>">
         <div class="description-block border-right">
-          <h1 style="color:purple"><%= total_on_hand(impact_metrics.dig("agency", "children_served") || 0) %> </h1>
+          <h1 style="color:purple"><%= total_on_hand(impact_metrics[:children_served] || 0) %> </h1>
           <h5>Children served</h5>
         </div>
         <!-- /.description-block -->
@@ -22,9 +22,9 @@
       <!-- /.col -->
       <div class="<%= show_header_column_class(partner) %>">
         <div class="description-block border-right">
-          <h1 style="color:purple"><%= total_on_hand(impact_metrics.dig("agency", "family_zipcodes") || 0) %> </h1>
+          <h1 style="color:purple"><%= total_on_hand(impact_metrics[:family_zipcodes] || 0) %> </h1>
           <h5>Zipcodes served</h5>
-          <%= modal_button_to("#seeZipcodes", {text: "See Zipcodes?", size: "xs"}) if impact_metrics.dig("agency", "family_zipcodes_list").present? %>
+          <%= modal_button_to("#seeZipcodes", {text: "See Zipcodes?", size: "xs"}) if impact_metrics[:family_zipcodes_list].present? %>
         </div>
         <!-- /.description-block -->
       </div>
@@ -67,7 +67,7 @@
       <div class="modal-body">
         <div class="box-body">
           <ul>
-            <% @impact_metrics.dig("agency", "family_zipcodes_list").each do |zipcode| %>
+            <% @impact_metrics[:family_zipcodes_list].each do |zipcode| %>
               <li><%= zipcode %></li>
             <% end %>
           </ul>

--- a/spec/factories/partners/child.rb
+++ b/spec/factories/partners/child.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :partners_child, class: Partners::Child do
+    association :family, factory: :partners_family
+
+    active               { true }
+    archived             { false }
+    comments             { 'Comments ' }
+    date_of_birth        { Time.zone.today - 5.years }
+    first_name           { Faker::Name.first_name }
+    last_name            { Faker::Name.last_name }
+    gender               { Faker::Gender.binary_type }
+    item_needed_diaperid { rand(1..10) }
+  end
+end

--- a/spec/factories/partners/family.rb
+++ b/spec/factories/partners/family.rb
@@ -1,0 +1,20 @@
+FactoryBot.define do
+  factory :partners_family, class: Partners::Family do
+    association :partner, factory: :partners_partner
+
+    comments                  { Faker::Lorem.paragraph }
+    guardian_country          { Faker::Address.country }
+    guardian_employed         { false }
+    guardian_employment_type  { nil }
+    guardian_first_name       { Faker::Name.first_name }
+    guardian_health_insurance { nil }
+    guardian_last_name        { Faker::Name.last_name }
+    guardian_monthly_pay      { rand(500.0..2000.0).round(2) }
+    guardian_phone            { Faker::PhoneNumber.phone_number_with_country_code }
+    guardian_zip_code         { Faker::Address.zip }
+    home_adult_count          { rand(1..5) }
+    home_child_count          { rand(0..5) }
+    home_young_child_count    { rand(0..5) }
+    military                  { false }
+  end
+end

--- a/spec/models/partners/partner_spec.rb
+++ b/spec/models/partners/partner_spec.rb
@@ -41,6 +41,26 @@ RSpec.describe Partners::Partner, type: :model do
       expect(subject).to eq(Organization.find_by!(id: partner.diaper_bank_id))
     end
   end
+
+  describe '#impact_metrics' do
+    subject { partner.impact_metrics }
+    let(:partner) { FactoryBot.create(:partners_partner) }
+
+    context 'when partner has related informations' do
+      let!(:family1) { FactoryBot.create(:partners_family, guardian_zip_code: '45612-123', partner: partner) }
+      let!(:family2) { FactoryBot.create(:partners_family, guardian_zip_code: '45612-126', partner: partner) }
+      let!(:family3) { FactoryBot.create(:partners_family, guardian_zip_code: '45612-123', partner: partner) }
+
+      let!(:child1) { FactoryBot.create_list(:partners_child, 2, family: family1) }
+      let!(:child2) { FactoryBot.create_list(:partners_child, 2, family: family3) }
+
+      it { is_expected.to eq({ families_served: 3, children_served: 4, family_zipcodes: 2, family_zipcodes_list: %w(45612-123 45612-126) }) }
+    end
+
+    context "when partner don't have any related informations" do
+      it { is_expected.to eq({ families_served: 0, children_served: 0, family_zipcodes: 0, family_zipcodes_list: [] }) }
+    end
+  end
 end
 
 

--- a/spec/requests/partners_requests_spec.rb
+++ b/spec/requests/partners_requests_spec.rb
@@ -45,17 +45,20 @@ RSpec.describe "Partners", type: :request do
     end
 
     let(:partner) { create(:partner, organization: @organization, status: :approved) }
-    let(:fake_get_return) do
-      { "agency" => {
-        "families_served" => Faker::Number.number,
-        "children_served" => Faker::Number.number,
-        "family_zipcodes" => Faker::Number.number,
-        "family_zipcodes_list" => [Faker::Number.number]
-      } }.to_json
-    end
+    let!(:family1) { FactoryBot.create(:partners_family, guardian_zip_code: '45612-123', partner: partner.profile) }
+    let!(:family2) { FactoryBot.create(:partners_family, guardian_zip_code: '45612-126', partner: partner.profile) }
+    let!(:family3) { FactoryBot.create(:partners_family, guardian_zip_code: '45612-123', partner: partner.profile) }
 
-    before do
-      allow(DiaperPartnerClient).to receive(:get).with({ id: partner.to_param }, query_params: { impact_metrics: true }).and_return(fake_get_return)
+    let!(:child1) { FactoryBot.create_list(:partners_child, 2, family: family1) }
+    let!(:child2) { FactoryBot.create_list(:partners_child, 2, family: family3) }
+
+    let(:expected_impact_metrics) do
+      {
+        families_served: 3,
+        children_served: 4,
+        family_zipcodes: 2,
+        family_zipcodes_list: %w(45612-123 45612-126)
+      }
     end
 
     context "html" do
@@ -66,7 +69,7 @@ RSpec.describe "Partners", type: :request do
       context "when the partner is invited" do
         it "includes impact metrics" do
           subject
-          expect(assigns[:impact_metrics]).to eq(JSON.parse(fake_get_return))
+          expect(assigns[:impact_metrics]).to eq(expected_impact_metrics)
         end
       end
 


### PR DESCRIPTION
Resolves #2165 

### Description
* Refactor the impact_metrics calculation of partners to use the local database instead of doing HTTP requests
 
### Type of change
* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?
* Access the Partner Agencies Menu
* Access the first and the second partners
* The first one should show impact metrics with 0 
* The second one should show impact metrics with some values (and the zipcodes)

ps: I have my database only with the seed data. If you have a different database, with other items, the result could be different

### Screenshots
![image](https://user-images.githubusercontent.com/4561599/110249643-ce003580-7f55-11eb-8cfe-576c38edf957.png)
![image](https://user-images.githubusercontent.com/4561599/110249664-f38d3f00-7f55-11eb-9a4a-207c02fc4842.png)
![image](https://user-images.githubusercontent.com/4561599/110249685-128bd100-7f56-11eb-995b-a87e878ad565.png)

