### PR TITLE
2262/purchase error messages

### DIFF
--- a/app/controllers/purchases_controller.rb
+++ b/app/controllers/purchases_controller.rb
@@ -36,7 +36,7 @@ class PurchasesController < ApplicationController
     else
       load_form_collections
       @purchase.line_items.build if @purchase.line_items.count.zero?
-      flash[:error] = "There was an error starting this purchase, try again?"
+      flash[:error] = "Failed to create purchase due to: #{@purchase.errors.full_messages}"
       Rails.logger.error "[!] PurchasesController#create ERROR: #{@purchase.errors.full_messages}"
       render action: :new
     end

--- a/spec/requests/purchases_requests_spec.rb
+++ b/spec/requests/purchases_requests_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe "Purchases", type: :request do
         it "renders GET#new with error" do
           post purchases_path(default_params.merge(purchase: { storage_location_id: nil, amount_spent_in_cents: nil }))
           expect(response).to be_successful # Will render :new
-          expect(response).to have_error(/error/i)
+          expect(response.body).to include('Failed to create purchase due to: ["Storage location must exist", "Vendor must exist", "Amount spent in cents is not a number"]')
         end
       end
     end

--- a/spec/system/purchase_system_spec.rb
+++ b/spec/system/purchase_system_spec.rb
@@ -170,16 +170,23 @@ RSpec.describe "Purchases", type: :system, js: true do
           expect(Purchase.last.line_items.first.quantity).to eq(16)
         end
 
-        # Bug fix -- Issue #71
-        # When a user creates a purchase without it passing validation, the items
-        # dropdown is not populated on the return trip.
-        it "items dropdown is still repopulated even if initial submission doesn't validate" do
-          item_count = @organization.items.count + 1 # Adds 1 for the "choose an item" option
-          expect(page).to have_css("#purchase_line_items_attributes_0_item_id option", count: item_count + 1)
-          click_button "Save"
+        context 'when creating a purchase incorrectly' do
+          # Bug fix -- Issue #71
+          # When a user creates a purchase without it passing validation, the items
+          # dropdown is not populated on the return trip.
+          it "items dropdown is still repopulated even if initial submission doesn't validate" do
+            item_count = @organization.items.count + 1 # Adds 1 for the "choose an item" option
+            expect(page).to have_css("#purchase_line_items_attributes_0_item_id option", count: item_count + 1)
+            click_button "Save"
 
-          expect(page).to have_content("error")
-          expect(page).to have_css("#purchase_line_items_attributes_0_item_id option", count: item_count + 1)
+            expect(page).to have_content("Failed to create purchase due to:")
+            expect(page).to have_css("#purchase_line_items_attributes_0_item_id option", count: item_count + 1)
+          end
+
+          it "should display failure with error messages" do
+            click_button "Save"
+            expect(page).to have_content('Failed to create purchase due to: ["Vendor must exist", "Amount spent in cents must be greater than 0"]')
+          end
         end
       end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2262 

### Description
Changes purchases#create error flash to provide full error messages.
To stay in line with precedent set for error handling I referred to [partners#create](https://github.com/PhilipDeFraties/diaper/blob/0c523fb3d750c2de69c5f8eec2034672b17bd874/app/controllers/partners_controller.rb#L17)

### Type of change

* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?

Adds context block for failed purchase creation in [purchase_system_spec.rb](https://github.com/PhilipDeFraties/diaper/blob/0c523fb3d750c2de69c5f8eec2034672b17bd874/spec/system/purchase_system_spec.rb#L173) which contains added test, also moves a similiar test for failed purchase creation concerning item dropdown to within said block.
![Screen Shot 2021-04-05 at 1 09 11 PM](https://user-images.githubusercontent.com/65036872/113615096-a6fa5980-9610-11eb-9786-e36d8553b196.png)

Had to edit purchase request POST#create failure [test](https://github.com/PhilipDeFraties/diaper/blob/bf777de12c4083999f420a905f0a0b87ba1246df/spec/requests/purchases_requests_spec.rb#L70), the previous assertion was different: 
![Screen Shot 2021-04-05 at 5 29 46 PM](https://user-images.githubusercontent.com/65036872/113639015-7bd63100-9635-11eb-8f48-9db61f809fa0.png)

I copied the test that was in the partners_request_spec POST#create failure [test](https://github.com/PhilipDeFraties/diaper/blob/bf777de12c4083999f420a905f0a0b87ba1246df/spec/requests/partners_requests_spec.rb#L82). I'm unsure if this is ok, I'm unfamiliar with the assertion that was previously there which stopped working once I changed the error message.



### Screenshots
![Screen Shot 2021-04-05 at 1 07 40 PM](https://user-images.githubusercontent.com/65036872/113615368-022c4c00-9611-11eb-875b-f99a359fa0ba.png)

