### PR TITLE
Remove the pickup sheet feature in partners due to its unclear purpose

### DIFF
--- a/app/views/partners/requests/_history.html.erb
+++ b/app/views/partners/requests/_history.html.erb
@@ -14,9 +14,8 @@
         <thead>
           <tr class="row">
             <th scope="col" class="col-1">No.</th>
-            <th scope="col" class="col-6">Contents</th>
-            <th scope="col" class="col text-right">Edit Pickup Sheet</th>
-            <th scope="col" class="col">Request Date</th>
+            <th scope="col" class="col-9">Contents</th>
+            <th scope="col" class="col-2">Request Date</th>
           </tr>
         </thead>
 
@@ -24,11 +23,8 @@
           <% @partner_requests.each do |partner_request| %>
             <tr class="row">
               <td class="col-1"><%= link_to partner_request.id, partners_request_path(id: partner_request.id) %></th>
-
-              <% # TODO - Make the following section an ordered list it isn't easy to read %>
-              <td class="col-6"><%= partner_request.item_requests.map {|item| "#{item.quantity} of #{item.name}"}.join(", ") %></td>
-              <td class="col text-right"><%= link_to '<i class="fa fa-edit"></i>&nbsp;&nbsp;Pickup Sheet'.html_safe, '', class: 'btn btn-sm btn-primary' %></td>
-              <td class="col"><%= partner_request.created_at.strftime("%B %-d %Y") %></td>
+              <td class="col-9"><%= partner_request.item_requests.map {|item| "#{item.quantity} of #{item.name}"}.join(", ") %></td>
+              <td class="col-2"><%= partner_request.created_at.strftime("%B %-d %Y") %></td>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/partners/requests/index.html.erb
+++ b/app/views/partners/requests/index.html.erb
@@ -41,7 +41,6 @@
               <tr>
                 <th scope="col">#</th>
                 <th scope="col">Contents</th>
-                <th scope="col">Pickup Sheet</th>
                 <th scope="col">Request Date</th>
               </tr>
               </thead>
@@ -50,13 +49,6 @@
                 <tr>
                   <th scope="row"><%= link_to partner_request.id, partners_request_path(id: partner_request.id) %></th>
                   <td><%= partner_request.item_requests.map { |item| "#{item.quantity} of #{item.name}" }.join(", ") %></td>
-                  <td>
-                    <% if partner_request.for_families? %>
-                      <%= link_to 'TODO', class: 'btn btn-sm btn-info' do %>
-                        <i class="fa fa-edit"></i> (TODO) Pickup Sheet
-                      <% end %>
-                    <% end %>
-                  </td>
                   <td><%= partner_request.created_at.strftime("%B %-d %Y") %></td>
                 </tr>
                 </tbody>


### PR DESCRIPTION
Resolves #2249 

### Description

After a series of confusing conversations, it comes to my attention that the pickup sheets the partners use to serve an unclear purpose. My usual instincts to not do this but... I think it is best to remove the feature and re-evaluate its purpose & the problem it tries to solve.

Here are some reasons why I think this:
- The usage rate of the pickup sheet and its features is very very small. (mentioned in #2249 )
- The complexity of that section of code seems more trouble to re-create than it is to figure it out.
- I think by removing it we'll hear more clearly what the problems are that we want to solve. And possibly deliver a better feature that is more directed to it.

**This PR removes the pickup sheet feature**

### Type of change
* Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How Has This Been Tested?
Tested locally

### Screenshots
<img width="1773" alt="Screen Shot 2021-04-03 at 4 29 04 PM" src="https://user-images.githubusercontent.com/11335191/113491902-bb681600-9499-11eb-9b92-3277120c34ab.png">

