### PR TITLE
2218 prevent requesting account demos in staging

### DIFF
--- a/app/views/account_requests/new.html.erb
+++ b/app/views/account_requests/new.html.erb
@@ -1,44 +1,59 @@
-<div class="card" style='width: 30rem'>
-  <div class="card-body">
-    <div class="card-title mb-10">
-      <h3>Account Request Form</h3>
-    </div>
+<% unless Rails.env.staging? %>
+  <div class="card" style='width: 30rem'>
+    <div class="card-body">
+      <div class="card-title mb-10">
+        <h3>Account Request Form</h3>
+      </div>
 
-    <div class='card-text'>
-      <%= simple_form_for(@account_request) do |f| %>
-        <%= f.error_notification %>
-        <%= render partial: "shared/flash" %>
-
-        <div class="form-inputs">
-          <div class="form-inputs">
-            <%= f.input :name, autofocus: true %>
-          </div>
+      <div class='card-text'>
+        <%= simple_form_for(@account_request) do |f| %>
+          <%= f.error_notification %>
+          <%= render partial: "shared/flash" %>
 
           <div class="form-inputs">
-            <%= f.input :email %>
+            <div class="form-inputs">
+              <%= f.input :name, autofocus: true %>
+            </div>
+
+            <div class="form-inputs">
+              <%= f.input :email %>
+            </div>
+
+            <div class="form-inputs">
+              <%= f.input :organization_name %>
+            </div>
+
+            <div class="form-inputs">
+              <%= f.input :organization_website %>
+            </div>
+
+            <div class="form-inputs">
+              <%= f.input :request_details, placeholder: 'Tell us more about your organization and how you would use the software account', label: "Request Details (min 50 characters)" %>
+            </div>
           </div>
 
-          <div class="form-inputs">
-            <%= f.input :organization_name %>
+          <div class="my-2">
+            <%= recaptcha_tags %>
           </div>
 
-          <div class="form-inputs">
-            <%= f.input :organization_website %>
+          <div class="card-footer">
+            <%= submit_button({text: 'Submit', icon: nil}) %>
           </div>
-
-          <div class="form-inputs">
-            <%= f.input :request_details, placeholder: 'Tell us more about your organization and how you would use the software account', label: "Request Details (min 50 characters)" %>
-          </div>
-        </div>
-
-        <div class="my-2">
-          <%= recaptcha_tags %>
-        </div>
-
-        <div class="card-footer">
-          <%= submit_button({text: 'Submit', icon: nil}) %>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
     </div>
   </div>
-</div>
+<% else %>
+<div class="card" style='width: 30rem'>
+    <div class="card-body">
+      <div class="card-title mb-10">
+        <h3>Request an account</h3>
+      </div>
+
+      <div class='card-text'>
+        <p> Hey there, it looks like you're trying to request an account, but you're not currently on the live version of Diaper Base </p>
+        <p> To request an account, <%= link_to 'click here', 'https://diaper.app/account_requests/new' %> to head on over to the Diaper Base website</p>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/spec/system/account_request_system_spec.rb
+++ b/spec/system/account_request_system_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Account request flow', type: :system, js: true do
 
     # Check for staging
     if Rails.env.development? || Rails.env.production? || Rails.env.test?
-      expect(page).to have_text(/Account Request Form/i)
+      expect(page).to have_selector(id: 'new_account_request')
     else
       expect(page).to have_link('click here', href: 'https://diaper.app/account_requests/new')
     end

--- a/spec/system/account_request_system_spec.rb
+++ b/spec/system/account_request_system_spec.rb
@@ -1,66 +1,71 @@
 RSpec.describe 'Account request flow', type: :system, js: true do
-  it 'should prompt prospective users to request an account on the live app if the new account form is accessed on a staging environment' do
-    visit new_account_request_path
+  context 'when in staging' do
+    before do
+      allow(Rails.env).to receive(:staging?).and_return(true)
+    end
 
-    # Check for staging
-    if Rails.env.development? || Rails.env.production? || Rails.env.test?
-      expect(page).to have_selector(id: 'new_account_request')
-    else
+    it 'should prompt prospective users to request an account on the live app' do
+      visit new_account_request_path
       expect(page).to have_link('click here', href: 'https://diaper.app/account_requests/new')
     end
   end
 
