### PR TITLE
Enable partner users to create new family essentials requests (but with unified service)

### DIFF
--- a/app/controllers/partners/base_controller.rb
+++ b/app/controllers/partners/base_controller.rb
@@ -17,5 +17,18 @@ module Partners
     def current_partner
       current_partner_user.partner
     end
+
+    def verify_status_in_diaper_base
+      if current_partner.status_in_diaper_base == "deactivated"
+        flash[:alert] = 'Your account has been disabled, contact the organization via their email to reactivate'
+        redirect_to partners_requests_path
+      end
+    end
+
+    def authorize_verified_partners
+      return if current_partner.verified?
+
+      redirect_to partners_requests_path, notice: "Please review your application details and submit for approval in order to make a new request."
+    end
   end
 end

--- a/app/controllers/partners/base_controller.rb
+++ b/app/controllers/partners/base_controller.rb
@@ -19,7 +19,7 @@ module Partners
     end
 
     def verify_status_in_diaper_base
-      if current_partner.status_in_diaper_base == "deactivated"
+      if current_partner.deactivated?
         flash[:alert] = 'Your account has been disabled, contact the organization via their email to reactivate'
         redirect_to partners_requests_path
       end

--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -1,26 +1,24 @@
-class FamilyRequestsController < ApplicationController
-  before_action :authenticate_user!
-  before_action :verify_status_in_diaper_base
-  before_action :authorize_verified_partners
+module Partners
+  class FamilyRequestsController < BaseController
+    def new
+      @filterrific = initialize_filterrific(
+        current_partner.children
+                       .order(last_name: :asc)
+                       .order(first_name: :asc),
+        params[:filterrific]
+      ) || return
+      @children = @filterrific.find
+    end
 
-  def new
-    @filterrific = initialize_filterrific(
-      current_partner.children
-          .order(last_name: :asc)
-          .order(first_name: :asc),
-      params[:filterrific]
-    ) || return
-    @children = @filterrific.find
-  end
+    def create
+      children = current_partner.children.active.where.not(item_needed_diaperid: [nil, 0])
+      request = FamilyRequestPayloadService.execute(children: children, partner: current_partner)
 
-  def create
-    children = current_partner.children.active.where.not(item_needed_diaperid: [nil, 0])
-    request = FamilyRequestPayloadService.execute(children: children, partner: current_partner)
+      FamilyRequestService.execute(request)
 
-    FamilyRequestService.execute(request)
-
-    redirect_to partner_requests_path, notice: "Requested items successfuly!"
-  rescue ActiveModel::ValidationError
-    render :new
+      redirect_to partner_requests_path, notice: "Requested items successfully!"
+    rescue ActiveModel::ValidationError
+      render :new
+    end
   end
 end

--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -14,7 +14,7 @@ module Partners
     end
 
     def create
-      # the checkbox toggles in the frontend will directly set active/inactive children,
+      # The checkbox toggles in the frontend will directly set active/inactive children,
       # so fetching them from the DB here instead of reading them from params works.
       # However this is a bit of an odd pattern so we should consider taking in params as usual here
       children = current_partner.children.active.where.not(item_needed_diaperid: [nil, 0])

--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -1,5 +1,8 @@
 module Partners
   class FamilyRequestsController < BaseController
