### PR TITLE
Enable partner users to request approval without legacy API approach

### DIFF
--- a/app/controllers/partners/approval_requests_controller.rb
+++ b/app/controllers/partners/approval_requests_controller.rb
@@ -7,7 +7,7 @@ module Partners
       if svc.errors.none?
         flash[:success] = "You have submitted your details for approval."
       else
-        flash[:error] = "Sorry we've encountered an issue. Please try this requesting approval again"
+        flash[:error] = "Sorry we've encountered an issue. Please try requesting this approval again"
       end
 
       redirect_to partners_profile_path

--- a/app/controllers/partners/approval_requests_controller.rb
+++ b/app/controllers/partners/approval_requests_controller.rb
@@ -1,0 +1,16 @@
+module Partners
+  class ApprovalRequestsController < BaseController
+    def create
+      svc = Partners::RequestApprovalService.new(partner: current_partner.partner)
+      svc.call
+
+      if svc.errors.none?
+        flash[:success] = "You have submitted your details for approval."
+      else
+        flash[:error] = "Sorry we've encountered an issue. Please try this requesting approval again"
+      end
+
+      redirect_to partners_profile_path
+    end
+  end
+end

--- a/app/controllers/partners/base_controller.rb
+++ b/app/controllers/partners/base_controller.rb
@@ -1,5 +1,7 @@
 module Partners
   class BaseController < ApplicationController
+    layout 'partners/application'
+
     before_action :redirect_to_root, unless: -> { Rails.env.test? || Flipper.enabled?(:onebase) }
     skip_before_action :authenticate_user!
     skip_before_action :authorize_user

--- a/app/controllers/partners/profiles_controller.rb
+++ b/app/controllers/partners/profiles_controller.rb
@@ -1,26 +1,20 @@
 module Partners
   class ProfilesController < BaseController
     layout 'partners/application'
-    # before_action :set_partner, only: [:show, :edit, :update, :destroy]
 
-    def index
-      # @partners = Partner.all
-      # authorize @partners
-    end
+    def show; end
 
-    def show
-      # @partner = current_partner
-    end
-
-    def edit
-      # @partner = current_partner
-    end
+    def edit; end
 
     def approve
-      @partner = Partner.find(params[:partner_id])
-      @partner.approve_me
+      partner = current_partner
+
+
+      # Add service object here to request approval
+
+      # Set Submitted
       flash[:success] = "You have submitted your details for approval."
-      redirect_to @partner
+      redirect_to partners_profile_path
     end
 
     def update
@@ -30,12 +24,6 @@ module Partners
       else
         render :edit
       end
-    end
-
-    def destroy
-      @partner.destroy
-      flash[:success] = "Partner was successfully destroyed."
-      redirect_to partners_path
     end
 
     private

--- a/app/controllers/partners/profiles_controller.rb
+++ b/app/controllers/partners/profiles_controller.rb
@@ -6,17 +6,6 @@ module Partners
 
     def edit; end
 
-    def approve
-      partner = current_partner
-
-
-      # Add service object here to request approval
-
-      # Set Submitted
-      flash[:success] = "You have submitted your details for approval."
-      redirect_to partners_profile_path
-    end
-
     def update
       if current_partner.update(partner_params)
         flash[:success] = "Details were successfully updated."

--- a/app/controllers/partners/profiles_controller.rb
+++ b/app/controllers/partners/profiles_controller.rb
@@ -1,7 +1,5 @@
 module Partners
   class ProfilesController < BaseController
-    layout 'partners/application'
-
     def show; end
 
     def edit; end

--- a/app/controllers/partners/profiles_controller.rb
+++ b/app/controllers/partners/profiles_controller.rb
@@ -9,10 +9,12 @@ module Partners
     end
 
     def show
-      @partner = current_partner
+      # @partner = current_partner
     end
 
-    def edit; end
+    def edit
+      # @partner = current_partner
+    end
 
     def approve
       @partner = Partner.find(params[:partner_id])
@@ -22,9 +24,9 @@ module Partners
     end
 
     def update
-      if @partner.update(partner_params)
+      if current_partner.update(partner_params)
         flash[:success] = "Details were successfully updated."
-        redirect_to @partner
+        redirect_to partners_profile_path
       else
         render :edit
       end
@@ -38,12 +40,8 @@ module Partners
 
     private
 
-    # def set_partner
-    # @partner = authorize Partner.find(params[:id])
-    # end
-
     def partner_params