-  it 'should allow prospect users to request an account via a form. And that request form data gets used to create an organization' do
-    visit root_path
+  context 'when not in staging' do
+    before do
+      allow(Rails.env).to receive(:staging?).and_return(false)
+    end
+    it 'should allow prospective users to request an account via a form. And that request form data gets used to create an organization' do
+      visit root_path
 
-    click_button('Request A Demo', match: :first)
+      click_button('Request A Demo', match: :first)
 
-    account_request_attrs = FactoryBot.attributes_for(:account_request)
+      account_request_attrs = FactoryBot.attributes_for(:account_request)
 
-    fill_in 'Name', with: account_request_attrs[:name]
-    fill_in 'Email', with: account_request_attrs[:email]
-    fill_in 'Organization name', with: account_request_attrs[:organization_name]
-    fill_in 'Organization website', with: account_request_attrs[:organization_website]
-    fill_in 'Request Details (min 50 characters)', with: account_request_attrs[:request_details]
+      fill_in 'Name', with: account_request_attrs[:name]
+      fill_in 'Email', with: account_request_attrs[:email]
+      fill_in 'Organization name', with: account_request_attrs[:organization_name]
+      fill_in 'Organization website', with: account_request_attrs[:organization_website]
+      fill_in 'Request Details (min 50 characters)', with: account_request_attrs[:request_details]
 
-    expect(AccountRequest.count).to eq(0)
+      expect(AccountRequest.count).to eq(0)
 
-    expect { click_button 'Submit' }.to change(AccountRequest, :count).by(1)
+      expect { click_button 'Submit' }.to change(AccountRequest, :count).by(1)
 
-    created_account_request = AccountRequest.last
+      created_account_request = AccountRequest.last
 
-    # Request Received
-    expect(page).to have_content('Request Received!')
-    expect(page).to have_content("We've sent you a email with instructions on next steps at #{created_account_request.email}!")
+      # Request Received
+      expect(page).to have_content('Request Received!')
+      expect(page).to have_content("We've sent you a email with instructions on next steps at #{created_account_request.email}!")
 
-    # Access link within email they would have received
-    visit confirmation_account_requests_path(token: created_account_request.identity_token)
+      # Access link within email they would have received
+      visit confirmation_account_requests_path(token: created_account_request.identity_token)
 
-    expect(created_account_request.confirmed_at).to eq(nil)
+      expect(created_account_request.confirmed_at).to eq(nil)
 
-    click_link 'I\'m ready! Let\'s go!'
+      click_link 'I\'m ready! Let\'s go!'
 
-    expect(created_account_request.reload.confirmed_at).not_to eq(nil)
+      expect(created_account_request.reload.confirmed_at).not_to eq(nil)
 
-    expect(page).to have_content('Confirmed!')
-    expect(page).to have_content('We will be processing your request now.')
+      expect(page).to have_content('Confirmed!')
+      expect(page).to have_content('We will be processing your request now.')
 
-    # Access link within email sent to admin user to process the request.
-    sign_in(@super_admin)
-    visit new_admin_organization_path(token: created_account_request.identity_token)
+      # Access link within email sent to admin user to process the request.
+      sign_in(@super_admin)
+      visit new_admin_organization_path(token: created_account_request.identity_token)
 
-    fill_in 'Short name', with: 'fakeshortname'
+      fill_in 'Short name', with: 'fakeshortname'
 
-    click_button 'Save'
+      click_button 'Save'
 
-    # Expect to see the a new organization with the name provided
-    # originally in the AccountRequest
-    expect(page).to have_content('All Diaperbase Organizations')
-    expect(page).to have_content(created_account_request.organization_name)
-    expect(page).to have_content(created_account_request.email)
+      # Expect to see the a new organization with the name provided
+      # originally in the AccountRequest
+      expect(page).to have_content('All Diaperbase Organizations')
+      expect(page).to have_content(created_account_request.organization_name)
+      expect(page).to have_content(created_account_request.email)
 
