### PR TITLE
Remove deprecated flipper flags

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -169,7 +169,7 @@ class DistributionsController < ApplicationController
   end
 
   def send_notification(org, dist, subject: 'Your Distribution', distribution_changes: {})
-    PartnerMailerJob.perform_now(org, dist, subject, distribution_changes) if Flipper.enabled?(:email_active)
+    PartnerMailerJob.perform_now(org, dist, subject, distribution_changes)
   end
 
   def schedule_reminder_email(distribution)

--- a/app/jobs/add_diaper_partner_job.rb
+++ b/app/jobs/add_diaper_partner_job.rb
@@ -4,6 +4,6 @@ class AddDiaperPartnerJob < ApplicationJob
   def perform(partner_id, options = {})
     @partner = Partner.find(partner_id)
     @invitation_message = @partner.organization.invitation_text
-    @response = DiaperPartnerClient.add(@partner.attributes.merge(options.stringify_keys), @invitation_message) # if Flipper.enabled?(:email_active)
+    @response = DiaperPartnerClient.add(@partner.attributes.merge(options.stringify_keys), @invitation_message)
   end
 end

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -20,6 +20,6 @@ class DistributionCreateService < DistributionService
   private
 
   def send_notification
-    PartnerMailerJob.perform_now(distribution_organization.id, distribution.id, 'Your Distribution') if Flipper.enabled?(:email_active)
+    PartnerMailerJob.perform_now(distribution_organization.id, distribution.id, 'Your Distribution')
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -54,9 +54,7 @@
                   <%= download_button_to(items_path(format: :csv, filters: filter_params.merge(date_range: date_range_params)), {text: "Export Items", size: "md"}) if @items.any? %>
 
                   <%= new_button_to new_item_path(organization_id: current_organization), {text: "New Item"} %>
-                  <% if Flipper.enabled?(:kits) %>
-                    <%= new_button_to new_kit_path(organization_id: current_organization), {text: "New Kit"} %>
-                  <% end %>
+                  <%= new_button_to new_kit_path(organization_id: current_organization), {text: "New Kit"} %>
                   </span>
               </div>
             <% end # form %>
@@ -84,20 +82,16 @@
                 <a class="nav-link" id="custom-tabs-three-profile-tab" data-toggle="pill" href="#custom-tabs-three-profile" role="tab" aria-controls="custom-tabs-three-profile" aria-selected="false">Items,
                   Quantity, and Location</a>
               </li>
-              <% if Flipper.enabled?(:kits) %>
-                <li class="nav-item">
-                  <a class="nav-link" id="custom-tabs-three-kits-tab" data-toggle="pill" href="#custom-tabs-three-kits" role="tab" aria-controls="custom-tabs-three-kits" aria-selected="false">Kits</a>
-                </li>
-              <% end %>
+              <li class="nav-item">
+                <a class="nav-link" id="custom-tabs-three-kits-tab" data-toggle="pill" href="#custom-tabs-three-kits" role="tab" aria-controls="custom-tabs-three-kits" aria-selected="false">Kits</a>
+              </li>
             </ul>
           </div>
           <div class="card-body">
             <div class="tab-content" id="custom-tabs-three-tabContent">
               <%= render partial: 'item_list' %>
               <%= render partial: 'items_quantity_and_location' %>
-              <% if Flipper.enabled?(:kits) %>
-                <%= render partial: 'kits' %>
-              <% end %>
+              <%= render partial: 'kits' %>
             </div>
           </div>
         </div>

--- a/app/views/layouts/_lte_sidebar.html.erb
+++ b/app/views/layouts/_lte_sidebar.html.erb
@@ -100,13 +100,11 @@
           <i class="nav-icon fa fa-circle-o"></i> Items &amp; Inventory
         <% end %>
       </li>
-      <% if Flipper.enabled?(:kits, current_user) %>
-        <li class="nav-item <%= active_class(['kits']) %>">
-          <%= link_to(kits_path(organization_id: current_user.organization), class: "nav-link #{active_class(['kits'])}") do %>
-            <i class="nav-icon fa fa-circle-o"></i> Kits
-          <% end %>
-        </li>
-      <% end %>
+      <li class="nav-item <%= active_class(['kits']) %>">
+        <%= link_to(kits_path(organization_id: current_user.organization), class: "nav-link #{active_class(['kits'])}") do %>
+          <i class="nav-icon fa fa-circle-o"></i> Kits
+        <% end %>
+      </li>
       <li class="nav-item <%= active_class(['barcode_items']) %>">
         <%= link_to(barcode_items_path(organization_id: current_user.organization), class: "nav-link #{active_class(['barcode_items'])}") do %>
           <i class="nav-icon fa fa-circle-o"></i> Barcode Items

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -58,9 +58,7 @@ Rails.application.configure do
   config.force_ssl = true
   config.ssl_options = { hsts: false }
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/connecting-the-partner-and-diaper.md
+++ b/connecting-the-partner-and-diaper.md
@@ -108,6 +108,3 @@ bundle exec sidekiq -q default
 #####  My ENV variables are incorrect even though I changed them in the `.env` file
 
 Try running `puma-dev -uninstall` and then running `puma-dev -install` again. It appears that the ENV variables (maybe initialization) doesn't change unless you re-install puma-dev.
