### PR TITLE
Enable recertification requests without the legacy API approach

### DIFF
--- a/app/controllers/partners/recertification_requests_controller.rb
+++ b/app/controllers/partners/recertification_requests_controller.rb
@@ -1,0 +1,19 @@
+module Partners
+  class RecertificationRequestsController < BaseController
+    def create
+      @partner = current_organization.partners.find(params[:id])
+
+      svc = PartnerRequestRecertificationService.new(partner: @partner)
+      svc.call
+
+      if svc.errors.none?
+        flash[:success] = "#{@partner.name} recertification successfully requested!"
+      else
+        flash[:error] = "#{@partner.name} failed to update partner records"
+      end
+
+      redirect_to partners_path
+    end
+  end
+end
+

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -109,13 +109,17 @@ class PartnersController < ApplicationController
 
   def recertify_partner
     @partner = current_organization.partners.find(params[:id])
-    response = DiaperPartnerClient.put(partner_id: @partner.id, status: "recertification_required")
-    if response.is_a?(Net::HTTPSuccess)
-      @partner.recertification_required!
-      redirect_to partners_path, notice: "#{@partner.name} recertification successfully requested!"
+
+    svc = PartnerRequestRecertificationService.new(partner: @partner)
+    svc.call
+
+    if svc.errors.none?
+      flash[:success] = "#{@partner.name} recertification successfully requested!"
     else
-      redirect_to partners_path, error: "#{@partner.name} failed to update partner records"
+      flash[:error] = "#{@partner.name} failed to update partner records"
     end
+
+    redirect_to partners_path
   end
 
   def deactivate

--- a/app/mailers/partner_mailer.rb
+++ b/app/mailers/partner_mailer.rb
@@ -1,0 +1,9 @@
+class PartnerMailer < ApplicationMailer
+  default from: "info@diaper.app"
+
+  def recertification_request(partner:)
+    @partner = partner
+
+    mail to: partner.email, subject: "[Action Required] Please Update Your Agency Information"
+  end
+end

--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -99,6 +99,7 @@ module Partners
     has_many_attached :documents
 
     VERIFIED_STATUS = 'verified'.freeze
