### PR TITLE
Prevent InventoryItem deletion to leads to distribution bugs

### DIFF
--- a/app/models/donation.rb
+++ b/app/models/donation.rb
@@ -119,8 +119,6 @@ class Donation < ApplicationRecord
       storage_location.increase_inventory(to_a)
       # Apply the new changes to the storage location inventory
       original_storage_location.decrease_inventory(old_data)
-      # TODO: Discuss this -- *should* we be removing InventoryItems when they hit 0 count?
-      original_storage_location.inventory_items.where(quantity: 0).destroy_all
     end
   rescue ActiveRecord::RecordInvalid
     false

--- a/spec/controllers/donations_controller_spec.rb
+++ b/spec/controllers/donations_controller_spec.rb
@@ -135,23 +135,6 @@ RSpec.describe DonationsController, type: :controller do
             put :update, params: default_params.merge(id: donation.id, donation: donation_params)
           end.to change { donation.storage_location.inventory_items.first.quantity }.by(-10)
         end
-
-        it "deletes inventory item if line item and inventory item quantities are equal" do
-          donation = create(:donation, :with_items, item_quantity: 1)
-          line_item = donation.line_items.first
-          inventory_item = donation.storage_location.inventory_items.first
-          inventory_item.update(quantity: line_item.quantity)
-          line_item_params = {
-            "0" => {
-              "_destroy" => "true",
-              item_id: line_item.item_id,
-              id: line_item.id
-            }
-          }
-          donation_params = { source: donation.source, line_items_attributes: line_item_params }
-          put :update, params: default_params.merge(id: donation.id, donation: donation_params)
-          expect { inventory_item.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        end
       end
     end
 

--- a/spec/models/donation_spec.rb
+++ b/spec/models/donation_spec.rb
@@ -175,19 +175,6 @@ RSpec.describe Donation, type: :model do
                                                  .and change { Item.active.count }.by(1)
         end
       end
-
-      context "with empty line_items" do
-        let(:attributes) { { line_items_attributes: {} } }
-
-        it "removes the inventory item if the item's removal results in a 0 count" do
-          subject
-          expect do
-            subject.replace_increase!(attributes)
-            storage_location.reload
-          end.to change { storage_location.inventory_items.size }.by(-1)
-                                                                 .and change { InventoryItem.count }.by(-1)
-        end
-      end
     end
 
     describe "source_view" do


### PR DESCRIPTION
Resolves N/A

### Description

I discovered a bug that prevented a user from marking a distribution as complete. When they tried to mark it as complete, it would show an error message saying that some items are not present in the storage location. The source of this was a missing InventoryItem caused by the `Donation#replace_increase!` deleting any InventoryItem that has a quantity of 0.

We run into various problems if the InventoryItem is missing from the StorageLocation such as this one. Another issue that I've noticed that requests that reference a non-existent InventoryItem will yield a blank or incorrect LineItem in the distribution fulfillment phase.

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
CI & Tested locally

### Screenshots
N/A
