### PR TITLE
2273 allow admins to view account reqs

### DIFF
--- a/app/controllers/admin/account_requests_controller.rb
+++ b/app/controllers/admin/account_requests_controller.rb
@@ -1,0 +1,6 @@
+class Admin::AccountRequestsController < AdminController
+  def index
+    @open_account_requests = AccountRequest.where(confirmed_at: nil).order('created_at').reverse
+    @closed_account_requests = AccountRequest.where.not(confirmed_at: nil).order('confirmed_at').reverse
+  end
+end

--- a/app/controllers/admin/account_requests_controller.rb
+++ b/app/controllers/admin/account_requests_controller.rb
@@ -1,6 +1,6 @@
 class Admin::AccountRequestsController < AdminController
   def index
-    @open_account_requests = AccountRequest.where(confirmed_at: nil).order('created_at').reverse
-    @closed_account_requests = AccountRequest.where.not(confirmed_at: nil).order('confirmed_at').reverse
+    @open_account_requests = AccountRequest.where(confirmed_at: nil).order('created_at DESC')
+    @closed_account_requests = AccountRequest.where.not(confirmed_at: nil).order('confirmed_at DESC')
   end
 end

--- a/app/views/admin/account_requests/index.html.erb
+++ b/app/views/admin/account_requests/index.html.erb
@@ -1,0 +1,103 @@
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <% content_for :title, "Open Account Requests" %>
+        <h1>
+          Open Account Requests
+        </h1>
+      </div>
+    </div>
+  </div><!-- /.container-fluid -->
+</section>
+
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12">
+        <!-- Default box -->
+        <div class="card">
+          <div class="card-body p-0">
+            <table class="table" id="open-account-requests">
+              <thead>
+              <tr>
+                <th>Date Submitted</th>
+                <th>Organization name</th>
+                <th>Organization website</th>
+                <th>Request details</th>
+                <th>Contact name</th>
+                <th>Contact email</th>
+              </tr>
+              </thead>
+              <tbody>
+              <% @open_account_requests.each do |account_request| %>
+                <tr>
+                  <td><%= account_request.created_at.strftime("%m/%d/%Y") %></td>
+                  <td><%= account_request.organization_name %></td>
+                  <td><%= account_request.organization_website %></td>
+                  <td><%= account_request.request_details %></td>
+                  <td><%= account_request.name %></td>
+                  <td><%= account_request.email %></td>
+              <% end %>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <!-- /.card -->
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="content-header">
+  <div class="container-fluid">
+    <div class="row mb-2">
+      <div class="col-sm-6">
+        <% content_for :title, "Confirmed Account Requests" %>
+        <h1>
+          Closed Account Requests
+        </h1>
+      </div>
+    </div>
+  </div><!-- /.container-fluid -->
+</section>
+
+<section class="content">
+  <div class="container-fluid">
+    <div class="row">
+      <div class="col-12">
+        <!-- Default box -->
+        <div class="card">
+          <div class="card-body p-0">
+            <table class="table" id="closed-account-requests">
+              <thead>
+              <tr>
+                <th>Date Confirmed</th>
+                <th>Organization name</th>
+                <th>Organization website</th>
+                <th>Request details</th>
+                <th>Contact name</th>
+                <th>Contact email</th>
+              </tr>
+              </thead>
+              <tbody>
+              <% @closed_account_requests.each do |account_request| %>
+                <tr>
+                  <td><%= account_request.confirmed_at.strftime("%m/%d/%Y") %></td>
+                  <td><%= account_request.organization_name %></td>
+                  <td><%= account_request.organization_website %></td>
+                  <td><%= account_request.request_details %></td>
+                  <td><%= account_request.name %></td>
+                  <td><%= account_request.email %></td>
+              <% end %>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <!-- /.card -->
+      </div>
+    </div>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,7 @@ Rails.application.routes.draw do
     resources :partners, except: %i[new create destroy]
     resources :users
     resources :barcode_items
+    resources :account_requests
     resources :feedback_messages do
       get :resolve
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,7 @@ Rails.application.routes.draw do
     resources :partners, except: %i[new create destroy]
     resources :users
     resources :barcode_items
