### PR TITLE
2261 prevent setting items to a negative number

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -64,7 +64,7 @@ class ItemsController < ApplicationController
       redirect_to items_path, notice: "#{@item.name} updated!"
     else
       @base_items = BaseItem.without_kit.alphabetized
-      flash[:error] = "Something didn't work quite right -- try again? #{@item.errors.each{ |msg| msg }}"
+      flash[:error] = "Something didn't work quite right -- try again? #{@item.errors.map { |attr, msg| "#{attr}: #{msg}" }}"
       render action: :edit
     end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -64,7 +64,7 @@ class ItemsController < ApplicationController
       redirect_to items_path, notice: "#{@item.name} updated!"
     else
       @base_items = BaseItem.without_kit.alphabetized
-      flash[:error] = "Something didn't work quite right -- try again?"
+      flash[:error] = "Something didn't work quite right -- try again? #{@item.errors.each{ |msg| msg }}"
       render action: :edit
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -34,7 +34,7 @@ class Item < ApplicationRecord
   validates :organization, presence: true
   validates :distribution_quantity, :on_hand_recommended_quantity, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
   validates :on_hand_minimum_quantity, numericality: { greater_than_or_equal_to: 0 }
-  
+
   has_many :line_items, dependent: :destroy
   has_many :inventory_items, dependent: :destroy
   has_many :barcode_items, as: :barcodeable, dependent: :destroy

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -32,7 +32,9 @@ class Item < ApplicationRecord
   validates :name, uniqueness: { scope: :organization }
   validates :name, presence: true
   validates :organization, presence: true
-
+  validates :distribution_quantity, :on_hand_recommended_quantity, numericality: { greater_than_or_equal_to: 0 }, allow_blank: true
+  validates :on_hand_minimum_quantity, numericality: { greater_than_or_equal_to: 0 }
+  
   has_many :line_items, dependent: :destroy
   has_many :inventory_items, dependent: :destroy
   has_many :barcode_items, as: :barcodeable, dependent: :destroy

--- a/db/migrate/20210409193928_convert_negative_distribution_quantity_into_positive.rb
+++ b/db/migrate/20210409193928_convert_negative_distribution_quantity_into_positive.rb
@@ -1,0 +1,11 @@
+class ConvertNegativeDistributionQuantityIntoPositive < ActiveRecord::Migration[6.0]
+  def change
+    safety_assured {
+      execute <<-SQL
+        UPDATE items 
+        SET distribution_quantity = ABS(distribution_quantity) 
+        WHERE distribution_quantity < 0
+      SQL
+    }
+  end
+end

--- a/db/migrate/20210409194754_add_none_negative_constraint_on_distribution_quantity.rb
+++ b/db/migrate/20210409194754_add_none_negative_constraint_on_distribution_quantity.rb
@@ -1,0 +1,20 @@
+class AddNoneNegativeConstraintOnDistributionQuantity < ActiveRecord::Migration[6.0]
+  def up
+    safety_assured {
+      execute <<-SQL
+        ALTER TABLE items
+        ADD CONSTRAINT distribution_quantity_nonnegative 
+        CHECK (distribution_quantity >= 0);
+      SQL
+    }
+  end
+
+  def down
+    safety_assured {
+      execute <<-SQL
+        ALTER TABLE items
+        DROP CONSTRAINT distribution_quantity_nonnegative 
+      SQL
+    }
+  end
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe Item, type: :model do
       expect(build(:item, name: item.name)).not_to be_valid
     end
     it "requires that items quantity are not a negative number" do
-      expect(build(:item, distribution_quantity: -1 )).not_to be_valid
-      expect(build(:item, on_hand_minimum_quantity: -1 )).not_to be_valid
-      expect(build(:item, on_hand_recommended_quantity: -1 )).not_to be_valid
+      expect(build(:item, distribution_quantity: -1)).not_to be_valid
+      expect(build(:item, on_hand_minimum_quantity: -1)).not_to be_valid
+      expect(build(:item, on_hand_recommended_quantity: -1)).not_to be_valid
     end
   end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -33,6 +33,11 @@ RSpec.describe Item, type: :model do
       expect(build(:item, name: nil)).not_to be_valid
       expect(build(:item, name: item.name)).not_to be_valid
     end
+    it "requires that items quantity are not a negative number" do
+      expect(build(:item, distribution_quantity: -1 )).not_to be_valid
+      expect(build(:item, on_hand_minimum_quantity: -1 )).not_to be_valid
+      expect(build(:item, on_hand_recommended_quantity: -1 )).not_to be_valid
+    end
   end
 
   context "Filtering >" do


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2261 <!--fill issue number-->

### Description

Prevent setting the "Distribution quantity", "On hand minimum quantity", and "On hand recommended quantity" of an Item to a negative number

<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
![image](https://user-images.githubusercontent.com/50420424/114451739-f9f28480-9bad-11eb-870e-7acd5121f9f1.png)
