### PR TITLE
2211 prevent demo users from changing the email & password of shared account in staging

### DIFF
--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -7,7 +7,12 @@
           Editing
           <small>your profile</small>
         </h1>
-      </div>
+        <% if Rails.env.staging? %>
+          <div class="staging-warning">
+            <p> <strong> You are accessing a demo version which does not allow changes to the demo account credentials </strong> </p>
+          </div>
+        <% end %>
+      </div> 
       <div class="col-sm-6">
         <ol class="breadcrumb float-sm-right">
           <li class="breadcrumb-item"><%= link_to(dashboard_path) do %>
@@ -82,7 +87,11 @@
             <!-- /.row -->
           </div>
             <div class="card-footer text-right">
+            <% unless Rails.env.staging? %>
               <%= submit_button %>
+              <% else %>
+              <%= _button_to({ text: "Save", icon: "floppy-o", type: "success", align: "pull-right" }, disabled: true) %>
+              <% end %>
             </div>
           <!-- ./card-body -->
           <!-- /.card-footer -->

--- a/spec/system/account_system_spec.rb
+++ b/spec/system/account_system_spec.rb
@@ -3,33 +3,54 @@ RSpec.describe "User account management", type: :system, js: true do
 
   before do
     sign_in(@user)
-    visit subject
   end
 
-  it "should change an user name" do
-    name = @user.name + "aaa"
-    fill_in "Name", with: name
-    fill_in "user_current_password", with: @user.password
-    click_button "Save"
+  context 'when in staging' do
+    before do
+      allow(Rails.env).to receive(:staging?).and_return(true)
+      visit subject
+    end
 
-    expect(page).to have_content(name)
+    it 'should display staging warning' do
+      expect(page).to have_selector('.staging-warning')
+    end
+
+    it 'should not allow the user to change staging credentials' do
+      expect(page).to have_button('Save', disabled: true)
+    end
   end
 
-  it "should change the email" do
-    email = "example@example.com"
-    fill_in "Email", with: email
-    fill_in "user_current_password", with: @user.password
-    click_button "Save"
+  context 'when not in staging' do
+    before do
+      allow(Rails.env).to receive(:staging?).and_return(false)
+      visit subject
+    end
 
-    expect(page).to have_content('Your account has been updated successfully.')
-  end
+    it "should change an user name" do
+      name = @user.name + "aaa"
+      fill_in "Name", with: name
+      fill_in "user_current_password", with: @user.password
+      click_button "Save"
 
-  it "should fail when the email is invalid" do
-    invalid_email = "invalid email"
-    fill_in "Email", with: invalid_email
-    fill_in "user_current_password", with: @user.password
-    click_button "Save"
+      expect(page).to have_content(name)
+    end
 
-    expect(page).to have_content('is invalid')
+    it "should change the email" do
+      email = "example@example.com"
+      fill_in "Email", with: email
+      fill_in "user_current_password", with: @user.password
+      click_button "Save"
+
+      expect(page).to have_content('Your account has been updated successfully.')
+    end
+
+    it "should fail when the email is invalid" do
+      invalid_email = "invalid email"
+      fill_in "Email", with: invalid_email
+      fill_in "user_current_password", with: @user.password
+      click_button "Save"
+
+      expect(page).to have_content('is invalid')
+    end
   end
 end


### PR DESCRIPTION
Resolves #2211 

### Description

- Added staging warning if in staging
- Disabled submit button if in staging
- No changes made to non-staging environments

Other potential solutions we discussed included:

- Editing a controller so that when a form receives a submission in staging it prevents an update and displays a flash message ([Slack discussion](https://rubyforgood.slack.com/archives/C6WLZL0DD/p1616518497014600))
- Not including the modules that allow for the user-management behavior (Recoverable and Registerable) if the ENV is staging ([Slack discussion](https://rubyforgood.slack.com/archives/C6WLZL0DD/p1616726801023500)

### Type of change

Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Viewed locally in different environments, and attempted to submit form data
Ran RSpec

### Screenshots
![Before](https://user-images.githubusercontent.com/33702528/112754717-4007ef80-8fd5-11eb-9583-18ed708f08ec.png)
![After](https://user-images.githubusercontent.com/33702528/112754724-47c79400-8fd5-11eb-954c-aa90acee9c9e.png)
