### PR TITLE
2229 display the request notes on several key pages it is needed in

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -659,4 +659,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.13
+   2.2.14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -659,4 +659,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.14
+   2.2.13

--- a/app/views/distributions/_distribution_row.html.erb
+++ b/app/views/distributions/_distribution_row.html.erb
@@ -6,6 +6,7 @@
   <td class="numeric"><%= distribution_row.line_items.total %></td>
   <td class="numeric"><%= dollar_value(distribution_row.value_per_itemizable) %></td>
   <td><%= distribution_row.delivery_method.humanize %></td>
+  <td><%= distribution_row.comment %></td>
   <td><%= distribution_row.state&.humanize %></td>
 
   <td class="text-right">

--- a/app/views/distributions/index.html.erb
+++ b/app/views/distributions/index.html.erb
@@ -99,6 +99,7 @@
                 <th class="numeric">Total items</th>
                 <th class="numeric">Total value</th>
                 <th>Delivery method</th>
+                <th>Comments</th>
                 <th>State</th>
                 <th class="text-right" style="width: 400px">Actions</th>
               </tr>

--- a/app/views/distributions/show.html.erb
+++ b/app/views/distributions/show.html.erb
@@ -39,6 +39,7 @@
                 <th>Source location:</th>
                 <th>Agency representative:</th>
                 <th>Delivery method:</th>
+                <th>Comments:</th>
                 <th>State:</th>
               </tr>
               </thead>
@@ -48,6 +49,7 @@
                 <td><%= @distribution.storage_location.name %></td>
                 <td><%= @distribution.agency_rep %></td>
                 <td><%= @distribution.delivery_method.humanize %></td>
+                <td><%= @distribution.comment %></td>
                 <td><%= @distribution.state&.humanize %></td>
               </tr>
             </table>

--- a/app/views/requests/_request_row.html.erb
+++ b/app/views/requests/_request_row.html.erb
@@ -6,6 +6,9 @@
     <%= quota_display(request_row.partner) %>
   </td>
   <td>
+    <%= request_row.comments %>
+  </td>  
+  <td>
     <%= render partial: "status", locals: {status: request_row.status} %>
   </td>
   <td class="text-right">

--- a/app/views/requests/index.html.erb
+++ b/app/views/requests/index.html.erb
@@ -90,6 +90,7 @@
                 <th style="width: 10px">Date</th>
                 <th>Requestor</th>
                 <th># of Items (Request Limit)</th>
+                <th>Comments</th>
                 <th>Status</th>
                 <th class="text-right">Actions</th>
               </tr>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -494,7 +494,8 @@ end
                                       partner: random_record_for_org(pdx_org, Partner),
                                       organization: pdx_org,
                                       issued_at: Faker::Date.between(from: 4.days.ago, to: Time.zone.today),
-                                      delivery_method: Distribution.delivery_methods.keys.sample)
+                                      delivery_method: Distribution.delivery_methods.keys.sample,
+                                      comment: 'Urgent')
 
   stored_inventory_items_sample.each do |stored_inventory_item|
     distribution_qty = rand(stored_inventory_item.quantity / 2)


### PR DESCRIPTION
Resolves #2229

### Description

Updated the following views to display comments:
- distributions/_distribution_row.html.erb
- distributions/index.html.erb
- distributions/show.html.erb
- requests/_request_row.html.erb
- requests/index.html.erb

Updated seeds.rb to add a distribution.comment seed value

### Type of change

* New feature (non-breaking change which adds functionality)
* 
### How Has This Been Tested?

Tested and viewed locally. I haven't created a spec yet, following the Slack discussion.

### Screenshots

![requests#index](https://user-images.githubusercontent.com/33702528/113772343-7e5f8600-971c-11eb-85c0-b11a44c16601.png)

![distributions#index](https://user-images.githubusercontent.com/33702528/113772114-2aed3800-971c-11eb-8d32-959cb10598b5.png)

![distributions#show](https://user-images.githubusercontent.com/33702528/113772486-a949da00-971c-11eb-948c-213da62ca297.png)

Originals can be seen [here](https://github.com/rubyforgood/diaper/issues/2229).

### Styling concerns

I'm unaware of the average comment length, but if it is too long it could result in unexpected consequences for styling. 

E.g. The following example shows how a comment might affect the buttons on the row.

![Longer comment](https://user-images.githubusercontent.com/33702528/113772892-32611100-971d-11eb-8239-0e39cc9d36cb.png)

This can be altered by changing the width property of the <th> as below, but it may prove unnecessary depending on real-world use. No changes made at this time:

![Longer comment with adjusted width](https://user-images.githubusercontent.com/33702528/113772870-2d03c680-971d-11eb-9f3f-b8e9bda88faa.png)

### CSV Export

Users may expect comments to show in CSV exports, which requires updating the e export request/partner distribution services.

### Lack of specs

Following the discussion on Slack, this was submitted without new tests (partially due to the timing of a stakeholder call). I fully intend to add specs at a later date as part of my own development and the epic to expand test coverage (can create a new issue for these)