-    resources :account_requests
+    resources :account_requests, only: [:index]
     resources :feedback_messages do
       get :resolve
     end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -166,29 +166,29 @@ note = [
   # ----------------------------------------------------------------------------
 
   partner = Partners::Partner.create!({
-    name: p.name,
-    address1: Faker::Address.street_address,
-    address2: "",
-    city: Faker::Address.city,
-    state: Faker::Address.state_abbr,
-    zip_code: Faker::Address.zip,
-    website: Faker::Internet.domain_name,
-    zips_served: Faker::Address.zip,
-    diaper_bank_id: pdx_org.id,
-    diaper_partner_id: p.id,
-    executive_director_name: Faker::Name.name,
-    executive_director_email: p.email,
-    executive_director_phone: Faker::PhoneNumber.phone_number,
-    program_contact_name: Faker::Name.name,
-    program_contact_email: Faker::Internet.email,
-    program_contact_phone: Faker::PhoneNumber.phone_number,
-    program_contact_mobile: Faker::PhoneNumber.phone_number,
-    pick_up_name: Faker::Name.name,
-    pick_up_email: Faker::Internet.email,
-    pick_up_phone: Faker::PhoneNumber.phone_number,
-    partner_status: partner_status_map[partner_option[:status]] || "pending",
-    status_in_diaper_base: partner_option[:status]
-  })
+                                        name: p.name,
+                                        address1: Faker::Address.street_address,
+                                        address2: "",
+                                        city: Faker::Address.city,
+                                        state: Faker::Address.state_abbr,
+                                        zip_code: Faker::Address.zip,
+                                        website: Faker::Internet.domain_name,
+                                        zips_served: Faker::Address.zip,
+                                        diaper_bank_id: pdx_org.id,
+                                        diaper_partner_id: p.id,
+                                        executive_director_name: Faker::Name.name,
+                                        executive_director_email: p.email,
+                                        executive_director_phone: Faker::PhoneNumber.phone_number,
+                                        program_contact_name: Faker::Name.name,
+                                        program_contact_email: Faker::Internet.email,
+                                        program_contact_phone: Faker::PhoneNumber.phone_number,
+                                        program_contact_mobile: Faker::PhoneNumber.phone_number,
+                                        pick_up_name: Faker::Name.name,
+                                        pick_up_email: Faker::Internet.email,
+                                        pick_up_phone: Faker::PhoneNumber.phone_number,
+                                        partner_status: partner_status_map[partner_option[:status]] || "pending",
+                                        status_in_diaper_base: partner_option[:status]
+                                      })
 
   Partners::User.create!(
     name: Faker::Name.name,
@@ -513,7 +513,7 @@ end
   status = count > 15 ? 'fulfilled' : 'pending'
 
   org_items = pdx_org.items.pluck(:id)
-  request_items = Array.new(Faker::Number.within(range: 3..8)).map do |item|
+  request_items = Array.new(Faker::Number.within(range: 3..8)).map do |_item|
     {
       "item_id" => org_items.sample,
       "quantity" => Faker::Number.within(range: 5..10)
@@ -610,4 +610,25 @@ users.each do |user|
       resolved: [true, false].sample
     )
   end
+end
+
+# ----------------------------------------------------------------------------
+# Account Requests
+# ----------------------------------------------------------------------------
+# Add some Account Requests to fill up the account requests admin page
+
+[{ organization_name: "Telluride Diaper Bank",    website: "TDB.com", confirmed_at: nil },
+ { organization_name: "Ouray Diaper Bank",        website: "ODB.com",   confirmed_at: nil },
+ { organization_name: "Canon City Diaper Bank",   website: "CCDB.com",  confirmed_at: nil },
+ { organization_name: "Golden Diaper Bank",       website: "GDB.com",   confirmed_at: (Time.zone.today - rand(15).days) },
+ { organization_name: "Westminster Diaper Bank",  website: "WDB.com",   confirmed_at: (Time.zone.today - rand(15).days) },
+ { organization_name: "Lakewood Diaper Bank",     website: "LDB.com",   confirmed_at: (Time.zone.today - rand(15).days) }].each do |account_request|
+  AccountRequest.create(
+    name: Faker::Name.unique.name,
+    email: Faker::Internet.unique.email,
+    organization_name: account_request[:organization_name],
+    organization_website: account_request[:website],
+    request_details: Faker::Lorem.paragraphs.join(", "),
+    confirmed_at: account_request[:confirmed_at]
+  )
 end

--- a/spec/requests/admin/account_requests_requests_spec.rb
+++ b/spec/requests/admin/account_requests_requests_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin::AccountRequestsController', type: :request do
+  context 'while signed in as a super admin' do
+    before do
+      sign_in(@super_admin)
+    end
+
+    describe 'GET #index' do
+      it 'returns success' do
+        get admin_account_requests_path
+        expect(response).to be_successful
+      end
+    end
+  end
+end

--- a/spec/system/admin/account_requests_system_spec.rb
+++ b/spec/system/admin/account_requests_system_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe "Account Requests Admin", type: :system do
+  context "while signed in as a super admin" do
+    before do
+      sign_in(@super_admin)
+    end
+
+    context "user visits the index page" do
+      let!(:request1) { create(:account_request, confirmed_at: Time.zone.today) }
+      let!(:request2) { create(:account_request, confirmed_at: Time.zone.today - 1.day) }
+      let!(:request3) { create(:account_request, confirmed_at: Time.zone.today - 2.days) }
+      let!(:request4) { create(:account_request, created_at: Time.zone.today) }
+      let!(:request5) { create(:account_request, created_at: Time.zone.today - 1.day) }
+      let!(:request6) { create(:account_request, created_at: Time.zone.today - 2.days) }
+
+      before do
+        visit admin_account_requests_path
+      end
+
+      it 'shows unconfirmed account requests within appropriate table' do
+        expect(page).to have_css("table", id: "open-account-requests")
+
+        within "#open-account-requests" do
+          [request4, request5, request6].each do |request|
+            expect(page).to have_content(request.created_at.strftime("%m/%d/%Y"))
+            expect(page).to have_content(request.organization_name)
+            expect(page).to have_content(request.organization_website)
+            expect(page).to have_content(request.request_details)
+            expect(page).to have_content(request.name)
+            expect(page).to have_content(request.email)
+          end
+          expect(page).to_not have_content(request1.name)
+        end
+      end
+
+      it 'shows confirmed account requests within appropriate table' do
+        expect(page).to have_css("table", id: "open-account-requests")
+
+        within "#closed-account-requests" do
+          [request1, request2, request3].each do |request|
+            expect(page).to have_content(request.created_at.strftime("%m/%d/%Y"))
+            expect(page).to have_content(request.organization_name)
+            expect(page).to have_content(request.organization_website)
+            expect(page).to have_content(request.request_details)
+            expect(page).to have_content(request.name)
+            expect(page).to have_content(request.email)
+          end
+          expect(page).to_not have_content(request4.name)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #2273 

### Description
As per issue criteria and confirmation from @edwinthinks, this adds a new page for admins to view all account requests. This required:
 *  a new admin [controller](app/controllers/admin/account_requests_controller.rb) with index action
 *  a new [view](app/views/admin/account_requests/index.html.erb) with 2 tables for open and closed account requests 
     ordered by date submitted and date created respectfully
 *  account requests resources added under the admin namespace in [routes](https://github.com/PhilipDeFraties/diaper/blob/d7adf44d6dcd1a0641b5b36f7d20cc0139f41803/config/routes.rb#L58)

The [admin/account_requests#index](app/controllers/admin/account_requests_controller.rb) action makes 2 ActiveRecord queries in order to separate the requests by presence of confirmed_at date. I'm unsure if this is the best way to do this, or if having two tables in the [view](app/views/admin/account_requests/index.html.erb) is best.

An alternative I was thinking of would be to have one table with open requests at the top and closed requests below maybe greyed out somehow, but the two groups are being ordered by different date columns and I would need to do a bit of a dive into CSS to figure out how to get this done. Let me know what you think.

* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?

I created system spec [file](spec/system/admin/account_requests_system_spec.rb) as well as a request spec [file](https://github.com/PhilipDeFraties/diaper/blob/2273-allow-admins-to-view-account-reqs/spec/requests/admin/account_requests_requests_spec.rb) that are in line with other similar tests.

### Screenshots

![Screen Shot 2021-04-12 at 8 10 05 PM](https://user-images.githubusercontent.com/65036872/114486418-19e47100-9bcb-11eb-9246-e7a664b8a9ad.png)

I was able to add seeds to the bottom of the seeds file, however when I went to commit the file I kept receiving an error that had to do with rubocop and making the suggested adjustments seemed a bit beyond the scope of this pr:

![Screen Shot 2021-04-12 at 8 27 15 PM](https://user-images.githubusercontent.com/65036872/114487834-82345200-9bcd-11eb-9edf-80f9020acc25.png)

The error window wouldn't expand so here is a the full error:
```
husky > pre-commit (node v14.15.4)
[STARTED] Preparing...
[SUCCESS] Preparing...
[STARTED] Running tasks...
[STARTED] Running tasks for *.rb
[STARTED] rubocop -a
[FAILED] rubocop -a [FAILED]
[FAILED] rubocop -a [FAILED]
[SUCCESS] Running tasks...
[STARTED] Applying modifications...
[SKIPPED] Skipped because of errors from tasks.
[STARTED] Reverting to original state because of errors...
[SUCCESS] Reverting to original state because of errors...
[STARTED] Cleaning up...
[SUCCESS] Cleaning up...
✖ rubocop -a:
The following cops were added to RuboCop, but are not configured. Please set Enabled to either `true` or `false` in your `.rubocop.yml` file.
Please also note that can also opt-in to new cops by default by adding this to your config:
  AllCops:
    NewCops: enable
Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
  Enabled: true
Lint/EmptyBlock: # (new in 1.1)
  Enabled: true
Lint/ToEnumArguments: # (new in 1.1)
  Enabled: true
Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
  Enabled: true
Style/ArgumentsForwarding: # (new in 1.1)
  Enabled: true
Style/DocumentDynamicEvalDefinition: # (new in 1.1)
  Enabled: true
Style/SwapValues: # (new in 1.1)
  Enabled: true
Rails/AttributeDefaultBlockValue: # (new in 2.9)
  Enabled: true
Rails/WhereEquals: # (new in 2.9)
  Enabled: true
For more information: https://docs.rubocop.org/rubocop/versioning.html
Inspecting 1 file
C
Offenses:
db/seeds.rb:5:3: C: Rails/Output: Do not write to stdout. Use Rails's logger if you want to log.
  puts "Database seeding has been configured to work only in non production settings"
  ^^^^
db/seeds.rb:75:48: C: Rails/SkipsModelValidations: Avoid using update_all because it skips validations.
  org.items.where(value_in_cents: 0).limit(10).update_all(value_in_cents: 100)
                                               ^^^^^^^^^^
db/seeds.rb:391:13: C: Style/NumericPredicate: Use quantity.zero? instead of quantity == 0.
  return if quantity == 0
            ^^^^^^^^^^^^^
db/seeds.rb:548:23: C: Rails/Date: Do not use Date.today without zone. Use Time.zone.today instead.
    created_at: (Date.today - rand(15).days),
                      ^^^^^
db/seeds.rb:549:23: C: Rails/Date: Do not use Date.today without zone. Use Time.zone.today instead.
    updated_at: (Date.today - rand(15).days),
                      ^^^^^
db/seeds.rb:573:22: C: Rails/Date: Do not use Date.today without zone. Use Time.zone.today instead.
    issued_at: (Date.today - rand(15).days),
                     ^^^^^
db/seeds.rb:574:23: C: Rails/Date: Do not use Date.today without zone. Use Time.zone.today instead.
    created_at: (Date.today - rand(15).days),
                      ^^^^^
db/seeds.rb:575:23: C: Rails/Date: Do not use Date.today without zone. Use Time.zone.today instead.
    updated_at: (Date.today - rand(15).days),
                      ^^^^^
1 file inspected, 8 offenses detected, 1 more offense can be corrected with `rubocop -A`
husky > pre-commit hook failed (add --no-verify to bypass)
```

