### PR TITLE
2204 migrate reminder deadline job

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,6 @@ gem "puma"
 gem "rails", "~> 6.0.3"
 gem "sass-rails"
 gem "sidekiq"
-gem 'sidekiq-scheduler'
 gem "strong_migrations", "~> 0.7.6"
 gem "sprockets", "~> 4.0.2"
 gem "toastr-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,10 +170,7 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
-    e2mmap (0.1.0)
     erubi (1.10.0)
-    et-orbi (1.2.2)
-      tzinfo
     execjs (2.7.0)
     factory_bot (6.1.0)
       activesupport (>= 5.0.0)
@@ -204,9 +201,6 @@ GEM
     font-ionicons-rails (2.0.1.6)
       railties (>= 3.2, < 7.0)
     formatador (0.2.5)
-    fugit (1.3.3)
-      et-orbi (~> 1.1, >= 1.1.8)
-      raabro (~> 1.1)
     fullcalendar-rails (3.9.0.0)
       jquery-rails (>= 4.0.5, < 5.0.0)
       jquery-ui-rails (>= 5.0.2)
@@ -346,7 +340,6 @@ GEM
     public_suffix (4.0.6)
     puma (4.3.7)
       nio4r (~> 2.0)
-    raabro (1.1.6)
     racc (1.5.2)
     rack (2.2.3)
     rack-protection (2.1.0)
@@ -449,8 +442,6 @@ GEM
     ruby-vips (2.0.17)
       ffi (~> 1.9)
     rubyzip (2.3.0)
-    rufus-scheduler (3.6.0)
-      fugit (~> 1.1, >= 1.1.6)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -473,13 +464,6 @@ GEM
       rack (~> 2.0)
       rack-protection (>= 1.5.0)
       redis (>= 3.3.5, < 4.2)
-    sidekiq-scheduler (3.0.1)
-      e2mmap
-      redis (>= 3, < 5)
-      rufus-scheduler (~> 3.2)
-      sidekiq (>= 3)
-      thwait
-      tilt (>= 1.4.0)
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
@@ -518,7 +502,6 @@ GEM
       climate_control (>= 0.0.3, < 1.0)
     thor (1.1.0)
     thread_safe (0.3.6)
-    thwait (0.1.0)
     tilt (2.0.10)
     toastr-rails (1.0.3)
       railties (>= 3.1.0)
@@ -637,7 +620,6 @@ DEPENDENCIES
   sass-rails
   shoulda-matchers (~> 4.5)
   sidekiq
-  sidekiq-scheduler
   simple_form
   simplecov
   skylight

--- a/app/jobs/reminder_deadline_job.rb
+++ b/app/jobs/reminder_deadline_job.rb
@@ -1,9 +1,9 @@
 class ReminderDeadlineJob < ApplicationJob
   def perform
     if Flipper.enabled?(:reminders_active)
-      # TODO: This query can probably be improved
-      organizations = Organization.where('reminder_day = ? and deadline_day is not null', Date.current.day)
-      organizations.each do |organization|
+      organizations = Organization.needs_reminding
+
+      organizations.includes(:partners).each do |organization|
         organization.partners.where(send_reminders: true).each do |partner|
           ReminderDeadlineMailer.notify_deadline(partner, organization).deliver_now
         end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -118,6 +118,7 @@ class Organization < ApplicationRecord
 
   scope :alphabetized, -> { order(:name) }
   scope :search_name, ->(query) { where('name ilike ?', "%#{query}%") }
+  scope :needs_reminding, -> { where('reminder_day = ? and deadline_day is not null', Date.current.day) }
 
   def assign_attributes_from_account_request(account_request)
     assign_attributes(

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,17 +1,5 @@
 require 'sidekiq'
-require 'sidekiq-scheduler'
 
-# Added this ENV variable to prevent sending double  reminders via
-# ReminderDeadlineJob scheduled whilst  two versions of production
-# are being hosted. We will have a time period were we will be hosting
-# this on azure and heroku.
-#
-# We will be removing this entire sidekiq scheduler in favor of a rake task
-# eventually that we'll run in herokus scheduler.
-# More details written in https://github.com/rubyforgood/diaper/issues/2204
-Sidekiq::Scheduler.enabled = ENV["DISABLE_SIDEKIQ_SCHEDULER"] ? false : true
-Sidekiq.schedule = YAML.load_file(File.expand_path(Rails.root + 'config/scheduler.yml', __FILE__))
-SidekiqScheduler::Scheduler.load_schedule!
 Sidekiq::Extensions.enable_delay!
 
 #

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 def set_up_sidekiq
   require 'sidekiq/web'
-  require 'sidekiq-scheduler/web'
 
   if Rails.env.production?
     Sidekiq::Web.use Rack::Auth::Basic do |username, password|

--- a/config/scheduler.yml
+++ b/config/scheduler.yml
@@ -1,4 +1,0 @@
-# config/scheduler.yml
-  ReminderDeadlineJob:
-    cron: '0 0 0 * * *'   # Runs once every day at 00:00 UTC
-    class: ReminderDeadlineJob

--- a/lib/tasks/initiate_reminder_deadline_job.rake
+++ b/lib/tasks/initiate_reminder_deadline_job.rake
@@ -1,0 +1,7 @@
+desc "This task is called by the Heroku scheduler add-on to initiate the ReminderDeadlineJob periodically"
+task :initiate_reminder_deadline_job => :environment do
+  puts "Initiating the Reminder Deadline job"
+  ReminderDeadlineJob.perform_now
+
+  puts "Done!"
+end


### PR DESCRIPTION
Resolves #2204 

### Description

~~Note that this is still WIP, as this needs to be properly tested in production on Heroku.~~  
**Update from @edwinthinks  - I've tested it on staging it looks good!**

- ReminderDeadlineJob:
   - Scope added for Organizations that needed reminders to be sent to them, named `needs_reminding`.
   - Added an `includes(:partners)` to avoid an N+1 query when querying `organization.partners` which I noticed. 
  (Note that it might not be in the optimal location!)
- New Rake task added, called `initiate_reminder_deadline_job` and which can be invoked as such in the command line: 
  ```rake initiate_reminder_deadline_job```
- Sidekiq scheduler gem removed, as well as `scheduler.yml` and code in the Sidekiq initializer which related to Sidekiq scheduler.  

### Type of change

* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?

Running the test suite as-is, which already includes a spec for ReminderDeadlineJob. Since there aren't any specs for the rake tasks, and none for ActiveRecord scopes, I decided to omit these specs. 

I also tried to run ReminderDeadlineJob locally, but given that there's not much in the way of Partner/Organization seeds, this wasn't very productive; potentially this could be something to address down the line? 


