### PR TITLE
Add missing logic for importing partners

### DIFF
--- a/app/models/partner.rb
+++ b/app/models/partner.rb
@@ -77,11 +77,13 @@ class Partner < ApplicationRecord
 
   # better to extract this outside of the model
   def self.import_csv(csv, organization_id)
+    organization = Organization.find(organization_id)
+
     csv.each do |row|
       hash_rows = Hash[row.to_hash.map { |k, v| [k.downcase, v] }]
-      loc = Partner.new(hash_rows)
-      loc.organization_id = organization_id
-      loc.save
+
+      svc = PartnerCreateService.new(organization: organization, partner_attrs: hash_rows)
+      svc.call
     end
   end
 


### PR DESCRIPTION
Resolves https://app.bugsnag.com/ruby-for-good/diaperbase/errors/6058ea34ae2bcc000709e3e9?filters[event.since][0][type]=eq&filters[event.since][0][value]=30d&filters[error.status][0][type]=eq&filters[error.status][0][value]=open&filters[app.release_stage][0][value]=production&filters[app.release_stage][0][type]=eq

### Description
A user notified me that the import feature for partners was not working. This is due to a missing piece of logic that enables importing partners using the new service object.

### Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Tested locally & on staging

### Screenshots
N/A