+    RECERTIFICATION_REQUESTED_STATUS = 'recertification_required'.freeze
 
     AGENCY_TYPES = {
       "CAREER" => "Career technical training",

--- a/app/services/partner_request_recertification_service.rb
+++ b/app/services/partner_request_recertification_service.rb
@@ -1,0 +1,39 @@
+class PartnerRequestRecertificationService
+  include ServiceObjectErrorsMixin
+
+  # Creates a new instance of PartnerRequestRecertificationService
+  #
+  # @param partner: [Partner] the partner record
+  #
+  # @return [PartnerRequestRecertificationService]
+  def initialize(partner:)
+    @partner = partner
+  end
+
+  def call
+    return self unless valid?
+
+    Partners::Base.transaction do
+      partner.profile.update!(partner_status: Partners::Partner::RECERTIFICATION_REQUESTED_STATUS)
+      partner.recertification_required!
+      PartnerMailer.recertification_request(partner: partner).deliver_later
+    rescue StandardError => e
+      errors.add(:base, e.message)
+      raise ActiveRecord::Rollback
+    end
+
+    self
+  end
+
+  private
+
+  attr_reader :partner
+
+  def valid?
+    if partner.recertification_required?
+      errors.add(:partner, 'has already been requested to recertify')
+    end
+
+    errors.none?
+  end
+end

--- a/app/views/partner_mailer/recertification_request.text.erb
+++ b/app/views/partner_mailer/recertification_request.text.erb
@@ -1,0 +1,11 @@
+Hi <%= @partner.name %>
+
+It's time to update your agency information!
+
+Please log in to your account at <%= ENV["PARTNER_BASE_URL"] %>
+
+If no information has changed, please click Update.
+If any information has changed, please amend it on the form and then click Update.
+
+Thank you and have a great day!
+

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -13,3 +13,18 @@ Sidekiq::Scheduler.enabled = ENV["DISABLE_SIDEKIQ_SCHEDULER"] ? false : true
 Sidekiq.schedule = YAML.load_file(File.expand_path(Rails.root + 'config/scheduler.yml', __FILE__))
 SidekiqScheduler::Scheduler.load_schedule!
 Sidekiq::Extensions.enable_delay!
+
+#
+# Added this conditional to run the async jobs immediately
+# in development. This allows us to see the results of
+# enqueuing a mailer job instantly.
+#
+# This effectively turns .deliver_later to .deliver_now in
+# the development environment.
+#
+# Refer to https://makandracards.com/makandra/28125-perform-sidekiq-jobs-immediately-in-development
+# for context and details.
+if Rails.env.development?
+  require 'sidekiq/testing'
+  Sidekiq::Testing.inline!
+end

--- a/spec/mailers/partner_mailer_spec.rb
+++ b/spec/mailers/partner_mailer_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe PartnerMailer, type: :mailer do
+  describe "#recertification_request" do
+    subject { PartnerMailer.recertification_request(partner: partner) }
+    let(:partner) { create(:partner) }
+    let(:fake_partner_base_url) { Faker::Internet.domain_name }
+    before do
+      allow(ENV).to receive(:[]).with("PARTNER_BASE_URL").and_return(fake_partner_base_url)
+    end
+
+    it "renders the body with text that indicates to recertify and link to where" do
+      expect(subject.body.encoded).to include("Hi #{partner.name}")
+      expect(subject.body.encoded).to include("It's time to update your agency information!")
+      expect(subject.body.encoded).to include("Please log in to your account at #{fake_partner_base_url}")
+    end
+
+    it "should be sent to the partner main email with the correct subject line" do
+      expect(subject.to).to eq([partner.email])
+      expect(subject.from).to eq(['info@diaper.app'])
+      expect(subject.subject).to eq("[Action Required] Please Update Your Agency Information")
+    end
+  end
+end
+

--- a/spec/services/partner_request_recertification_service_spec.rb
+++ b/spec/services/partner_request_recertification_service_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+describe PartnerRequestRecertificationService do
+  describe '#call' do
+    subject { described_class.new(partner: partner).call }
+    let(:partner) { create(:partner) }
+    let(:partner_profile) { partner.profile }
+
+    before do
+      partner.awaiting_review!
+    end
+
+    context 'when the arguments are incorrect' do
+      context 'because the partner has already been requested to recertify' do
+        before do
+          partner.recertification_required!
+        end
+
+        it 'should return the PartnerRequestRecertificationService object with an error' do
+          result = subject
+
+          expect(result).to be_a_kind_of(PartnerRequestRecertificationService)
+          expect(result.errors[:partner]).to eq(["has already been requested to recertify"])
+        end
+      end
+    end
+
+    context 'when the arguments are correct' do
+      let(:fake_recertification_request) { double('mailer', deliver_later: -> {}) }
+      before do
+        allow(PartnerMailer).to receive(:recertification_request).with(partner: partner).and_return(fake_recertification_request)
+      end
+
+      it 'should have no errors' do
+        expect(subject.errors).to be_empty
+      end
+
+      it 'should change the partner status to approved' do
+        expect { subject }.to change { partner.reload.recertification_required? }.from(false).to(true)
+      end
+
+      it 'should change the partner profile partner_status' do
+        expect { subject }.to change { partner_profile.reload.partner_status }.to(Partners::Partner::RECERTIFICATION_REQUESTED_STATUS)
+      end
+
+      it 'should queue sending the notice to the partner' do
+        subject
+        expect(fake_recertification_request).to have_received(:deliver_later)
+      end
+
+      context 'but a unexpected error occured during the save' do
+        let(:error_message) { 'boom' }
+
+        context 'for partner approval' do
+          before do
+            allow(partner).to receive(:recertification_required!).and_raise(error_message)
+          end
+
+          it 'should have an error with the raised error' do
+            expect(subject.errors[:base]).to eq([error_message])
+          end
+
+          it 'should not change the partner status to recertification_required' do
+            expect { subject }.not_to change { partner.reload.approved? }
+          end
+
+          it 'should not change the partner_profile partner_status' do
+            expect { subject }.not_to change { partner_profile.reload.partner_status }
+          end
+
+          it 'should NOT queue sending the notice to the partner' do
+            subject
+            expect(fake_recertification_request).not_to have_received(:deliver_later)
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/services/partner_request_recertification_service_spec.rb
+++ b/spec/services/partner_request_recertification_service_spec.rb
@@ -48,7 +48,7 @@ describe PartnerRequestRecertificationService do
         expect(fake_recertification_request).to have_received(:deliver_later)
       end
 
-      context 'but a unexpected error occured during the save' do
+      context 'but a unexpected error occurred during the save' do
         let(:error_message) { 'boom' }
 
         context 'for partner approval' do
@@ -77,4 +77,3 @@ describe PartnerRequestRecertificationService do
     end
   end
 end
-

--- a/spec/system/partner_system_spec.rb
+++ b/spec/system/partner_system_spec.rb
@@ -115,6 +115,26 @@ RSpec.describe "Partner management", type: :system, js: true do
     end
   end
 
+  describe 'requesting recertification of a partner' do
+    context 'GIVEN a user goes through the process of requesting recertificaiton of partner' do
+      let!(:partner_to_request_recertification) { create(:partner, status: 'approved') }
+
+      before do
+        sign_in(@user)
+        visit partners_path(@organization)
+      end
+
+      it 'should notify the user that its been successful and change the partner status' do
+        accept_confirm do
+          find_button('Request Recertification').click
+        end
+
+        assert page.has_content? "#{partner_to_request_recertification.name} recertification successfully requested!"
+        expect(partner_to_request_recertification.reload.recertification_required?).to eq(true)
+      end
+    end
+  end
+
   describe "#index" do
     before(:each) do
       @uninvited = create(:partner, name: "Bcd", status: :uninvited)


### PR DESCRIPTION
Resolves #2169 

### Description

This PR refactors the partner recertification request flow by using a service object and direct DB calls instead of the legacy API approach.

Notable changes:
- Added "[Action Required]" in the subject of the recertification mailer (I copied this over from partner - https://github.com/rubyforgood/partner/blob/main/app/views/recertification_mailer/notice_email.text.erb)
- Added a `PartnerMailer` to store the code for requesting recertification. Ideally, this is where we include mailers that involve communication with partners.
- Added a service object `PartnerRequestRecertificationRequest`
- Added the missing system test for this flow
- Updated `sidekiq.rb` to allow jobs to run instantly in development so that you don't need to REDIS

### Type of change
* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?
Manually tested + system test

### Screenshots
![recertification_demo](https://user-images.githubusercontent.com/11335191/111908660-0c9ef100-8a28-11eb-8185-b536a0f8f7d9.gif)