-    # Ensure the AccountRequest is not considered processed
-    expect(created_account_request.reload.processed?).to eq(true)
+      # Ensure the AccountRequest is not considered processed
+      expect(created_account_request.reload.processed?).to eq(true)
+    end
   end
 end
 

--- a/spec/system/account_request_system_spec.rb
+++ b/spec/system/account_request_system_spec.rb
@@ -1,25 +1,36 @@
-RSpec.describe "Account request flow", type: :system, js: true do
+RSpec.describe 'Account request flow', type: :system, js: true do
+  it 'should prompt prospective users to request an account on the live app if the new account form is accessed on a staging environment' do
+    visit new_account_request_path
+
+    # Check for staging
+    if Rails.env.development? || Rails.env.production? || Rails.env.test?
+      expect(page).to have_text(/Account Request Form/i)
+    else
+      expect(page).to have_link('click here', href: 'https://diaper.app/account_requests/new')
+    end
+  end
+
   it 'should allow prospect users to request an account via a form. And that request form data gets used to create an organization' do
     visit root_path
 
-    click_button("Request A Demo", match: :first)
+    click_button('Request A Demo', match: :first)
 
     account_request_attrs = FactoryBot.attributes_for(:account_request)
 
-    fill_in "Name", with: account_request_attrs[:name]
-    fill_in "Email", with: account_request_attrs[:email]
-    fill_in "Organization name", with: account_request_attrs[:organization_name]
-    fill_in "Organization website", with: account_request_attrs[:organization_website]
-    fill_in "Request Details (min 50 characters)", with: account_request_attrs[:request_details]
+    fill_in 'Name', with: account_request_attrs[:name]
+    fill_in 'Email', with: account_request_attrs[:email]
+    fill_in 'Organization name', with: account_request_attrs[:organization_name]
+    fill_in 'Organization website', with: account_request_attrs[:organization_website]
+    fill_in 'Request Details (min 50 characters)', with: account_request_attrs[:request_details]
 
     expect(AccountRequest.count).to eq(0)
 
-    expect { click_button "Submit" }.to change(AccountRequest, :count).by(1)
+    expect { click_button 'Submit' }.to change(AccountRequest, :count).by(1)
 
     created_account_request = AccountRequest.last
 
     # Request Received
-    expect(page).to have_content("Request Received!")
+    expect(page).to have_content('Request Received!')
     expect(page).to have_content("We've sent you a email with instructions on next steps at #{created_account_request.email}!")
 
     # Access link within email they would have received
@@ -27,18 +38,18 @@ RSpec.describe "Account request flow", type: :system, js: true do
 
     expect(created_account_request.confirmed_at).to eq(nil)
 
-    click_link "I'm ready! Let's go!"
+    click_link 'I\'m ready! Let\'s go!'
 
     expect(created_account_request.reload.confirmed_at).not_to eq(nil)
 
-    expect(page).to have_content("Confirmed!")
-    expect(page).to have_content("We will be processing your request now.")
+    expect(page).to have_content('Confirmed!')
+    expect(page).to have_content('We will be processing your request now.')
 
     # Access link within email sent to admin user to process the request.
     sign_in(@super_admin)
     visit new_admin_organization_path(token: created_account_request.identity_token)
 
-    fill_in "Short name", with: 'fakeshortname'
+    fill_in 'Short name', with: 'fakeshortname'
 
     click_button 'Save'
 


### PR DESCRIPTION
Resolves #2218 

### Description

- Added to account_request_system_spec to check for the account request form 
- Changed quotation marks in spec from double to single quotation marks (unless required for interpolation) while I was there
- Views/account_requests/new will now hide the account request form if accessed from a staging environment and instead display a brief paragraph explaining that the user is not on the live site, and link to the correct page of the live app.

### Type of change

Bugfix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Created and ran the spec
- Viewed local code in the browser in different environments 

### Screenshots

![Before](https://user-images.githubusercontent.com/33702528/111321745-245d2a80-8660-11eb-95a6-13561ab4aba4.png)
![After](https://user-images.githubusercontent.com/33702528/111321748-245d2a80-8660-11eb-8be8-468d2d300e81.png)

### Other

I'm unsure if the spec is formatted correctly, or even if I put it in the correct place.

