### PR TITLE
Adds missing slash in closing TH tag

### DIFF
--- a/app/views/diaper_drives/index.html.erb
+++ b/app/views/diaper_drives/index.html.erb
@@ -79,7 +79,7 @@
                 <th>Diaper Drive Name</th>
                 <th>Start Date</th>
                 <th>End Date</th>
-                <th>Held Virtually?<th>
+                <th>Held Virtually?</th>
                 <th class="numeric">Quantity of Items</th>
                 <th class="numeric">Variety of Items</th>
                 <th class="numeric">In Kind Value</th>


### PR DESCRIPTION
Fixes #2243

### Description

The table cells were misaligned with the table headers because one of
the table headers was missing a `/` in its closing tag.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Manually loaded page in dev and confirmed page displayed differently.

As it was a syntax issue, I did not feel writing an automated test was prudent :)

### Screenshots
<img width="1199" alt="Screen Shot 2021-03-25 at 11 11 45 PM" src="https://user-images.githubusercontent.com/502363/112571951-8421a700-8dbf-11eb-9826-5cd10cbde214.png">
