### PR TITLE
Fix rubocop errors for hash syntax in production/staging config

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,13 +17,13 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: "diaper.app" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    :address        => 'smtp.sendgrid.net',
-    :port           => '587',
-    :authentication => :plain,
-    :user_name => ENV['SENDGRID_USERNAME'],
-    :password => ENV['SENDGRID_PASSWORD'],
-    :domain         => 'diaper.app',
-    :enable_starttls_auto => true
+    address: 'smtp.sendgrid.net',
+    port: '587',
+    authentication: :plain,
+    user_name: ENV['SENDGRID_USERNAME'],
+    password: ENV['SENDGRID_PASSWORD'],
+    domain: 'diaper.app',
+    enable_starttls_auto: true
   }
 
   # Full error reports are disabled and caching is turned on.

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -17,12 +17,12 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: "staging.humanessentials.app" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    :user_name => ENV['MAILTRAP_USERNAME'],
-    :password => ENV['MAILTRAP_PASSWORD'],
-    :address => 'smtp.mailtrap.io',
-    :domain => 'smtp.mailtrap.io',
-    :port => '2525',
-    :authentication => :cram_md5
+    user_name: ENV['MAILTRAP_USERNAME'],
+    password: ENV['MAILTRAP_PASSWORD'],
+    address: 'smtp.mailtrap.io',
+    domain: 'smtp.mailtrap.io',
+    port: '2525',
+    authentication: :cram_md5
   }
 
   # Full error reports are disabled and caching is turned on.


### PR DESCRIPTION
### Description

For some reason we're getting this hash syntax rubocop error now (maybe a rubocop upgrade turned these on?). Anyway, I just ran the autocorrect for those files.