-
-##### Creating a partner on the diaper app does not seem to trigger a invite on the partner application.
-As of today, you need to explicitly tell `Flipper` to enable sending emails locally. You can do this by opening up the rails console in diaper and running `Flipper.activate(:email_active).` You will need to re-queue the invitation request again.

--- a/spec/controllers/distributions_controller_spec.rb
+++ b/spec/controllers/distributions_controller_spec.rb
@@ -207,7 +207,6 @@ RSpec.describe DistributionsController, type: :controller do
 
         before do
           ActiveJob::Base.queue_adapter = :test
-          allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
         end
 
         it "redirects with a flash notice and send send_notification" do

--- a/spec/requests/distributions_requests_spec.rb
+++ b/spec/requests/distributions_requests_spec.rb
@@ -60,7 +60,6 @@ RSpec.describe "Distributions", type: :request do
         params = default_params.merge(distribution)
         expect(storage_location).to be_valid
         expect(partner).to be_valid
-        expect(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
 
         expect do
           post distributions_path(params)
@@ -255,8 +254,6 @@ RSpec.describe "Distributions", type: :request do
 
       context "mail follow up" do
         subject { patch distribution_path(distribution_params) }
-
-        before { allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true) }
 
         it "does not send an e-mail" do
           expect { subject }.not_to change { ActionMailer::Base.deliveries.count }

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -20,7 +20,6 @@ RSpec.describe DistributionCreateService, type: :service do
     context "partner has send reminders setting set to true" do
       it "Sends a PartnerMailer" do
         @partner.update!(send_reminders: true)
-        allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
 
         expect(PartnerMailerJob).to receive(:perform_now).once
         subject.new(distribution_params).call
@@ -30,7 +29,6 @@ RSpec.describe DistributionCreateService, type: :service do
     context "partner has send reminders setting set to false" do
       it "does not send a PartnerMailer" do
         @partner.update!(send_reminders: false)
-        allow(Flipper).to receive(:enabled?).with(:email_active).and_return(true)
 
         expect(PartnerMailerJob).not_to receive(:perform_now)
         subject.new(distribution_params).call

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -11,40 +11,36 @@ RSpec.feature "Distributions", type: :system do
 
   context "When creating a new distribution manually" do
     it "Allows a distribution to be created" do
-      with_features email_active: true do
-        visit @url_prefix + "/distributions/new"
+      visit @url_prefix + "/distributions/new"
 
-        select @partner.name, from: "Partner"
-        select @storage_location.name, from: "From storage location"
-        choose "Pick up"
+      select @partner.name, from: "Partner"
+      select @storage_location.name, from: "From storage location"
+      choose "Pick up"
 
-        fill_in "Comment", with: "Take my wipes... please"
+      fill_in "Comment", with: "Take my wipes... please"
 
-        expect do
-          click_button "Save", match: :first
-        end.to change { ActionMailer::Base.deliveries.count }.by(1)
+      expect do
+        click_button "Save", match: :first
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
 
-        expect(page).to have_content "Distributions"
-        expect(page.find(".alert-info")).to have_content "reated"
-      end
+      expect(page).to have_content "Distributions"
+      expect(page.find(".alert-info")).to have_content "reated"
     end
 
     it "Displays a complete form after validation errors" do
-      with_features email_active: true do
-        visit @url_prefix + "/distributions/new"
+      visit @url_prefix + "/distributions/new"
 
-        # verify line items appear on initial load
-        expect(page).to have_selector "#distribution_line_items"
+      # verify line items appear on initial load
+      expect(page).to have_selector "#distribution_line_items"
 
-        select @partner.name, from: "Partner"
-        expect do
-          click_button "Save"
-        end.not_to change { ActionMailer::Base.deliveries.count }
+      select @partner.name, from: "Partner"
+      expect do
+        click_button "Save"
+      end.not_to change { ActionMailer::Base.deliveries.count }
 
-        # verify line items appear on reload
-        expect(page).to have_content "New Distribution"
-        expect(page).to have_selector "#distribution_line_items"
-      end
+      # verify line items appear on reload
+      expect(page).to have_content "New Distribution"
+      expect(page).to have_selector "#distribution_line_items"
     end
 
     context "when the quantity is lower than the on hand minminum quantity" do
@@ -145,14 +141,12 @@ RSpec.feature "Distributions", type: :system do
     end
 
     it "sends an email if reminders are enabled" do
-      with_features email_active: true do
-        visit @url_prefix + "/distributions"
-        click_on "Edit", match: :first
-        fill_in "Agency representative", with: "SOMETHING DIFFERENT"
-        click_on "Save", match: :first
-        distribution.reload
-        expect(DistributionMailer.method(:reminder_email)).to be_delayed(distribution.id)
-      end
+      visit @url_prefix + "/distributions"
+      click_on "Edit", match: :first
+      fill_in "Agency representative", with: "SOMETHING DIFFERENT"
+      click_on "Save", match: :first
+      distribution.reload
+      expect(DistributionMailer.method(:reminder_email)).to be_delayed(distribution.id)
     end
 
     it "allows the user can change the issued_at date" do


### PR DESCRIPTION
Resolves N/A

### Description
This PR removes two flipper flaps that aren't necessary anymore:
- `email_active` since each environment is using the correct mailing configuration. That is, you don't need to worry about sending real emails in either environments other than production
- `kits` since we've released it to everyone already

### Type of change
* Tech Debt

### How Has This Been Tested?
CI

### Screenshots
N/A
