### PR TITLE
2223 update demo information of account requests with new staging url

### DIFF
--- a/app/views/account_request_mailer/confirmation.html.erb
+++ b/app/views/account_request_mailer/confirmation.html.erb
@@ -23,7 +23,7 @@
     </p>
 
     <p>
-      <strong> The details below allow you to log into a demo site. All data on the demo site is reset every day 6 AM EST. </strong>
+      <strong> The details below allow you to log into a demo site. All data on the demo site is reset every day at 6 AM EST. </strong>
     </p>
 
     <p>

--- a/app/views/account_request_mailer/confirmation.html.erb
+++ b/app/views/account_request_mailer/confirmation.html.erb
@@ -19,12 +19,15 @@
     </p>
 
     <p>
-      If you'd like to experience the app, please log in to the sandbox/demo sites and test it out.
-      Here is the login information for the demo sites:
+      If you'd like to experience the app, please log in to the sandbox/demo sites and test it out using the information below.
     </p>
 
     <p>
-      <a href='https://diaperbase.org/'>DiaperBase</a>
+      <strong> The details below allow you to log into a demo site. All data on the demo site is reset every day 6 AM EST. </strong>
+    </p>
+
+    <p>
+      <a href='https://staging.humanessentials.app/'>DiaperBase</a>
       <br>
       <span>Username: org_admin1@example.com</span>
       <br>
@@ -32,7 +35,7 @@
     </p>
 
     <p>
-      <a href='https://partnerbase.org/'>PartnerBase</a>
+      <a href='https://staging.partner.humanessentials.app/'>PartnerBase</a>
       <br>
       <span>Username: verified@example.com</span>
       <br>

--- a/spec/mailers/account_request_mailer_spec.rb
+++ b/spec/mailers/account_request_mailer_spec.rb
@@ -25,11 +25,11 @@ RSpec.describe AccountRequestMailer, type: :mailer do
     end
 
     it 'should include the staging/demo account information' do
-      expect(mail.body.encoded).to match(%r{<a href='https://diaperbase.org/'>DiaperBase</a>})
+      expect(mail.body.encoded).to match(%r{<a href='https://staging.humanessentials.app/'>DiaperBase</a>})
       expect(mail.body.encoded).to match('Username: org_admin1@example.com')
       expect(mail.body.encoded).to match('Password: password')
 
-      expect(mail.body.encoded).to match(%r{<a href='https://partnerbase.org/'>PartnerBase</a>})
+      expect(mail.body.encoded).to match(%r{<a href='https://staging.partner.humanessentials.app/'>PartnerBase</a>})
       expect(mail.body.encoded).to match('Username: verified@example.com')
       expect(mail.body.encoded).to match('Password: password')
     end


### PR DESCRIPTION
Resolves #2223

### Description

- Updated mailer to point to correct demo/staging URLs
- Updated mailer copy to include bold message reminding the user that the staging environment resets its data every day 6 AM EST
- Updated the URLs in related spec (account_request_mailer_spec.rb)

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

- Viewed mailer locally
- Ran specs

### Screenshots

![After](https://user-images.githubusercontent.com/33702528/111882244-85f8fe00-89ac-11eb-9da4-5b0fd8259ba6.png)