+    before_action :verify_status_in_diaper_base
+    before_action :authorize_verified_partners
+
     def new
       @filterrific = initialize_filterrific(
         current_partner.children
@@ -11,14 +14,28 @@ module Partners
     end
 
     def create
+      # the checkbox toggles in the frontend will directly set active/inactive children,
+      # so fetching them from the DB here instead of reading them from params works.
+      # However this is a bit of an odd pattern so we should consider taking in params as usual here
       children = current_partner.children.active.where.not(item_needed_diaperid: [nil, 0])
-      request = FamilyRequestPayloadService.execute(children: children, partner: current_partner)
 
-      FamilyRequestService.execute(request)
+      children_grouped_by_item_id = children.group_by(&:item_needed_diaperid)
+      family_requests_attributes = children_grouped_by_item_id.map do |item_id, item_requested_children|
+        { item_id: item_id, person_count: children.count, children: item_requested_children }
+      end
 
-      redirect_to partner_requests_path, notice: "Requested items successfully!"
-    rescue ActiveModel::ValidationError
-      render :new
+      create_service = Partners::FamilyRequestCreateService.new(
+        partner_user_id: current_partner_user.id,
+        family_requests_attributes: family_requests_attributes
+      )
+
+      create_service.call
+
+      if create_service.errors.none?
+        redirect_to partners_request_path(create_service.partner_request), notice: "Requested items successfully!"
+      else
+        render :new
+      end
     end
   end
 end

--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -1,0 +1,26 @@
+class FamilyRequestsController < ApplicationController
+  before_action :authenticate_user!
+  before_action :verify_status_in_diaper_base
+  before_action :authorize_verified_partners
+
+  def new
+    @filterrific = initialize_filterrific(
+      current_partner.children
+          .order(last_name: :asc)
+          .order(first_name: :asc),
+      params[:filterrific]
+    ) || return
+    @children = @filterrific.find
+  end
+
+  def create
+    children = current_partner.children.active.where.not(item_needed_diaperid: [nil, 0])
+    request = FamilyRequestPayloadService.execute(children: children, partner: current_partner)
+
+    FamilyRequestService.execute(request)
+
+    redirect_to partner_requests_path, notice: "Requested items successfuly!"
+  rescue ActiveModel::ValidationError
+    render :new
+  end
+end

--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -101,6 +101,7 @@ module Partners
 
     VERIFIED_STATUS = 'verified'.freeze
     RECERTIFICATION_REQUESTED_STATUS = 'recertification_required'.freeze
+    DEACTIVATED_STATUS = "deactivated".freeze
 
     AGENCY_TYPES = {
       "CAREER" => "Career technical training",
@@ -142,6 +143,10 @@ module Partners
 
     def verified?
       partner_status == VERIFIED_STATUS
+    end
+
+    def deactivated?
+      status_in_diaper_base == DEACTIVATED_STATUS
     end
 
     def organization

--- a/app/services/partners/family_request_create_service.rb
+++ b/app/services/partners/family_request_create_service.rb
@@ -1,12 +1,13 @@
+# This service object is meant to transform a family request
+# into the correct parameters that would be expected a regular
+# Partners::ItemRequest. It will create the relevant
+# organization request (i.e. ::Request), the Partners::Request,
+# the Partners::ItemRequest(s), and Partners::ChildItemRequest(s)
 module Partners
   class FamilyRequestCreateService
     include ServiceObjectErrorsMixin
 
-    #
-    # This service object is meant to transform a family request
-    # into the correct parameters that would be expected in a
-    # regular request.
-    #
+    attr_reader :partner_user_id, :comments, :family_requests_attributes, :partner_request
 
     def initialize(partner_user_id:, comments: nil, family_requests_attributes: [])
       @partner_user_id = partner_user_id
@@ -29,6 +30,9 @@ module Partners
         request_create_svc.errors.full_messages.each do |msg|
           errors.add(:base, msg)
         end
+      else
+        # store partner request so frontend can redirect to it
+        @partner_request = request_create_svc.partner_request
       end
 
       self
@@ -36,14 +40,12 @@ module Partners
 
     private
 
-    attr_reader :partner_user_id, :comments, :family_requests_attributes
-
     def valid?
       if family_requests_attributes.blank?
         errors.add(:base, 'family_requests_attributes cannot be empty')
       end
 
-      if item_requests_attributes.any? { |attr| attr[:item_id].nil? }
+      if item_requests_attributes.any? { |attr| included_items_by_id[attr[:item_id].to_i].nil? }
         errors.add(:base, 'detected a unknown item_id')
       end
 
@@ -52,17 +54,16 @@ module Partners
 
     def item_requests_attributes
       @item_requests_attributes ||= family_requests_attributes.map do |fr_attr|
-        item = included_items.find { |i| i.id == fr_attr[:item_id].to_i }
-
         {
-          item_id: item&.id,
-          quantity: convert_person_count_to_item_quantity(item_id: fr_attr[:item_id], person_count: fr_attr[:person_count])&.to_i
+          item_id: fr_attr[:item_id],
+          quantity: convert_person_count_to_item_quantity(item_id: fr_attr[:item_id], person_count: fr_attr[:person_count])&.to_i,
+          children: fr_attr[:children]
         }.with_indifferent_access
       end
     end
 
     def convert_person_count_to_item_quantity(item_id:, person_count:)
-      item = included_items.find { |i| i.id == item_id.to_i }
+      item = included_items_by_id[item_id.to_i]
 
       # Could not find matching item so return nil instead
       return nil if item.blank?
@@ -70,8 +71,8 @@ module Partners
       person_count.to_i * item.default_quantity.abs
     end
 
-    def included_items
-      @included_items ||= Item.where(id: family_requests_attributes.map { |fr_attr| fr_attr[:item_id] })
+    def included_items_by_id
+      @included_items_by_id ||= Item.where(id: family_requests_attributes.pluck(:item_id)).index_by(&:id)
     end
   end
 end

--- a/app/services/partners/family_request_create_service.rb
+++ b/app/services/partners/family_request_create_service.rb
@@ -31,7 +31,7 @@ module Partners
           errors.add(:base, msg)
         end
       else
-        # store partner request so frontend can redirect to it
+        # Store partner request so the frontend can redirect to it
         @partner_request = request_create_svc.partner_request
       end
 

--- a/app/services/partners/request_create_service.rb
+++ b/app/services/partners/request_create_service.rb
@@ -48,8 +48,9 @@ module Partners
         Partners::ItemRequest.new(
           item_id: ira['item_id'],
           quantity: ira['quantity'],
+          children: ira['children'] || [], # will create ChildItemRequests if there are any
           name: fetch_organization_item_name(ira['item_id']),
-          partner_key: fetch_orgnaization_partner_key(ira['item_id'])
+          partner_key: fetch_organization_partner_key(ira['item_id'])
         )
       end
 
@@ -65,7 +66,7 @@ module Partners
       end
     end
 
-    def fetch_orgnaization_partner_key(item_id)
+    def fetch_organization_partner_key(item_id)
       item_data = organization_item_data.find { |item| item[:id] == item_id.to_i }
       if item_data.present?
         item_data[:partner_key]

--- a/app/views/partners/children/index.html.erb
+++ b/app/views/partners/children/index.html.erb
@@ -64,11 +64,9 @@
                         reset_filterrific_url,
                         class: 'btn btn-danger'
                     ) %>
-                <span class="float-right">
-          </span>
-            <% end %>
-
-            </div>
+                  <span class="float-right"></span>
+                <% end %>
+              </div>
             </div>
       </div>
     </div>

--- a/app/views/partners/family_requests/_list.html.erb
+++ b/app/views/partners/family_requests/_list.html.erb
@@ -1,0 +1,42 @@
+<table class='table table-striped'>
+  <thead>
+  <tr>
+    <th>Guardian</th>
+    <th>Child</th>
+    <th>Item Needed</th>
+    <th>Include This Child?</th>
+  </tr>
+  </thead>
+  <tbody class='fields'>
+  <% @children.each_with_index do |child, index| %>
+    <tr>
+      <td>
+        <%= child.family.guardian_first_name %>
+        <%= child.family.guardian_last_name %>
+      </td>
+      <td>
+        <%= child.first_name %> <%= child.last_name %>
+      </td>
+      <td>
+        <% if child.item_needed_diaperid %>
+          <%= item_id_to_display_string_map[child.item_needed_diaperid] %>
+        <% else %>
+          <%= "N/A" %>
+        <% end %>
+      </td>
+      <td>
+        <div class="custom-control custom-switch">
+          <% if child.item_needed_diaperid %>
+            <%= check_box_tag 'Active', child.active, child.active,
+                              data: {url: child_active_path(child),
+                                     remote: true, method: :post },
+                              class: "custom-control-input",
+                              id: "child-#{child.id}" %>
+            <label class="custom-control-label" for="child-<%= child.id %>"></label>
+          <% end %>
+        </div>
+      </td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/app/views/partners/family_requests/_list.html.erb
+++ b/app/views/partners/family_requests/_list.html.erb
@@ -19,7 +19,7 @@
       </td>
       <td>
         <% if child.item_needed_diaperid %>
-          <%= item_id_to_display_string_map[child.item_needed_diaperid] %>
+          <%= current_partner.organization.item_id_to_display_string_map[child.item_needed_diaperid] %>
         <% else %>
           <%= "N/A" %>
         <% end %>
@@ -28,7 +28,7 @@
         <div class="custom-control custom-switch">
           <% if child.item_needed_diaperid %>
             <%= check_box_tag 'Active', child.active, child.active,
-                              data: {url: child_active_path(child),
+                              data: {url: partners_child_active_path(child),
                                      remote: true, method: :post },
                               class: "custom-control-input",
                               id: "child-#{child.id}" %>

--- a/app/views/partners/family_requests/new.html.erb
+++ b/app/views/partners/family_requests/new.html.erb
@@ -1,0 +1,91 @@
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <% content_for :title, "Families - #{current_partner.name}" %>
+        <h1><i class="fa fa-users"></i>&nbsp;&nbsp;
+          Family Details
+          <small>for <%= current_partner.name %></small>
+        </h1>
+      </div>
+      <div class="col-sm-6">
+        <ol class="breadcrumb float-sm-right">
+          <li class="breadcrumb-item"><a href="<%= dashboard_path %>"><i class="fa fa-home fa-lg"></i></a></li>
+          <li class="breadcrumb-item"><a href="#">New Family Request</a></li>
+        </ol>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card">
+          <div class="card-header bg-primary">
+            <h3 class="card-title">Filters</h3>
+          </div>
+          <div class="card-body">
+            <%= form_for_filterrific @filterrific, remote: true do |f| %>
+              <div class="row">
+                <div class="col-3">
+                  <%= f.label :search_names, "Search By Child Name" %>
+                  <%= f.text_field(
+                          :search_names,
+                          class: 'filterrific-periodically-observed form-control'
+                      ) %>
+                </div>
+                <div class="col-3">
+                  <%= f.label :search_families, "Search By Guardian Name" %>
+                  <%= f.text_field(
+                          :search_families,
+                          class: 'filterrific-periodically-observed form-control'
+                      ) %>
+                </div>
+                <div class="col-3">
+                  <%= f.label :search_comments, "Show Active Only?" %>
+                  <%= f.check_box(
+                          :search_active,
+                          class: 'filterrific-periodically-observed form-control'
+                      ) %>
+                </div>
+                <div class="col-3">
+                  <%= render_filterrific_spinner %>
+                </div>
+              </div>
+              </div><!-- /.row -->
+              <div class="card-footer">
+                <%= link_to(
+                        'Reset Search',
+                        reset_filterrific_url,
+                        class: 'btn btn-danger'
+                    ) %>
+            <% end %>
+            </div>
+        </div>
+      </div>
+    </div>
+  </div><!-- /.container-fluid -->
+</section>
+
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-md-12">
+        <div class="card mb-4">
+          <%= form_tag(family_requests_path) do %>
+            <div id="filterrific_results">
+              <%= render(
+                partial: 'family_requests/list',
+                locals: {children: @children}
+              ) %>
+            </div>
+
+            <hr>
+
+            <div class="card-footer">
+              <%= submit_tag("Submit Essentials Request", class: "btn btn-primary") %>
+              <%= link_to "Cancel Request", partner_requests_path, class: "btn btn-danger" %>
+            </div>
+            </div>
+          <% end %>
+          </div>
+    </div>
+  </div>
+</section>

--- a/app/views/partners/family_requests/new.html.erb
+++ b/app/views/partners/family_requests/new.html.erb
@@ -10,7 +10,7 @@
       </div>
       <div class="col-sm-6">
         <ol class="breadcrumb float-sm-right">
-          <li class="breadcrumb-item"><a href="<%= dashboard_path %>"><i class="fa fa-home fa-lg"></i></a></li>
+          <li class="breadcrumb-item"><a href="<%= partner_user_root_path %>"><i class="fa fa-home fa-lg"></i></a></li>
           <li class="breadcrumb-item"><a href="#">New Family Request</a></li>
         </ol>
       </div>
@@ -69,10 +69,10 @@
     <div class="row">
       <div class="col-md-12">
         <div class="card mb-4">
-          <%= form_tag(family_requests_path) do %>
+          <%= form_tag(partners_family_requests_path) do %>
             <div id="filterrific_results">
               <%= render(
-                partial: 'family_requests/list',
+                partial: 'partners/family_requests/list',
                 locals: {children: @children}
               ) %>
             </div>
@@ -81,11 +81,11 @@
 
             <div class="card-footer">
               <%= submit_tag("Submit Essentials Request", class: "btn btn-primary") %>
-              <%= link_to "Cancel Request", partner_requests_path, class: "btn btn-danger" %>
-            </div>
+              <%= link_to "Cancel Request", partners_requests_path, class: "btn btn-danger" %>
             </div>
           <% end %>
-          </div>
+        </div>
+      </div>
     </div>
   </div>
 </section>

--- a/app/views/partners/family_requests/new.js.erb
+++ b/app/views/partners/family_requests/new.js.erb
@@ -1,0 +1,4 @@
+<% js = escape_javascript(
+  render(partial: 'family_requests/list', locals: { children: @children })
+) %>
+$("#filterrific_results").html("<%= js %>");

--- a/app/views/partners/family_requests/new.js.erb
+++ b/app/views/partners/family_requests/new.js.erb
@@ -1,4 +1,4 @@
 <% js = escape_javascript(
-  render(partial: 'family_requests/list', locals: { children: @children })
+  render(partial: 'partners/family_requests/list', locals: { children: @children })
 ) %>
 $("#filterrific_results").html("<%= js %>");

--- a/app/views/partners/requests/_request_options_card.html.erb
+++ b/app/views/partners/requests/_request_options_card.html.erb
@@ -12,7 +12,7 @@
             other essentials. Example - 1000 Size 1 Diapers, 500 Tampons, etc.</h6>
         </div>
         <div class="col-4">
-          <h2><%= link_to '', class: 'btn btn-primary' do %>
+          <h2><%= link_to new_partners_family_request_path, class: 'btn btn-primary' do %>
               <i class="fa fa-users"></i> Create New Family Essentials Request
             <% end %>
           </h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
     resource :dashboard, only: [:show]
     resources :requests, only: [:show, :new, :index, :create]
     resources :individuals_requests, only: [:new, :create]
+    resources :family_requests, only: [:new, :create]
     resources :users, only: [:index, :new, :create]
     resource :profile, only: [:show, :edit, :update]
     resource :approval_request, only: [:create]

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -250,7 +250,7 @@ note = [
         comments: Faker::Lorem.paragraph,
         active: Faker::Boolean.boolean,
         archived: false,
-        item_needed_diaperid: Partners::Child::CHILD_ITEMS.sample
+        item_needed_diaperid: partner.organization.item_id_to_display_string_map.key(Partners::Child::CHILD_ITEMS.sample)
       )
     end
 
@@ -268,7 +268,7 @@ note = [
         comments: Faker::Lorem.paragraph,
         active: Faker::Boolean.boolean,
         archived: false,
-        item_needed_diaperid: Partners::Child::CHILD_ITEMS.sample
+        item_needed_diaperid: partner.organization.item_id_to_display_string_map.key(Partners::Child::CHILD_ITEMS.sample)
       )
     end
   end

--- a/spec/requests/partners/family_requests_controller_spec.rb
+++ b/spec/requests/partners/family_requests_controller_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Partners::FamilyRequestsController, type: :request do
+  let(:partner) { create(:partner) }
+  let(:partners_partner) { Partners::Partner.find_by(diaper_partner_id: partner.id) }
+  let(:family) { create(:partners_family, partner_id: partners_partner.id) }
+  let(:children) { FactoryBot.create_list(:partners_child, 3, family: family) }
+  let(:partner_user) { partners_partner.primary_user }
+
+  before { sign_in(partner_user, scope: :partner_user) }
+
+  describe 'GET #new' do
+    subject { get new_partners_family_request_path }
+
+    it "does not allow deactivated partners" do
+      partners_partner.update!(status_in_diaper_base: :deactivated)
+
+      expect(subject).to redirect_to(partners_requests_path)
+    end
+
+    it "does not allow partners not verified" do
+      partners_partner.update!(partner_status: :pending)
+
+      expect(subject).to redirect_to(partners_requests_path)
+    end
+  end
+
+  describe 'POST #create' do
+    before do
+      # Set one child as deactivated and the other as active but
+      # without a item_needed_diaperid
+      children[0].update(active: false)
+      children[1].update(item_needed_diaperid: nil)
+    end
+    subject { post partners_family_requests_path }
+
+    it "does not allow deactivated partners" do
+      partners_partner.update!(status_in_diaper_base: :deactivated)
+
+      expect(subject).to redirect_to(partners_requests_path)
+    end
+
+    it "does not allow partners not verified" do
+      partners_partner.update!(partner_status: :pending)
+
+      expect(subject).to redirect_to(partners_requests_path)
+    end
+
+    it "submits the request" do
+      partners_partner.update!(partner_status: :verified)
+
+      subject
+
+      expect(response.request.flash[:notice]).to eql "Requested items successfully!"
+    end
+  end
+end

--- a/spec/services/partners/family_request_create_service_spec.rb
+++ b/spec/services/partners/family_request_create_service_spec.rb
@@ -13,18 +13,6 @@ describe Partners::FamilyRequestCreateService do
     let(:partner_user) { partner.primary_partner_user }
     let(:partner) { create(:partner) }
     let(:comments) { Faker::Lorem.paragraph }
-    let(:family_requests_attributes) do
-      [
-        ActionController::Parameters.new(
-          item_id: FactoryBot.create(:item).id,
-          person_count: Faker::Number.within(range: 1..10)
-        ),
-        ActionController::Parameters.new(
-          item_id: FactoryBot.create(:item).id,
-          person_count: Faker::Number.within(range: 1..10)
-        )
-      ]
-    end
 
     context 'when the arguments are incorrect' do
       context 'because no family_requests_attributes were defined' do
@@ -55,32 +43,77 @@ describe Partners::FamilyRequestCreateService do
     end
 
     context 'when the arguments are correct' do
-      let(:items_to_request) { partner_user.partner.organization.items.all.sample(3) }
-      let(:family_requests_attributes) do
-        items_to_request.map do |item|
-          ActionController::Parameters.new(
-            item_id: item.id,
-            person_count: Faker::Number.within(range: 1..10)
-          )
+      context 'with children' do
+        let(:items_to_request) { partner_user.partner.organization.items.all.sample(2) }
+        let(:first_item_id) { items_to_request.first.id.to_i }
+        let(:second_item_id) { items_to_request.second.id.to_i }
+        let(:child1) { create(:partners_child) }
+        let(:child2) { create(:partners_child) }
+        let(:family_requests_attributes) do
+          [
+            {
+              item_id: first_item_id,
+              person_count: 1,
+              children: [child1]
+            },
+            {
+              item_id: second_item_id,
+              person_count: 2,
+              children: [child1, child2]
+            }
+          ]
+        end
+
+        it 'should create the appropriate organization ::Request, Partners::Request, Partners::ItemRequest and Partners::ChildItemRequests' do
+          expect do
+            subject
+          end.to change { ::Request.count }
+            .by(1)
+            .and change { Partners::Request.count }
+            .by(1)
+
+          expect(::Request.last.request_items.map { |item| item["item_id"] }).to match_array(items_to_request.pluck(:id))
+
+          partner_request = Partners::Request.last
+          expect(partner_request.item_requests.count).to eq(2)
+
+          first_item_request = partner_request.item_requests.find_by(item_id: first_item_id)
+          expect(first_item_request.children).to contain_exactly(child1)
+
+          second_item_request = partner_request.item_requests.find_by(item_id: second_item_id)
+          expect(second_item_request.children).to contain_exactly(child1, child2)
         end
       end
-      let(:expected_item_request_attributes) do
-        family_requests_attributes.map do |fr_attr|
-          {
-            item_id: fr_attr[:item_id],
-            quantity: Item.find(fr_attr[:item_id]).default_quantity * fr_attr[:person_count]
-          }
+
+      context 'without children' do
+        let(:items_to_request) { partner_user.partner.organization.items.all.sample(3) }
+        let(:family_requests_attributes) do
+          items_to_request.map do |item|
+            ActionController::Parameters.new(
+              item_id: item.id,
+              person_count: Faker::Number.within(range: 1..10)
+            )
+          end
         end
-      end
-      let(:fake_request_create_service) { instance_double(Partners::RequestCreateService, call: -> {}, errors: []) }
+        let(:expected_item_request_attributes) do
+          family_requests_attributes.map do |fr_attr|
+            {
+              item_id: fr_attr[:item_id],
+              quantity: Item.find(fr_attr[:item_id]).default_quantity * fr_attr[:person_count],
+              children: nil
+            }
+          end
+        end
+        let(:fake_request_create_service) { instance_double(Partners::RequestCreateService, call: -> {}, errors: [], partner_request: -> {}) }
 
-      before do
-        allow(Partners::RequestCreateService).to receive(:new).with(partner_user_id: partner_user.id, comments: comments, item_requests_attributes: contain_exactly(*expected_item_request_attributes)).and_return(fake_request_create_service)
-      end
+        before do
+          allow(Partners::RequestCreateService).to receive(:new).with(partner_user_id: partner_user.id, comments: comments, item_requests_attributes: contain_exactly(*expected_item_request_attributes)).and_return(fake_request_create_service)
+        end
 
-      it 'should send the correct request payload to the Partners::RequestCreateService and call it' do
-        subject
-        expect(fake_request_create_service).to have_received(:call)
+        it 'should send the correct request payload to the Partners::RequestCreateService and call it' do
+          subject
+          expect(fake_request_create_service).to have_received(:call)
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves #2202

### Description
Copied over FamilyRequest feature from partner and made the necessary changes to get it working in diaper (updating routes and constants)

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Tested locally and with specs I added

### Screenshots

![diaper](https://user-images.githubusercontent.com/217050/114285020-c75b5700-9a08-11eb-9880-c7e70db69e60.gif)