-      params.require(:partner).permit(
+      params.require(:partners_partner).permit(
         :name,
         :agency_type,
         :other_agency_type,

--- a/app/controllers/partners/profiles_controller.rb
+++ b/app/controllers/partners/profiles_controller.rb
@@ -1,0 +1,127 @@
+module Partners
+  class ProfilesController < BaseController
+    layout 'partners/application'
+    # before_action :set_partner, only: [:show, :edit, :update, :destroy]
+
+    def index
+      # @partners = Partner.all
+      # authorize @partners
+    end
+
+    def show
+      @partner = current_partner
+    end
+
+    def edit; end
+
+    def approve
+      @partner = Partner.find(params[:partner_id])
+      @partner.approve_me
+      flash[:success] = "You have submitted your details for approval."
+      redirect_to @partner
+    end
+
+    def update
+      if @partner.update(partner_params)
+        flash[:success] = "Details were successfully updated."
+        redirect_to @partner
+      else
+        render :edit
+      end
+    end
+
+    def destroy
+      @partner.destroy
+      flash[:success] = "Partner was successfully destroyed."
+      redirect_to partners_path
+    end
+
+    private
+
+    # def set_partner
+    # @partner = authorize Partner.find(params[:id])
+    # end
+
+    def partner_params
+      params.require(:partner).permit(
+        :name,
+        :agency_type,
+        :other_agency_type,
+        :partner_status,
+        :proof_of_partner_status,
+        :agency_mission,
+        :address1,
+        :address2,
+        :city,
+        :state,
+        :zip_code,
+        :website,
+        :facebook,
+        :twitter,
+        :founded,
+        :form_990,
+        :proof_of_form_990,
+        :program_name,
+        :program_description,
+        :program_age,
+        :case_management,
+        :evidence_based,
+        :evidence_based_description,
+        :program_client_improvement,
+        :diaper_use,
+        :other_diaper_use,
+        :currently_provide_diapers,
+        :turn_away_child_care,
+        :program_address1,
+        :program_address2,
+        :program_city,
+        :program_state,
+        :program_zip_code,
+        :max_serve,
+        :incorporate_plan,
+        :responsible_staff_position,
+        :storage_space,
+        :describe_storage_space,
+        :trusted_pickup,
+        :income_requirement_desc,
+        :serve_income_circumstances,
+        :income_verification,
+        :internal_db,
+        :maac,
+        :population_black,
+        :population_white,
+        :population_hispanic,
+        :population_asian,
+        :population_american_indian,
+        :population_island,
+        :population_multi_racial,
+        :population_other,
+        :zips_served,
+        :at_fpl_or_below,
+        :above_1_2_times_fpl,
+        :greater_2_times_fpl,
+        :poverty_unknown,
+        :ages_served,
+        :executive_director_name,
+        :executive_director_phone,
+        :executive_director_email,
+        :program_contact_name,
+        :program_contact_phone,
+        :program_contact_mobile,
+        :program_contact_email,
+        :pick_up_method,
+        :pick_up_name,
+        :pick_up_phone,
+        :pick_up_email,
+        :distribution_times,
+        :new_client_times,
+        :more_docs_required,
+        :sources_of_funding,
+        :sources_of_diapers,
+        :diaper_budget,
+        :diaper_funding_source,
+        documents: []
+      )
+    end
+  end
+end

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -18,4 +18,14 @@ module PartnersHelper
   def humanize_boolean(boolean)
     boolean ? 'Yes' : 'No'
   end
+
+  def partner_status_badge(partner)
+    if partner.partner_status == "verified"
+      tag.span partner.partner_status, class: %w(badge badge-pill badge-primary float-right)
+    elsif partner.partner_status == "recertification_required"
+      tag.span partner.partner_status, class: %w(badge badge-pill badge-danger float-right)
+    else
+      tag.span partner.partner_status, class: %w(badge badge-pill badge-info float-right)
+    end
+  end
 end

--- a/app/helpers/partners_helper.rb
+++ b/app/helpers/partners_helper.rb
@@ -14,4 +14,8 @@ module PartnersHelper
       "col-sm-4 col-4 #{additional_classes}"
     end
   end
+
+  def humanize_boolean(boolean)
+    boolean ? 'Yes' : 'No'
+  end
 end

--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -277,7 +277,6 @@ module Partners
     #
     def sync_attachments_from_partnerbase!
       ActiveRecord::Base.transaction do
-        # Fetch Blob data from Partner
         attachment_records = Partners::Base.connection.execute(
           <<-SQL
             SELECT asb.*, asa.* filename FROM active_storage_blobs asb
@@ -286,9 +285,6 @@ module Partners
               AND record_id = '#{id}'
           SQL
         )
-
-        # Must determine wither or not to keep or hide files depending on when it
-        # was added.
 
         old_acs_attachments = ActiveStorage::Attachment.where(
           record_type: self.class.name,

--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -100,6 +100,32 @@ module Partners
 
     VERIFIED_STATUS = 'verified'.freeze
 
+    AGENCY_TYPES = {
+      "CAREER" => "Career technical training",
+      "ABUSE" => "Child abuse resource center",
+      "CHURCH" => "Church outreach ministry",
+      "CDC" => "Community development corporation",
+      "HEALTH" => "Community health program",
+      "OUTREACH" => "Community outreach services",
+      "CRISIS" => "Crisis/Disaster services",
+      "DISAB" => "Developmental disabilities program",
+      "DOMV" => "Domestic violence shelter",
+      "CHILD" => "Early childhood services",
+      "EDU" => "Education program",
+      "FAMILY" => "Family resource center",
+      "FOOD" => "Food bank/pantry",
+      "GOVT" => "Government Agency/Affiliate",
+      "HEADSTART" => "Head Start/Early Head Start",
+      "HOMEVISIT" => "Home visits",
+      "HOMELESS" => "Homeless resource center",
+      "INFPAN" => "Infant/Child Pantry/Closet",
+      "PREG" => "Pregnancy resource center",
+      "REF" => "Refugee resource center",
+      "TREAT" => "Treatment clinic",
+      "WIC" => "Women, Infants and Children",
+      "OTHER" => "Other"
+    }.freeze
+
     ALL_PARTIALS = %w[
       media_information
       agency_stability

--- a/app/services/partners/request_approval_service.rb
+++ b/app/services/partners/request_approval_service.rb
@@ -2,6 +2,11 @@ module Partners
   class RequestApprovalService
     include ServiceObjectErrorsMixin
 
+    # Creates a new instance of Partners::RequestApprovalService
+    #
+    # @param partner: [Partner] the partner record
+    #
+    # @return [Partners::RequestApprovalService]
     def initialize(partner:)
       @partner = partner
     end

--- a/app/services/partners/request_approval_service.rb
+++ b/app/services/partners/request_approval_service.rb
@@ -1,0 +1,30 @@
+module Partners
+  class RequestApproval
+    include ServiceObjectErrorsMixin
+
+    attr_reader :partner
+
+    def initialize(partner:)
+      @partner = partner
+    end
+
+    def call
+      return self unless valid?
+
+      self
+    end
+
+    private
+
+    attr_reader :partner
+
+    def valid?
+      if partner.partner_status == 'submitted'
+        errors.add(:base, 'partner has already requested approval')
+      end
+
+      errors.none?
+    end
+
+  end
+end

--- a/app/services/partners/request_approval_service.rb
+++ b/app/services/partners/request_approval_service.rb
@@ -1,8 +1,6 @@
 module Partners
-  class RequestApproval
+  class RequestApprovalService
     include ServiceObjectErrorsMixin
-
-    attr_reader :partner
 
     def initialize(partner:)
       @partner = partner
@@ -10,6 +8,9 @@ module Partners
 
     def call
       return self unless valid?
+
+      partner.profile.update(partner_status: 'submitted')
+      partner.awaiting_review!
 
       self
     end
@@ -19,12 +20,11 @@ module Partners
     attr_reader :partner
 
     def valid?
-      if partner.partner_status == 'submitted'
+      if partner.profile.partner_status == 'submitted'
         errors.add(:base, 'partner has already requested approval')
       end
 
       errors.none?
     end
-
   end
 end

--- a/app/views/layouts/partners/application.html.erb
+++ b/app/views/layouts/partners/application.html.erb
@@ -10,7 +10,7 @@
   <%= stylesheet_link_tag 'application', media: 'all' %>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
   <link rel="stylesheet" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
-
+  <%= render 'magic_test/support' if Rails.env.test? %>
 </head>
 <body class="hold-transition sidebar-mini layout-fixed">
 <!-- Site wrapper -->

--- a/app/views/layouts/partners/navigation/_sidebar.html.erb
+++ b/app/views/layouts/partners/navigation/_sidebar.html.erb
@@ -8,14 +8,14 @@
   </li>
 
   <li class="nav-item">
-    <%= link_to('TODO', class: "nav-link") do %>
+    <%= link_to(partners_profile_path, class: "nav-link") do %>
       <i class="nav-icon fa fa-building"></i>
-      <p>(TODO) My Organization</p>
+      <p>My Organization</p>
     <% end %>
   </li>
 
   <li class="nav-item">
-    <%= link_to('TODO', class: "nav-link") do %>
+    <%= link_to(partners_profile_path, class: "nav-link") do %>
       <i class="nav-icon fa fa-cog"></i>
       <p>(TODO) Edit My Organization</p>
     <% end %>

--- a/app/views/layouts/partners/navigation/_sidebar.html.erb
+++ b/app/views/layouts/partners/navigation/_sidebar.html.erb
@@ -10,14 +10,14 @@
   <li class="nav-item">
     <%= link_to(partners_profile_path, class: "nav-link") do %>
       <i class="nav-icon fa fa-building"></i>
-      <p>My Organization</p>
+      <p>My Profile</p>
     <% end %>
   </li>
 
   <li class="nav-item">
-    <%= link_to(partners_profile_path, class: "nav-link") do %>
+    <%= link_to(edit_partners_profile_path, class: "nav-link") do %>
       <i class="nav-icon fa fa-cog"></i>
-      <p>(TODO) Edit My Organization</p>
+      <p>Edit My Profile</p>
     <% end %>
   </li>
 

--- a/app/views/partners/dashboards/show.html.erb
+++ b/app/views/partners/dashboards/show.html.erb
@@ -29,7 +29,7 @@
         </div>
         <div class="row">
           <div class="col">
-            <%= render '/partners/requests/request_options_card' %>
+            <%= render partial: '/partners/requests/request_options_card' if @partner.verified? %>
             <%= render partial: "/partners/requests/history" %>
           </div>
         </div>

--- a/app/views/partners/profiles/edit.html.erb
+++ b/app/views/partners/profiles/edit.html.erb
@@ -1,0 +1,51 @@
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <% content_for :title, "Editing - #{current_partner.name}" %>
+        <h1><i class="fa fa-edit"></i>&nbsp;&nbsp;Edit My Organization&nbsp;&nbsp;&nbsp;
+          <%= current_partner.partner_status %>
+          <small>for <%= current_partner.name %></small>
+        </h1>
+      </div>
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item"><a href="<%= partner_user_root_path %>"><i class="fa fa-home fa-lg"></i></a></li>
+          <li class="breadcrumb-item">
+            <a href="<%= edit_partners_profile_path %>"><%= "#{current_partner.name}" %></a></li>
+          <li class="breadcrumb-item"><a href="#">Edit</a></li>
+        </ol>
+      </div>
+    </div>
+  </div><!-- /.container-fluid -->
+</section>
+
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <!-- left column -->
+      <div class="col-md-12">
+        <!-- jquery validation -->
+        <div class="card-transparent">
+          <%= simple_form_for current_partner, url: partners_profile_path, html: {role: 'form', class: 'form-horizontal'} do |form| %>
+            <div class="row">
+              <div class="col-6">
+                <%= render partial: "partners/profiles/edit/agency_information", locals: {form: form, partner: current_partner} %>
+              </div>
+              <% current_partner.partials_to_show.each do |partial| %>
+                <div class="col-6">
+                  <%= render partial: "partners/profiles/edit/#{partial}", locals: {form: form, partner: current_partner} %>
+                </div>
+              <% end %>
+            </div>
+            <div class="card-footer">
+              <%= form.submit("Update Information", class: "btn btn-primary") %>
+              <%= link_to "Cancel Update", partners_profile_path, class: "btn btn-danger float-right" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+

--- a/app/views/partners/profiles/edit.html.erb
+++ b/app/views/partners/profiles/edit.html.erb
@@ -4,7 +4,7 @@
       <div class="col-sm-6">
         <% content_for :title, "Editing - #{current_partner.name}" %>
         <h1><i class="fa fa-edit"></i>&nbsp;&nbsp;Edit My Organization&nbsp;&nbsp;&nbsp;
-          <%= current_partner.partner_status %>
+          <%= partner_status_badge(current_partner) %>
           <small>for <%= current_partner.name %></small>
         </h1>
       </div>

--- a/app/views/partners/profiles/edit/_agency_distribution_information.html.erb
+++ b/app/views/partners/profiles/edit/_agency_distribution_information.html.erb
@@ -1,0 +1,18 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Agency Distribution Information</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :distribution_times, label: "Distribution Times", class: "form-control", wrapper: :input_group %>
+            <%= form.input :new_client_times, label: "New Client Times", class: "form-control", wrapper: :input_group %>
+            <%= form.input :more_docs_required, label: "More Docs Required", class: "form-control", wrapper: :input_group %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/profiles/edit/_agency_information.html.erb
+++ b/app/views/partners/profiles/edit/_agency_information.html.erb
@@ -1,0 +1,38 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Agency Information</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :name, label: "Agency Name", class: "form-control", wrapper: :input_group %>
+            <%= form.input :agency_type, collection: Partners::Partner::AGENCY_TYPES.values, label: "Agency Type", class: "form-control", wrapper: :input_group %>
+            <%= form.input :other_agency_type, label: "Other Agency Type", class: "form-control", wrapper: :input_group %>
+            <div class="form-group row">
+              <label class="control-label col-md-3">501(c)(3) IRS Determination Letter</label>
+              <% if partner.proof_of_partner_status.attached? %>
+                <div class="col-md-8">
+                  Attached
+                  file: <%= link_to partner.proof_of_partner_status.blob['filename'], rails_blob_path(partner.proof_of_partner_status), class: "font-weight-bold" %>
+                  <%= form.file_field :proof_of_partner_status, class: "form-control-file form-control" %>
+                </div>
+              <% else %>
+                <div class="col-md-8">
+                  <%= form.file_field :proof_of_partner_status, class: "form-control-file" %>
+                </div>
+              <% end %>
+            </div>
+            <%= form.input :agency_mission, label: "Description of Agency Mission", class: "form-control", wrapper: :input_group %>
+            <%= form.input :address1, label: "Address (line 1)", class: "form-control", wrapper: :input_group %>
+            <%= form.input :address2, label: "Address (line 2)", class: "form-control", wrapper: :input_group %>
+            <%= form.input :city, label: "City", class: "form-control", wrapper: :input_group %>
+            <%= form.input :state, label: "State", class: "form-control", wrapper: :input_group %>
+            <%= form.input :zip_code, label: "Zip Code", class: "form-control", wrapper: :input_group %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/profiles/edit/_agency_information.html.erb
+++ b/app/views/partners/profiles/edit/_agency_information.html.erb
@@ -13,7 +13,7 @@
             <div class="form-group row">
               <label class="control-label col-md-3">501(c)(3) IRS Determination Letter</label>
               <% if true %>
-                <div> Work In Progress </div>
+                <strong> Deactivated Until Merger Is Completed </strong>
               <% elsif partner.proof_of_partner_status.attached? %>
                 <div class="col-md-8">
                   Attached

--- a/app/views/partners/profiles/edit/_agency_information.html.erb
+++ b/app/views/partners/profiles/edit/_agency_information.html.erb
@@ -12,7 +12,9 @@
             <%= form.input :other_agency_type, label: "Other Agency Type", class: "form-control", wrapper: :input_group %>
             <div class="form-group row">
               <label class="control-label col-md-3">501(c)(3) IRS Determination Letter</label>
-              <% if partner.proof_of_partner_status.attached? %>
+              <% if true %>
+                <div> Work In Progress </div>
+              <% elsif partner.proof_of_partner_status.attached? %>
                 <div class="col-md-8">
                   Attached
                   file: <%= link_to partner.proof_of_partner_status.blob['filename'], rails_blob_path(partner.proof_of_partner_status), class: "font-weight-bold" %>

--- a/app/views/partners/profiles/edit/_agency_stability.html.erb
+++ b/app/views/partners/profiles/edit/_agency_stability.html.erb
@@ -10,7 +10,9 @@
             <%= form.input :founded, label: "Year Founded", class: "form-control", wrapper: :input_group %>
             <%= form.input :form_990, label: "Form 990 Filed", as: :boolean, class: "form-control", wrapper: :input_group %>
             <label class="control-label col-md-3">Form 990</label>
-            <% if partner.proof_of_form_990.attached? %>
+            <% if true %>
+              <div> Work In Progress </div>
+            <% elsif partner.proof_of_form_990.attached? %>
               <div class="col-md-8">
                 Attached
                 file: <%= link_to partner.proof_of_form_990.blob['filename'], rails_blob_path(partner.proof_of_form_990), class: "font-weight-bold" %>

--- a/app/views/partners/profiles/edit/_agency_stability.html.erb
+++ b/app/views/partners/profiles/edit/_agency_stability.html.erb
@@ -1,0 +1,68 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Agency Stability</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :founded, label: "Year Founded", class: "form-control", wrapper: :input_group %>
+            <%= form.input :form_990, label: "Form 990 Filed", as: :boolean, class: "form-control", wrapper: :input_group %>
+            <label class="control-label col-md-3">Form 990</label>
+            <% if partner.proof_of_form_990.attached? %>
+              <div class="col-md-8">
+                Attached
+                file: <%= link_to partner.proof_of_form_990.blob['filename'], rails_blob_path(partner.proof_of_form_990), class: "font-weight-bold" %>
+                <%= form.file_field :proof_of_form_990, class: "form-control-file form-control" %>
+              </div>
+            <% else %>
+              <div class="col-md-8">
+                <%= form.file_field :proof_of_form_990, class: "form-control-file" %>
+              </div>
+            <% end %>
+            <%= form.input :program_name, label: "Program Name", class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_description, label: "Program Description", class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_age, label: "Agency Age", class: "form-control", wrapper: :input_group %>
+            <%= form.input :evidence_based, label: "Do You Track Program Results", as: :boolean,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :case_management, label: "Case Management", class: "form-control", wrapper: :input_group %>
+            <%= form.input :evidence_based_description, label: "Evidence Based Description", as: :text,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_client_improvement, label: "Verified Successes of Program", as: :text,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :diaper_use, label: "Diaper Use", as: :text,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :other_diaper_use, label: "Do You Receive Diapers From Other Sources",
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :currently_provide_diapers, label: "Currently Providing Diapers?", as: :boolean,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :turn_away_child_care, label: "Turn Away Child Care", class: "form-control", wrapper: :input_group %>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Program Address</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :program_address1, label: "Address (line 1)", class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_address2, label: "Address (line 2)", class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_city, label: "City", class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_state, label: "State", class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_zip_code, label: "Zip Code", class: "form-control", wrapper: :input_group %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/profiles/edit/_agency_stability.html.erb
+++ b/app/views/partners/profiles/edit/_agency_stability.html.erb
@@ -11,7 +11,7 @@
             <%= form.input :form_990, label: "Form 990 Filed", as: :boolean, class: "form-control", wrapper: :input_group %>
             <label class="control-label col-md-3">Form 990</label>
             <% if true %>
-              <div> Work In Progress </div>
+              <strong> Deactivated Until Merger Is Completed </strong>
             <% elsif partner.proof_of_form_990.attached? %>
               <div class="col-md-8">
                 Attached

--- a/app/views/partners/profiles/edit/_attached_documents.html.erb
+++ b/app/views/partners/profiles/edit/_attached_documents.html.erb
@@ -1,0 +1,32 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Additional Documents</strong></h3>
+          </div>
+          <div class="card-body">
+            <% if partner.documents.attached? %>
+              <div class="row">
+                <div class="col-6">
+                  Attached files:
+                  <ul>
+                    <% partner.documents.each do |doc| %>
+                      <li><%= link_to doc.blob['filename'], rails_blob_path(doc), class: "font-weight-bold" %></li>
+                    <% end %>
+                  </ul>
+                </div>
+                <div class="col-6">
+                  <%= form.file_field :documents, multiple: true, class: "form-control-file" %>
+                </div>
+              </div>
+            <% else %>
+              <%= form.file_field :documents, multiple: true, class: "form-control-file" %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/profiles/edit/_attached_documents.html.erb
+++ b/app/views/partners/profiles/edit/_attached_documents.html.erb
@@ -7,7 +7,9 @@
             <h3 class="card-title"><strong>Additional Documents</strong></h3>
           </div>
           <div class="card-body">
-            <% if partner.documents.attached? %>
+            <% if true %>
+              <div> Work In Progress </div>
+            <% elsif partner.documents.attached? %>
               <div class="row">
                 <div class="col-6">
                   Attached files:

--- a/app/views/partners/profiles/edit/_attached_documents.html.erb
+++ b/app/views/partners/profiles/edit/_attached_documents.html.erb
@@ -8,7 +8,7 @@
           </div>
           <div class="card-body">
             <% if true %>
-              <div> Work In Progress </div>
+              <strong> Deactivated Until Merger Is Completed </strong>
             <% elsif partner.documents.attached? %>
               <div class="row">
                 <div class="col-6">

--- a/app/views/partners/profiles/edit/_diaper_pick_up_person.html.erb
+++ b/app/views/partners/profiles/edit/_diaper_pick_up_person.html.erb
@@ -1,0 +1,19 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Diaper Pick Up Person</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :pick_up_method, label: "Pick Up Method", class: "form-control", wrapper: :input_group %>
+            <%= form.input :pick_up_name, label: "Pick Up Person Name", class: "form-control", wrapper: :input_group %>
+            <%= form.input :pick_up_phone, label: "Pick Up Person's Phone #", class: "form-control", wrapper: :input_group %>
+            <%= form.input :pick_up_email, label: "Pick Up Person's Email", class: "form-control", wrapper: :input_group %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/profiles/edit/_executive_director.html.erb
+++ b/app/views/partners/profiles/edit/_executive_director.html.erb
@@ -1,0 +1,38 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Executive Director</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :executive_director_name, label: "Executive Director Name", class: "form-control", wrapper: :input_group %>
+            <%= form.input :executive_director_phone, label: "Executive Director Phone", class: "form-control", wrapper: :input_group %>
+            <%= form.input :executive_director_email, label: "Executive Director Email", class: "form-control", wrapper: :input_group %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Program Contact</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :program_contact_name, label: "Program Contact Name", class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_contact_phone, label: "Program Contact Phone", class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_contact_mobile, label: "Program Contact Cell", class: "form-control", wrapper: :input_group %>
+            <%= form.input :program_contact_email, label: "Program Contact Email", class: "form-control", wrapper: :input_group %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/profiles/edit/_media_information.html.erb
+++ b/app/views/partners/profiles/edit/_media_information.html.erb
@@ -1,0 +1,18 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Media Information</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :website, label: "DWebsite", class: "form-control", wrapper: :input_group %>
+            <%= form.input :facebook, label: "Facebook", class: "form-control", wrapper: :input_group %>
+            <%= form.input :twitter, label: "Twitter", class: "form-control", wrapper: :input_group %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/profiles/edit/_media_information.html.erb
+++ b/app/views/partners/profiles/edit/_media_information.html.erb
@@ -7,7 +7,7 @@
             <h3 class="card-title"><strong>Media Information</strong></h3>
           </div>
           <div class="card-body">
-            <%= form.input :website, label: "DWebsite", class: "form-control", wrapper: :input_group %>
+            <%= form.input :website, label: "Website", class: "form-control", wrapper: :input_group %>
             <%= form.input :facebook, label: "Facebook", class: "form-control", wrapper: :input_group %>
             <%= form.input :twitter, label: "Twitter", class: "form-control", wrapper: :input_group %>
           </div>

--- a/app/views/partners/profiles/edit/_organizational_capacity.html.erb
+++ b/app/views/partners/profiles/edit/_organizational_capacity.html.erb
@@ -1,0 +1,24 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Organization Capacity</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :max_serve, label: "Max Serve", class: "form-control", wrapper: :input_group %>
+            <%= form.input :incorporate_plan, label: "Incorporate Plan", class: "form-control", wrapper: :input_group %>
+            <%= form.input :responsible_staff_position, label: "Responsible Staff Position", as: :boolean,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :storage_space, label: "Storage Space", as: :boolean,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :describe_storage_space, label: "Storage Space Description", class: "form-control", wrapper: :input_group %>
+            <%= form.input :trusted_pickup, label: "Trusted Pickup", class: "form-control", wrapper: :input_group %>
+
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/profiles/edit/_population_served.html.erb
+++ b/app/views/partners/profiles/edit/_population_served.html.erb
@@ -1,0 +1,68 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Population Served</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :income_requirement_desc, label: "Clients Have An Income Requirement to Work With You?",
+                           as: :boolean, class: "form-control", wrapper: :input_group %>
+            <%= form.input :serve_income_circumstances,label: "Serve Income Circumstances",
+                           as: :boolean, class: "form-control", wrapper: :input_group %>
+            <%= form.input :income_verification,label: "Do You Verify The Income Of Your Clients?",
+                           as: :boolean, class: "form-control", wrapper: :input_group %>
+            <%= form.input :internal_db,label: "Do you maintain an internal database?",
+                           as: :boolean, class: "form-control", wrapper: :input_group %>
+            <%= form.input :maac,label: "Are you a MAAC Program Participant?",
+                           as: :boolean, class: "form-control", wrapper: :input_group %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Ethnic Composition of Those Served</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :population_black, label: "% African American", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :population_white, label: "% Caucasian", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :population_hispanic, label: "% Hispanic", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :population_asian, label: "% Asian", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :population_american_indian, label: "% American Indian", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :population_island, label: "% Pacific Island", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :population_multi_racial, label: "% Multi-racial", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :population_other, label: "% Other", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :zips_served, label: "Zip Codes Served", class: "form-control", wrapper: :input_group %>
+            <h3 class="font-weight-bold pt-3">Poverty Information of Those Served</h3>
+            <%= form.input :at_fpl_or_below, label: "% At FPL or Below", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :above_1_2_times_fpl, label: "% Above 1-2 times FPL", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :greater_2_times_fpl, label: "% Greater than 2 times FPL", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :poverty_unknown, label: "% Poverty Unknown", as: :integer,
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :ages_served, label: "Ages Served", class: "form-control", wrapper: :input_group %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/profiles/edit/_sources_of_funding.html.erb
+++ b/app/views/partners/profiles/edit/_sources_of_funding.html.erb
@@ -1,0 +1,20 @@
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-white">
+            <h3 class="card-title"><strong>Sources of Funding</strong></h3>
+          </div>
+          <div class="card-body">
+            <%= form.input :sources_of_funding, label: "Sources Of Funding", class: "form-control", wrapper: :input_group %>
+            <%= form.input :sources_of_diapers, label: "How do you currently obtain diapers?",
+                           class: "form-control", wrapper: :input_group %>
+            <%= form.input :diaper_budget, label: "Diaper Budget", class: "form-control", wrapper: :input_group %>
+            <%= form.input :diaper_funding_source, label: "Diaper Funding Source", class: "form-control", wrapper: :input_group %>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/profiles/show.html.erb
+++ b/app/views/partners/profiles/show.html.erb
@@ -1,0 +1,69 @@
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <% content_for :title, "My Organization - #{current_partner.name}" %>
+        <% if @partner.partner_status == "recertification_required" %>
+          <div class="alert alert-danger"><i class="fa fa-warning"></i>&nbsp;
+            Please review your application details and submit for approval.</div>
+        <% end %>
+        <h1><i class="fa fa-building"></i>&nbsp;&nbsp;Organization Details&nbsp;&nbsp;&nbsp;
+          <%= @partner.partner_status %>
+          <small>for <%= current_partner.name %></small>
+        </h1>
+      </div>
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item"><a href="<%= partner_user_root_path %>"><i class="fa fa-home fa-lg"></i></a></li>
+          <li class="breadcrumb-item"><a href="#">Profile</a></li>
+        </ol>
+      </div>
+    </div>
+  </div><!-- /.container-fluid -->
+</section>
+
+<div class="row">
+  <div class="col-md-12">
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-6">
+            <%= render "partners/profiles/show/agency_information" %>
+          </div>
+          <% @partner.partials_to_show.each do |partial| %>
+            <div class="col-6">
+              <%= render "partners/profiles/show/#{partial}" %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+</div>
+
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <!-- left column -->
+      <div class="col-md-12">
+        <!-- jquery validation -->
+        <div class="card card-primary">
+          <div class="card-footer">
+            <%# <% if @partner.verified? %> %>
+              <%# <%= link_to "Request Diapers", partner_requests_path, class: 'btn btn-success' %> %>
+            <%# <% end %> %>
+            <%# <% unless @partner.verified? %> %>
+              <%# <%= link_to partner_approve_path(@partner), class: "btn btn-primary #{'disabled' unless @partner.pending? || @partner.partner_status == "recertification_required"}" do %> %>
+                <%# <i class="fa fa-paper-plane"></i> Submit for Approval %>
+              <%# <% end %> %>
+            <%# <% end %> %>
+            <%# <%= link_to edit_partner_path(@partner), class: 'btn btn-primary' do %> %>
+              <%# <i class="fa fa-pencil"></i> Update Information %>
+            <%# <% end %> %>
+          <%# </div> %>
+        </div>
+        <!-- /.card -->
+      </div>
+      <!--/.col (left) -->
+    </div>
+    <!-- /.row -->
+  </div><!-- /.container-fluid -->
+</section>

--- a/app/views/partners/profiles/show.html.erb
+++ b/app/views/partners/profiles/show.html.erb
@@ -3,12 +3,12 @@
     <div class="row mb-2">
       <div class="col-sm-6">
         <% content_for :title, "My Organization - #{current_partner.name}" %>
-        <% if @partner.partner_status == "recertification_required" %>
+        <% if current_partner.partner_status == "recertification_required" %>
           <div class="alert alert-danger"><i class="fa fa-warning"></i>&nbsp;
             Please review your application details and submit for approval.</div>
         <% end %>
         <h1><i class="fa fa-building"></i>&nbsp;&nbsp;Organization Details&nbsp;&nbsp;&nbsp;
-          <%= @partner.partner_status %>
+          <%= current_partner.partner_status %>
           <small>for <%= current_partner.name %></small>
         </h1>
       </div>
@@ -27,11 +27,11 @@
       <div class="container-fluid">
         <div class="row">
           <div class="col-6">
-            <%= render "partners/profiles/show/agency_information" %>
+            <%= render partial: "partners/profiles/show/agency_information", locals: { partner: current_partner } %>
           </div>
-          <% @partner.partials_to_show.each do |partial| %>
+          <% current_partner.partials_to_show.each do |partial| %>
             <div class="col-6">
-              <%= render "partners/profiles/show/#{partial}" %>
+              <%= render partial: "partners/profiles/show/#{partial}", locals: { partner: current_partner }%>
             </div>
           <% end %>
         </div>
@@ -47,18 +47,18 @@
         <!-- jquery validation -->
         <div class="card card-primary">
           <div class="card-footer">
-            <%# <% if @partner.verified? %> %>
-              <%# <%= link_to "Request Diapers", partner_requests_path, class: 'btn btn-success' %> %>
-            <%# <% end %> %>
-            <%# <% unless @partner.verified? %> %>
-              <%# <%= link_to partner_approve_path(@partner), class: "btn btn-primary #{'disabled' unless @partner.pending? || @partner.partner_status == "recertification_required"}" do %> %>
+            <% if current_partner.verified? %>
+              <%= link_to "My Essentials Requests", partners_requests_path, class: 'btn btn-success' %>
+            <% end %>
+            <% unless current_partner.verified? %>
+              <%# <%= link_to partner_approve_path(current_partner), class: "btn btn-primary #{'disabled' unless current_partner.pending? || current_partner.partner_status == "recertification_required"}" do %> %>
                 <%# <i class="fa fa-paper-plane"></i> Submit for Approval %>
               <%# <% end %> %>
-            <%# <% end %> %>
-            <%# <%= link_to edit_partner_path(@partner), class: 'btn btn-primary' do %> %>
-              <%# <i class="fa fa-pencil"></i> Update Information %>
-            <%# <% end %> %>
-          <%# </div> %>
+            <% end %>
+            <%= link_to edit_partners_profile_path, class: 'btn btn-primary' do %>
+              <i class="fa fa-pencil"></i> Update Information
+            <% end %>
+          </div>
         </div>
         <!-- /.card -->
       </div>

--- a/app/views/partners/profiles/show.html.erb
+++ b/app/views/partners/profiles/show.html.erb
@@ -48,13 +48,19 @@
         <div class="card card-primary">
           <div class="card-footer">
             <% if current_partner.verified? %>
-              <%= link_to "My Essentials Requests", partners_requests_path, class: 'btn btn-success' %>
+              <%= link_to '', class: 'btn btn-info disabled' do %>
+                <i class="fa fa-check"></i> Approved
+              <% end %>
+            <% elsif current_partner.partner_status == 'submitted' %>
+              <%= link_to '', class: "btn btn-warning disabled" do %>
+                <i class="fa fa-clock"></i> Pending Approval
+              <% end %>
+            <% else %>
+              <%= link_to approve_partners_profile_path, class: "btn btn-success" do %>
+                <i class="fa fa-paper-plane"></i> Submit for Approval
+              <% end %>
             <% end %>
-            <% unless current_partner.verified? %>
-              <%# <%= link_to partner_approve_path(current_partner), class: "btn btn-primary #{'disabled' unless current_partner.pending? || current_partner.partner_status == "recertification_required"}" do %> %>
-                <%# <i class="fa fa-paper-plane"></i> Submit for Approval %>
-              <%# <% end %> %>
-            <% end %>
+
             <%= link_to edit_partners_profile_path, class: 'btn btn-primary' do %>
               <i class="fa fa-pencil"></i> Update Information
             <% end %>

--- a/app/views/partners/profiles/show.html.erb
+++ b/app/views/partners/profiles/show.html.erb
@@ -8,7 +8,7 @@
             Please review your application details and submit for approval.</div>
         <% end %>
         <h1><i class="fa fa-building"></i>&nbsp;&nbsp;Organization Details&nbsp;&nbsp;&nbsp;
-          <%= current_partner.partner_status %>
+          <%= partner_status_badge(current_partner) %>
           <small>for <%= current_partner.name %></small>
         </h1>
       </div>
@@ -56,7 +56,7 @@
                 <i class="fa fa-clock"></i> Pending Approval
               <% end %>
             <% else %>
-              <%= link_to approve_partners_profile_path, class: "btn btn-success" do %>
+              <%= link_to partners_approval_request_path, method: :post, class: "btn btn-success" do %>
                 <i class="fa fa-paper-plane"></i> Submit for Approval
               <% end %>
             <% end %>

--- a/app/views/partners/profiles/show/_agency_distribution_information.html.erb
+++ b/app/views/partners/profiles/show/_agency_distribution_information.html.erb
@@ -1,0 +1,15 @@
+<div class="card mb-4">
+  <h5 class="card-header bg-primary text-white">Agency Distribution Information</h5>
+  <div class="card-body">
+    <dl>
+      <dt>Distribution Times</dt>
+      <dd><%= @partner.distribution_times %></dd>
+
+      <dt>New Client Times</dt>
+      <dd><%= @partner.new_client_times %></dd>
+
+      <dt>More Docs Required</dt>
+      <dd><%= @partner.more_docs_required %></dd>
+    </dl>
+  </div>
+</div>

--- a/app/views/partners/profiles/show/_agency_distribution_information.html.erb
+++ b/app/views/partners/profiles/show/_agency_distribution_information.html.erb
@@ -3,13 +3,13 @@
   <div class="card-body">
     <dl>
       <dt>Distribution Times</dt>
-      <dd><%= @partner.distribution_times %></dd>
+      <dd><%= partner.distribution_times %></dd>
 
       <dt>New Client Times</dt>
-      <dd><%= @partner.new_client_times %></dd>
+      <dd><%= partner.new_client_times %></dd>
 
       <dt>More Docs Required</dt>
-      <dd><%= @partner.more_docs_required %></dd>
+      <dd><%= partner.more_docs_required %></dd>
     </dl>
   </div>
 </div>

--- a/app/views/partners/profiles/show/_agency_information.html.erb
+++ b/app/views/partners/profiles/show/_agency_information.html.erb
@@ -1,0 +1,41 @@
+<div class="card mb-4">
+  <h5 class="card-header bg-primary text-white">Agency Information</h5>
+  <div class="card-body">
+    <dl>
+      <dt>Name</dt>
+      <dd><%= @partner.name %></dd>
+
+      <dt>Agency Type</dt>
+      <dd><%= @partner.agency_type %></dd>
+
+      <% if @partner.agency_type == "Other" %>
+        <dt>Other Agency Type</dt>
+        <dd><%= @partner.other_agency_type %></dd>
+      <% end %>
+
+      <dt>Status</dt>
+      <dd><%= @partner.partner_status.humanize %></dd>
+
+      <dt>501(c)(3) IRS Determination Letter</dt>
+      <% if @partner.proof_of_partner_status.attached? %>
+        <dd>Attached
+          file: <%= link_to @partner.proof_of_partner_status.blob['filename'], rails_blob_path(@partner.proof_of_partner_status), class: "font-weight-bold" %></dd>
+      <% else %>
+        <dd>Documentation not on file</dd>
+      <% end %>
+
+      <dt>Description of Agency Mission</dt>
+      <dd><%= @partner.agency_mission %></dd>
+
+      <address>
+        <strong>Address</strong> <br>
+        <%= @partner.address1 %> <br>
+        <% unless @partner.address2.blank? %> <br>
+          <%= @partner.address2 %> <br>
+        <% end %>
+        <%= @partner.city %> <%= @partner.state %> <br>
+        <%= @partner.zip_code %>
+      </address>
+    </dl>
+  </div>
+</div>

--- a/app/views/partners/profiles/show/_agency_information.html.erb
+++ b/app/views/partners/profiles/show/_agency_information.html.erb
@@ -3,38 +3,38 @@
   <div class="card-body">
     <dl>
       <dt>Name</dt>
-      <dd><%= @partner.name %></dd>
+      <dd><%= partner.name %></dd>
 
       <dt>Agency Type</dt>
-      <dd><%= @partner.agency_type %></dd>
+      <dd><%= partner.agency_type %></dd>
 
-      <% if @partner.agency_type == "Other" %>
+      <% if partner.agency_type == "Other" %>
         <dt>Other Agency Type</dt>
-        <dd><%= @partner.other_agency_type %></dd>
+        <dd><%= partner.other_agency_type %></dd>
       <% end %>
 
       <dt>Status</dt>
-      <dd><%= @partner.partner_status.humanize %></dd>
+      <dd><%= partner.partner_status.humanize %></dd>
 
       <dt>501(c)(3) IRS Determination Letter</dt>
-      <% if @partner.proof_of_partner_status.attached? %>
+      <% if partner.proof_of_partner_status.attached? %>
         <dd>Attached
-          file: <%= link_to @partner.proof_of_partner_status.blob['filename'], rails_blob_path(@partner.proof_of_partner_status), class: "font-weight-bold" %></dd>
+          file: <%= link_to partner.proof_of_partner_status.blob['filename'], rails_blob_path(partner.proof_of_partner_status), class: "font-weight-bold" %></dd>
       <% else %>
         <dd>Documentation not on file</dd>
       <% end %>
 
       <dt>Description of Agency Mission</dt>
-      <dd><%= @partner.agency_mission %></dd>
+      <dd><%= partner.agency_mission %></dd>
 
       <address>
         <strong>Address</strong> <br>
-        <%= @partner.address1 %> <br>
-        <% unless @partner.address2.blank? %> <br>
-          <%= @partner.address2 %> <br>
+        <%= partner.address1 %> <br>
+        <% unless partner.address2.blank? %> <br>
+          <%= partner.address2 %> <br>
         <% end %>
-        <%= @partner.city %> <%= @partner.state %> <br>
-        <%= @partner.zip_code %>
+        <%= partner.city %> <%= partner.state %> <br>
+        <%= partner.zip_code %>
       </address>
     </dl>
   </div>

--- a/app/views/partners/profiles/show/_agency_stability.html.erb
+++ b/app/views/partners/profiles/show/_agency_stability.html.erb
@@ -1,0 +1,63 @@
+<div class="card mb-4">
+  <h5 class="card-header bg-primary text-white">Agency Stability</h5>
+  <div class="card-body">
+    <dl>
+      <dt>Year Founded</dt>
+      <dd><%= @partner.founded %></dd>
+
+      <dt>Form 990 Filed</dt>
+      <dd><%= humanize_boolean(@partner.form_990) %></dd>
+
+      <dt>Form 990</dt>
+      <% if @partner.proof_of_form_990.attached? %>
+        <dd>Attached
+          file: <%= link_to @partner.proof_of_form_990.blob['filename'], rails_blob_path(@partner.proof_of_form_990), class: "font-weight-bold" %></dd>
+      <% else %>
+        <dd>Form 990 not on file</dd>
+      <% end %>
+
+      <dt>Program Name</dt>
+      <dd><%= @partner.program_name %></dd>
+
+      <dt>Program Description</dt>
+      <dd><%= @partner.program_description %></dd>
+
+      <dt>Agency Age</dt>
+      <dd><%= @partner.program_age %></dd>
+
+      <dt>Case Management</dt>
+      <dd><%= humanize_boolean(@partner.case_management) %></dd>
+
+      <dt>Evidence Based</dt>
+      <dd><%= humanize_boolean(@partner.evidence_based) %></dd>
+
+      <dt>Evidence Base Description</dt>
+      <dd><%= @partner.evidence_based_description %></dd>
+
+      <dt>Verified Successes of Program</dt>
+      <dd><%= @partner.program_client_improvement %></dd>
+
+      <dt>Diaper Use</dt>
+      <dd><%= @partner.diaper_use %></dd>
+
+      <dt>Do You Receive Diapers From Other Sources</dt>
+      <dd><%= @partner.other_diaper_use %></dd>
+
+      <dt>Current Providing Diapers</dt>
+      <dd><%= humanize_boolean(@partner.currently_provide_diapers) %></dd>
+
+      <dt>Turn Away Child Care</dt>
+      <dd><%= humanize_boolean(@partner.turn_away_child_care) %></dd>
+
+      <address>
+        <strong>Program Address</strong> <br>
+        <%= @partner.program_address1 %> <br>
+        <% unless @partner.program_address2.blank? %>
+          <%= @partner.program_address2 %> <br>
+        <% end %>
+        <%= @partner.program_city %> <%= @partner.program_state %> <br>
+        <%= @partner.program_zip_code %>
+      </address>
+    </dl>
+  </div>
+</div>

--- a/app/views/partners/profiles/show/_agency_stability.html.erb
+++ b/app/views/partners/profiles/show/_agency_stability.html.erb
@@ -3,60 +3,60 @@
   <div class="card-body">
     <dl>
       <dt>Year Founded</dt>
-      <dd><%= @partner.founded %></dd>
+      <dd><%= partner.founded %></dd>
 
       <dt>Form 990 Filed</dt>
-      <dd><%= humanize_boolean(@partner.form_990) %></dd>
+      <dd><%= humanize_boolean(partner.form_990) %></dd>
 
       <dt>Form 990</dt>
-      <% if @partner.proof_of_form_990.attached? %>
+      <% if partner.proof_of_form_990.attached? %>
         <dd>Attached
-          file: <%= link_to @partner.proof_of_form_990.blob['filename'], rails_blob_path(@partner.proof_of_form_990), class: "font-weight-bold" %></dd>
+          file: <%= link_to partner.proof_of_form_990.blob['filename'], rails_blob_path(partner.proof_of_form_990), class: "font-weight-bold" %></dd>
       <% else %>
         <dd>Form 990 not on file</dd>
       <% end %>
 
       <dt>Program Name</dt>
-      <dd><%= @partner.program_name %></dd>
+      <dd><%= partner.program_name %></dd>
 
       <dt>Program Description</dt>
-      <dd><%= @partner.program_description %></dd>
+      <dd><%= partner.program_description %></dd>
 
       <dt>Agency Age</dt>
-      <dd><%= @partner.program_age %></dd>
+      <dd><%= partner.program_age %></dd>
 
       <dt>Case Management</dt>
-      <dd><%= humanize_boolean(@partner.case_management) %></dd>
+      <dd><%= humanize_boolean(partner.case_management) %></dd>
 
       <dt>Evidence Based</dt>
-      <dd><%= humanize_boolean(@partner.evidence_based) %></dd>
+      <dd><%= humanize_boolean(partner.evidence_based) %></dd>
 
       <dt>Evidence Base Description</dt>
-      <dd><%= @partner.evidence_based_description %></dd>
+      <dd><%= partner.evidence_based_description %></dd>
 
       <dt>Verified Successes of Program</dt>
-      <dd><%= @partner.program_client_improvement %></dd>
+      <dd><%= partner.program_client_improvement %></dd>
 
       <dt>Diaper Use</dt>
-      <dd><%= @partner.diaper_use %></dd>
+      <dd><%= partner.diaper_use %></dd>
 
       <dt>Do You Receive Diapers From Other Sources</dt>
-      <dd><%= @partner.other_diaper_use %></dd>
+      <dd><%= partner.other_diaper_use %></dd>
 
       <dt>Current Providing Diapers</dt>
-      <dd><%= humanize_boolean(@partner.currently_provide_diapers) %></dd>
+      <dd><%= humanize_boolean(partner.currently_provide_diapers) %></dd>
 
       <dt>Turn Away Child Care</dt>
-      <dd><%= humanize_boolean(@partner.turn_away_child_care) %></dd>
+      <dd><%= humanize_boolean(partner.turn_away_child_care) %></dd>
 
       <address>
         <strong>Program Address</strong> <br>
-        <%= @partner.program_address1 %> <br>
-        <% unless @partner.program_address2.blank? %>
-          <%= @partner.program_address2 %> <br>
+        <%= partner.program_address1 %> <br>
+        <% unless partner.program_address2.blank? %>
+          <%= partner.program_address2 %> <br>
         <% end %>
-        <%= @partner.program_city %> <%= @partner.program_state %> <br>
-        <%= @partner.program_zip_code %>
+        <%= partner.program_city %> <%= partner.program_state %> <br>
+        <%= partner.program_zip_code %>
       </address>
     </dl>
   </div>

--- a/app/views/partners/profiles/show/_attached_documents.html.erb
+++ b/app/views/partners/profiles/show/_attached_documents.html.erb
@@ -1,0 +1,13 @@
+<div class="card mb-4">
+  <h5 class="card-header bg-primary text-white">Attached Documents</h5>
+  <div class="card-body">
+    <% if @partner.documents.attached? %>
+      <dt>Attached files:</dt>
+      <% @partner.documents.each do |doc| %>
+        <dd><%= link_to doc.blob['filename'], rails_blob_path(doc), class: "font-weight-bold" %></dd>
+      <% end %>
+    <% else %>
+      <dd>No files saved</dd>
+    <% end %>
+  </div>
+</div>

--- a/app/views/partners/profiles/show/_attached_documents.html.erb
+++ b/app/views/partners/profiles/show/_attached_documents.html.erb
@@ -1,9 +1,9 @@
 <div class="card mb-4">
   <h5 class="card-header bg-primary text-white">Attached Documents</h5>
   <div class="card-body">
-    <% if @partner.documents.attached? %>
+    <% if partner.documents.attached? %>
       <dt>Attached files:</dt>
-      <% @partner.documents.each do |doc| %>
+      <% partner.documents.each do |doc| %>
         <dd><%= link_to doc.blob['filename'], rails_blob_path(doc), class: "font-weight-bold" %></dd>
       <% end %>
     <% else %>

--- a/app/views/partners/profiles/show/_diaper_pick_up_person.html.erb
+++ b/app/views/partners/profiles/show/_diaper_pick_up_person.html.erb
@@ -1,0 +1,18 @@
+<div class="card mb-4">
+  <h5 class="card-header bg-primary text-white">Diaper Pick Up Person</h5>
+  <div class="card-body">
+    <dl>
+      <dt>Pick Up Method</dt>
+      <dd><%= @partner.pick_up_method %></dd>
+
+      <dt>Name</dt>
+      <dd><%= @partner.pick_up_name %></dd>
+
+      <dt>Phone</dt>
+      <dd><%= @partner.pick_up_phone %></dd>
+
+      <dt>Email</dt>
+      <dd><%= @partner.pick_up_email %></dd>
+    </dl>
+  </div>
+</div>

--- a/app/views/partners/profiles/show/_diaper_pick_up_person.html.erb
+++ b/app/views/partners/profiles/show/_diaper_pick_up_person.html.erb
@@ -3,16 +3,16 @@
   <div class="card-body">
     <dl>
       <dt>Pick Up Method</dt>
-      <dd><%= @partner.pick_up_method %></dd>
+      <dd><%= partner.pick_up_method %></dd>
 
       <dt>Name</dt>
-      <dd><%= @partner.pick_up_name %></dd>
+      <dd><%= partner.pick_up_name %></dd>
 
       <dt>Phone</dt>
-      <dd><%= @partner.pick_up_phone %></dd>
+      <dd><%= partner.pick_up_phone %></dd>
 
       <dt>Email</dt>
-      <dd><%= @partner.pick_up_email %></dd>
+      <dd><%= partner.pick_up_email %></dd>
     </dl>
   </div>
 </div>

--- a/app/views/partners/profiles/show/_executive_director.html.erb
+++ b/app/views/partners/profiles/show/_executive_director.html.erb
@@ -1,0 +1,30 @@
+<div class="card mb-4">
+  <h5 class="card-header bg-primary text-white">Executive Director</h5>
+  <div class="card-body">
+    <dl>
+      <dt>Name</dt>
+      <dd><%= @partner.executive_director_name %></dd>
+
+      <dt>Phone Number</dt>
+      <dd><%= @partner.executive_director_phone %></dd>
+
+      <dt>Email</dt>
+      <dd><%= @partner.executive_director_email %></dd>
+    </dl>
+
+    <h6>Program Contact Person</h6>
+    <dl>
+      <dt>Name</dt>
+      <dd><%= @partner.program_contact_name %></dd>
+
+      <dt>Phone Number</dt>
+      <dd><%= @partner.program_contact_phone %></dd>
+
+      <dt>Mobile Phone Number</dt>
+      <dd><%= @partner.program_contact_mobile %></dd>
+
+      <dt>Email</dt>
+      <dd><%= @partner.program_contact_email %></dd>
+    </dl>
+  </div>
+</div>

--- a/app/views/partners/profiles/show/_executive_director.html.erb
+++ b/app/views/partners/profiles/show/_executive_director.html.erb
@@ -3,28 +3,28 @@
   <div class="card-body">
     <dl>
       <dt>Name</dt>
-      <dd><%= @partner.executive_director_name %></dd>
+      <dd><%= partner.executive_director_name %></dd>
 
       <dt>Phone Number</dt>
-      <dd><%= @partner.executive_director_phone %></dd>
+      <dd><%= partner.executive_director_phone %></dd>
 
       <dt>Email</dt>
-      <dd><%= @partner.executive_director_email %></dd>
+      <dd><%= partner.executive_director_email %></dd>
     </dl>
 
     <h6>Program Contact Person</h6>
     <dl>
       <dt>Name</dt>
-      <dd><%= @partner.program_contact_name %></dd>
+      <dd><%= partner.program_contact_name %></dd>
 
       <dt>Phone Number</dt>
-      <dd><%= @partner.program_contact_phone %></dd>
+      <dd><%= partner.program_contact_phone %></dd>
 
       <dt>Mobile Phone Number</dt>
-      <dd><%= @partner.program_contact_mobile %></dd>
+      <dd><%= partner.program_contact_mobile %></dd>
 
       <dt>Email</dt>
-      <dd><%= @partner.program_contact_email %></dd>
+      <dd><%= partner.program_contact_email %></dd>
     </dl>
   </div>
 </div>

--- a/app/views/partners/profiles/show/_media_information.html.erb
+++ b/app/views/partners/profiles/show/_media_information.html.erb
@@ -1,0 +1,15 @@
+<div class="card mb-4">
+  <h5 class="card-header bg-primary text-white">Media Information</h5>
+  <div class="card-body">
+    <dl>
+      <dt>Website</dt>
+      <dd><%= @partner.website %></dd>
+
+      <dt>Facebook</dt>
+      <dd><%= @partner.facebook %></dd>
+
+      <dt>Twitter</dt>
+      <dd><%= @partner.twitter %></dd>
+    </dl>
+  </div>
+</div>

--- a/app/views/partners/profiles/show/_media_information.html.erb
+++ b/app/views/partners/profiles/show/_media_information.html.erb
@@ -3,13 +3,13 @@
   <div class="card-body">
     <dl>
       <dt>Website</dt>
-      <dd><%= @partner.website %></dd>
+      <dd><%= partner.website %></dd>
 
       <dt>Facebook</dt>
-      <dd><%= @partner.facebook %></dd>
+      <dd><%= partner.facebook %></dd>
 
       <dt>Twitter</dt>
-      <dd><%= @partner.twitter %></dd>
+      <dd><%= partner.twitter %></dd>
     </dl>
   </div>
 </div>

--- a/app/views/partners/profiles/show/_organizational_capacity.html.erb
+++ b/app/views/partners/profiles/show/_organizational_capacity.html.erb
@@ -1,0 +1,21 @@
+<div class="card mb-4">
+  <h5 class="card-header bg-primary text-white">Organizational Capacity</h5>
+  <div class="card-body">
+    <dl>
+      <dt>Max Serve</dt>
+      <dd><%= @partner.max_serve %></dd>
+
+      <dt>Incorporate Plan</dt>
+      <dd><%= @partner.incorporate_plan %></dd>
+
+      <dt>Responsible Staff Position</dt>
+      <dd><%= humanize_boolean(@partner.responsible_staff_position) %></dd>
+
+      <dt>Storage Space</dt>
+      <dd><%= humanize_boolean(@partner.storage_space) %></dd>
+
+      <dt>Storage Space Description</dt>
+      <dd><%= @partner.describe_storage_space %></dd>
+    </dl>
+  </div>
+</div>

--- a/app/views/partners/profiles/show/_organizational_capacity.html.erb
+++ b/app/views/partners/profiles/show/_organizational_capacity.html.erb
@@ -3,19 +3,19 @@
   <div class="card-body">
     <dl>
       <dt>Max Serve</dt>
-      <dd><%= @partner.max_serve %></dd>
+      <dd><%= partner.max_serve %></dd>
 
       <dt>Incorporate Plan</dt>
-      <dd><%= @partner.incorporate_plan %></dd>
+      <dd><%= partner.incorporate_plan %></dd>
 
       <dt>Responsible Staff Position</dt>
-      <dd><%= humanize_boolean(@partner.responsible_staff_position) %></dd>
+      <dd><%= humanize_boolean(partner.responsible_staff_position) %></dd>
 
       <dt>Storage Space</dt>
-      <dd><%= humanize_boolean(@partner.storage_space) %></dd>
+      <dd><%= humanize_boolean(partner.storage_space) %></dd>
 
       <dt>Storage Space Description</dt>
-      <dd><%= @partner.describe_storage_space %></dd>
+      <dd><%= partner.describe_storage_space %></dd>
     </dl>
   </div>
 </div>

--- a/app/views/partners/profiles/show/_population_served.html.erb
+++ b/app/views/partners/profiles/show/_population_served.html.erb
@@ -1,0 +1,65 @@
+<div class="card mb-4">
+  <h5 class="card-header bg-primary text-white">Population Served</h5>
+  <div class="card-body">
+    <dl>
+      <dt>Clients Have An Income Requirement to Work With You</dt>
+      <dd><%= humanize_boolean(@partner.income_requirement_desc) %></dd>
+
+      <dt>Serve Income Circumstances</dt>
+      <dd><%= humanize_boolean(@partner.serve_income_circumstances) %></dd>
+
+      <dt>Do You Verify The Income Of Your Clients</dt>
+      <dd><%= humanize_boolean(@partner.income_verification) %></dd>
+
+      <dt>Internal DB</dt>
+      <dd><%= humanize_boolean(@partner.internal_db) %></dd>
+
+      <dt>MAAC Program Participant</dt>                  <dd><%= humanize_boolean(@partner.maac) %></dd>
+
+      <h6>Ethnic Composition of Those Served</h6>
+      <dt>African American</dt>
+      <dd><%= @partner.population_black || t(:not_provided) %></dd>
+
+      <dt>Caucasian</dt>
+      <dd><%= @partner.population_white || t(:not_provided) %></dd>
+
+      <dt>Hispanic</dt>
+      <dd><%= @partner.population_hispanic || t(:not_provided) %></dd>
+
+      <dt>Asian</dt>
+      <dd><%= @partner.population_asian || t(:not_provided) %></dd>
+
+      <dt>American Indian</dt>
+      <dd><%= @partner.population_american_indian || t(:not_provided) %></dd>
+
+      <dt>Pacific Islander</dt>
+      <dd><%= @partner.population_island || t(:not_provided) %></dd>
+
+      <dt>Multi-racial</dt>
+      <dd><%= @partner.population_multi_racial || t(:not_provided) %></dd>
+
+      <dt>Other</dt>
+      <dd><%= @partner.population_other || t(:not_provided) %></dd>
+
+      <dt>Zip Codes Served</dt>
+      <dd><%= @partner.zips_served %></dd>
+
+      <h6>Poverty Information of Those Served</h6>
+      <dt>At FPL or below</dt>
+      <dd><%= @partner.at_fpl_or_below || t(:not_provided) %></dd>
+
+      <dt>Above 1-2 times FPL</dt>
+      <dd><%= @partner.above_1_2_times_fpl || t(:not_provided) %></dd>
+
+      <dt>Greater than 2 times FPL</dt>
+      <dd><%= @partner.greater_2_times_fpl || t(:not_provided) %></dd>
+
+      <dt>Poverty Unknown</dt>
+      <dd><%= @partner.poverty_unknown || t(:not_provided) %></dd>
+
+      <h6>Ages Served</h6>
+      <dt>Ages</dt>
+      <dd><%= @partner.ages_served || t(:not_provided) %></dd>
+    </dl>
+  </div>
+</div>

--- a/app/views/partners/profiles/show/_population_served.html.erb
+++ b/app/views/partners/profiles/show/_population_served.html.erb
@@ -3,63 +3,63 @@
   <div class="card-body">
     <dl>
       <dt>Clients Have An Income Requirement to Work With You</dt>
-      <dd><%= humanize_boolean(@partner.income_requirement_desc) %></dd>
+      <dd><%= humanize_boolean(partner.income_requirement_desc) %></dd>
 
       <dt>Serve Income Circumstances</dt>
-      <dd><%= humanize_boolean(@partner.serve_income_circumstances) %></dd>
+      <dd><%= humanize_boolean(partner.serve_income_circumstances) %></dd>
 
       <dt>Do You Verify The Income Of Your Clients</dt>
-      <dd><%= humanize_boolean(@partner.income_verification) %></dd>
+      <dd><%= humanize_boolean(partner.income_verification) %></dd>
 
       <dt>Internal DB</dt>
-      <dd><%= humanize_boolean(@partner.internal_db) %></dd>
+      <dd><%= humanize_boolean(partner.internal_db) %></dd>
 
-      <dt>MAAC Program Participant</dt>                  <dd><%= humanize_boolean(@partner.maac) %></dd>
+      <dt>MAAC Program Participant</dt>                  <dd><%= humanize_boolean(partner.maac) %></dd>
 
       <h6>Ethnic Composition of Those Served</h6>
       <dt>African American</dt>
-      <dd><%= @partner.population_black || t(:not_provided) %></dd>
+      <dd><%= partner.population_black || t(:not_provided) %></dd>
 
       <dt>Caucasian</dt>
-      <dd><%= @partner.population_white || t(:not_provided) %></dd>
+      <dd><%= partner.population_white || t(:not_provided) %></dd>
 
       <dt>Hispanic</dt>
-      <dd><%= @partner.population_hispanic || t(:not_provided) %></dd>
+      <dd><%= partner.population_hispanic || t(:not_provided) %></dd>
 
       <dt>Asian</dt>
-      <dd><%= @partner.population_asian || t(:not_provided) %></dd>
+      <dd><%= partner.population_asian || t(:not_provided) %></dd>
 
       <dt>American Indian</dt>
-      <dd><%= @partner.population_american_indian || t(:not_provided) %></dd>
+      <dd><%= partner.population_american_indian || t(:not_provided) %></dd>
 
       <dt>Pacific Islander</dt>
-      <dd><%= @partner.population_island || t(:not_provided) %></dd>
+      <dd><%= partner.population_island || t(:not_provided) %></dd>
 
       <dt>Multi-racial</dt>
-      <dd><%= @partner.population_multi_racial || t(:not_provided) %></dd>
+      <dd><%= partner.population_multi_racial || t(:not_provided) %></dd>
 
       <dt>Other</dt>
-      <dd><%= @partner.population_other || t(:not_provided) %></dd>
+      <dd><%= partner.population_other || t(:not_provided) %></dd>
 
       <dt>Zip Codes Served</dt>
-      <dd><%= @partner.zips_served %></dd>
+      <dd><%= partner.zips_served %></dd>
 
       <h6>Poverty Information of Those Served</h6>
       <dt>At FPL or below</dt>
-      <dd><%= @partner.at_fpl_or_below || t(:not_provided) %></dd>
+      <dd><%= partner.at_fpl_or_below || t(:not_provided) %></dd>
 
       <dt>Above 1-2 times FPL</dt>
-      <dd><%= @partner.above_1_2_times_fpl || t(:not_provided) %></dd>
+      <dd><%= partner.above_1_2_times_fpl || t(:not_provided) %></dd>
 
       <dt>Greater than 2 times FPL</dt>
-      <dd><%= @partner.greater_2_times_fpl || t(:not_provided) %></dd>
+      <dd><%= partner.greater_2_times_fpl || t(:not_provided) %></dd>
 
       <dt>Poverty Unknown</dt>
-      <dd><%= @partner.poverty_unknown || t(:not_provided) %></dd>
+      <dd><%= partner.poverty_unknown || t(:not_provided) %></dd>
 
       <h6>Ages Served</h6>
       <dt>Ages</dt>
-      <dd><%= @partner.ages_served || t(:not_provided) %></dd>
+      <dd><%= partner.ages_served || t(:not_provided) %></dd>
     </dl>
   </div>
 </div>

--- a/app/views/partners/profiles/show/_population_served.html.erb
+++ b/app/views/partners/profiles/show/_population_served.html.erb
@@ -14,7 +14,8 @@
       <dt>Internal DB</dt>
       <dd><%= humanize_boolean(partner.internal_db) %></dd>
 
-      <dt>MAAC Program Participant</dt>                  <dd><%= humanize_boolean(partner.maac) %></dd>
+      <dt>MAAC Program Participant</dt>
+      <dd><%= humanize_boolean(partner.maac) %></dd>
 
       <h6>Ethnic Composition of Those Served</h6>
       <dt>African American</dt>

--- a/app/views/partners/profiles/show/_sources_of_funding.html.erb
+++ b/app/views/partners/profiles/show/_sources_of_funding.html.erb
@@ -1,0 +1,18 @@
+<div class="card mb-4">
+  <h5 class="card-header bg-primary text-white">Sources of Funding</h5>
+  <div class="card-body">
+    <dl>
+      <dt>Sources of Funding</dt>
+      <dd><%= @partner.sources_of_funding %></dd>
+
+      <dt>How do you currently obtain diapers?</dt>
+      <dd><%= @partner.sources_of_diapers %></dd>
+
+      <dt>Diaper Budget</dt>
+      <dd><%= @partner.diaper_budget %></dd>
+
+      <dt>Diaper Funding Source</dt>
+      <dd><%= @partner.diaper_funding_source %></dd>
+    </dl>
+  </div>
+</div>

--- a/app/views/partners/profiles/show/_sources_of_funding.html.erb
+++ b/app/views/partners/profiles/show/_sources_of_funding.html.erb
@@ -3,16 +3,16 @@
   <div class="card-body">
     <dl>
       <dt>Sources of Funding</dt>
-      <dd><%= @partner.sources_of_funding %></dd>
+      <dd><%= partner.sources_of_funding %></dd>
 
       <dt>How do you currently obtain diapers?</dt>
-      <dd><%= @partner.sources_of_diapers %></dd>
+      <dd><%= partner.sources_of_diapers %></dd>
 
       <dt>Diaper Budget</dt>
-      <dd><%= @partner.diaper_budget %></dd>
+      <dd><%= partner.diaper_budget %></dd>
 
       <dt>Diaper Funding Source</dt>
-      <dd><%= @partner.diaper_funding_source %></dd>
+      <dd><%= partner.diaper_funding_source %></dd>
     </dl>
   </div>
 </div>

--- a/app/views/partners/requests/index.html.erb
+++ b/app/views/partners/requests/index.html.erb
@@ -18,7 +18,7 @@
           <li class="breadcrumb-item"><a href="#">Essentials Requests</a></li>
         </ol>
       </div>
-    </div>`
+    </div>
   </div><!-- /.container-fluid -->
 </section>
 

--- a/app/views/partners/requests/new.html.erb
+++ b/app/views/partners/requests/new.html.erb
@@ -10,7 +10,6 @@
       </div>
       <div class="col-sm-6">
         <ol class="breadcrumb float-sm-right">
-
           <li class="breadcrumb-item"><a href="<%= partner_user_root_path %>"><i class="fa fa-home fa-lg"></i></a></li>
           <li class="breadcrumb-item"><a href="#">New Essentials Request</a></li>
         </ol>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,11 +34,8 @@ Rails.application.routes.draw do
   namespace :partners do
     resource :dashboard, only: [:show]
     resources :requests, only: [:show, :new, :index, :create]
-    resource :profile, only: [:show, :edit, :update] do
-      collection do
-        get :approve
-      end
-    end
+    resource :profile, only: [:show, :edit, :update]
+    resource :approval_request, only: [:create]
 
     resources :children, except: [:destroy] do
       post :active

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,11 @@ Rails.application.routes.draw do
   namespace :partners do
     resource :dashboard, only: [:show]
     resources :requests, only: [:show, :new, :index, :create]
-    resource :profile
+    resource :profile, only: [:show, :edit, :update] do
+      collection do
+        get :approve
+      end
+    end
 
     resources :children, except: [:destroy] do
       post :active

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
   namespace :partners do
     resource :dashboard, only: [:show]
     resources :requests, only: [:show, :new, :index, :create]
+    resource :profile
 
     resources :children, except: [:destroy] do
       post :active

--- a/spec/services/partners/request_approval_service_spec.rb
+++ b/spec/services/partners/request_approval_service_spec.rb
@@ -1,23 +1,36 @@
 require 'rails_helper'
 
-describe Partners::RequestApproval do
+describe Partners::RequestApprovalService do
   describe '#call' do
     subject { described_class.new(partner: partner).call }
     let(:partner) { create(:partner) }
 
     it 'should return an instance of itself' do
-      expect(subject).to be_a_kind_of(Partners::RequestApproval)
+      expect(subject).to be_a_kind_of(Partners::RequestApprovalService)
     end
 
     context 'when the partner is already awaiting approval' do
       before do
-        partner.update!(partner_status: 'submitted')
+        partner.profile.update!(partner_status: 'submitted')
       end
 
       it 'should return an error saying it the partner is already requested approval' do
-        expect(subject.errors[:name]).to eq(["partner has already requested approval"])
+        expect(subject.errors[:base]).to eq(["partner has already requested approval"])
       end
     end
 
+    context 'when the partner is not yet awaiting approval' do
+      before do
+        expect(partner.profile.partner_status).not_to eq('submitted')
+      end
+
+      it 'should set the partner_status of the partner profile to submitted' do
+        expect { subject }.to change { partner.profile.reload.partner_status }.to('submitted')
+      end
+
+      it 'should set the status on the partner record to awaiting_review' do
+        expect { subject }.to change { partner.awaiting_review? }.from(false).to(true)
+      end
+    end
   end
 end

--- a/spec/services/partners/request_approval_service_spec.rb
+++ b/spec/services/partners/request_approval_service_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+describe Partners::RequestApproval do
+  describe '#call' do
+    subject { described_class.new(partner: partner).call }
+    let(:partner) { create(:partner) }
+
+    it 'should return an instance of itself' do
+      expect(subject).to be_a_kind_of(Partners::RequestApproval)
+    end
+
+    context 'when the partner is already awaiting approval' do
+      before do
+        partner.update!(partner_status: 'submitted')
+      end
+
+      it 'should return an error saying it the partner is already requested approval' do
+        expect(subject.errors[:name]).to eq(["partner has already requested approval"])
+      end
+    end
+
+  end
+end

--- a/spec/system/partners/approval_process_spec.rb
+++ b/spec/system/partners/approval_process_spec.rb
@@ -1,0 +1,69 @@
+RSpec.describe "Approval process for partners", type: :system, js: true do
+  describe 'filling in organization details and requesting for approval' do
+    let(:partner_user) { partner.primary_partner_user }
+    let!(:partner) { FactoryBot.create(:partner) }
+
+    context 'GIVEN a partner user is new and wants to request approval' do
+      before do
+        login_as(partner_user, scope: :partner_user)
+        visit partner_user_root_path
+      end
+
+      it 'should not allow them to make requests on the dashboard or the requests page' do
+        # Checking that the dashboard doesn't have these options
+        refute page.has_content? 'Request Essentials'
+        refute page.has_content? 'Create New Bulk Essentials Request'
+        refute page.has_content? 'Create New Family Essentials Request'
+        refute page.has_content? 'Create New Individuals Essentials Request'
+
+        # Checking that the request page doesn't have these options
+        visit partners_requests_path
+        refute page.has_content? 'Request Essentials'
+        refute page.has_content? 'Create New Bulk Essentials Request'
+        refute page.has_content? 'Create New Family Essentials Request'
+        refute page.has_content? 'Create New Individuals Essentials Request'
+      end
+
+      context 'AND they fill out the form and submit it' do
+        before do
+          click_on 'My Profile'
+          assert page.has_content? 'pending'
+          click_on 'Update Information'
+
+          fill_in 'Other Agency Type', with: 'Lorem'
+
+          fill_in 'Executive Director Name', with: 'Lorem'
+          fill_in 'Executive Director Phone', with: '8889990000'
+          fill_in 'Executive Director Email', with: 'lorem@example.com'
+          fill_in 'Program Contact Phone', with: '8889990000'
+
+          click_on 'Update Information'
+          assert page.has_content? 'Details were successfully updated.'
+
+          find_link(text: 'Submit for Approval').click
+          assert page.has_content? 'You have submitted your details for approval.'
+          assert page.has_content? 'submitted'
+        end
+
+        context 'THEN the organization approves them' do
+          before do
+            # Emulate approving the partner using the service object
+            PartnerApprovalService.new(partner: partner.reload).call
+            # Revisit the profile page
+            visit partners_profile_path
+          end
+
+          it 'should show that they have been approved and able to make requests' do
+            assert page.has_content? 'verified'
+
+            visit partners_requests_path
+            assert page.has_content? 'Request Essentials'
+            assert page.has_content? 'Create New Bulk Essentials Request'
+            assert page.has_content? 'Create New Family Essentials Request'
+            assert page.has_content? 'Create New Individuals Essentials Request'
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #2201

### Description

This PR implements the ability for partner users to go through the entire approval process. That is, they are able to fill out the information and then send a request to be approved.

Here are some notable changes:
- Changed what use to be called the `partner_controller` (in partnerbase) to `profile_controller`. I felt that this was closer to what these controllers are operating on. That is, I believe `Partners::Partner` is more like a profile as it describes several things about themselves.
- Moved the controller for requesting approvals to it's own resource. That is, I treat requesting approval as a creation via `POST /partners/approval_request`
- Added a `Partners::RequestApprovalService` to handle the transaction of requesting an approval as a partner user.
- Added the missing `magic_test/support` in the partners/application layout. Without this you cannot use the magic_test gem.
- **Disabled the file uploading in the edit form because it isn't trivial to make ActiveStorage work while still supporting legacy users on the old partnerbase application*.*

### Type of change
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Added a spec to show this approval flow in spec/system/partners/approval_process_spec.rb

### Screenshots
![partner_approval_process](https://user-images.githubusercontent.com/11335191/111560432-74bbb180-8760-11eb-8693-46914b8f6a43.gif)
