### PR TITLE
2311 update seed distribution state from started to scheduled

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,8 +505,6 @@ GEM
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
     thor (1.1.0)
-    thwait (0.1.0)
-    thread_safe (0.3.6)
     tilt (2.0.10)
     toastr-rails (1.0.3)
       railties (>= 3.1.0)
@@ -646,4 +644,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.13
+   2.2.16

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -9,7 +9,7 @@ require 'time_util'
 #  delivery_method        :integer          default("pick_up"), not null
 #  issued_at              :datetime
 #  reminder_email_enabled :boolean          default(FALSE), not null
-#  state                  :integer          default("started"), not null
+#  state                  :integer          default("scheduled"), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  organization_id        :integer

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -41,7 +41,7 @@ class Distribution < ApplicationRecord
 
   before_save :combine_distribution
 
-  enum state: { started: 0, scheduled: 5, complete: 10 }
+  enum state: { scheduled: 5, complete: 10 }
   enum delivery_method: { pick_up: 0, delivery: 1 }
 
   # add item_id scope to allow filtering distributions by item

--- a/app/services/distribution_create_service.rb
+++ b/app/services/distribution_create_service.rb
@@ -9,7 +9,6 @@ class DistributionCreateService < DistributionService
   def call
     perform_distribution_service do
       distribution.save!
-      distribution.scheduled!
       distribution.storage_location.decrease_inventory distribution
       distribution.reload
       @request&.update!(distribution_id: distribution.id, status: 'fulfilled')

--- a/db/migrate/20210504164328_change_state_default_on_distributions.rb
+++ b/db/migrate/20210504164328_change_state_default_on_distributions.rb
@@ -1,0 +1,5 @@
+class ChangeStateDefaultOnDistributions < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :distributions, :state, from: 0, to: 5
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_425_024_157) do
+ActiveRecord::Schema.define(version: 20_210_504_164_328) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -160,7 +160,7 @@ ActiveRecord::Schema.define(version: 20_210_425_024_157) do
     t.datetime "issued_at"
     t.string "agency_rep"
     t.boolean "reminder_email_enabled", default: false, null: false
-    t.integer "state", default: 0, null: false
+    t.integer "state", default: 5, null: false
     t.integer "delivery_method", default: 0, null: false
     t.index ["organization_id"], name: "index_distributions_on_organization_id"
     t.index ["partner_id"], name: "index_distributions_on_partner_id"

--- a/spec/factories/distributions.rb
+++ b/spec/factories/distributions.rb
@@ -8,7 +8,7 @@
 #  delivery_method        :integer          default("pick_up"), not null
 #  issued_at              :datetime
 #  reminder_email_enabled :boolean          default(FALSE), not null
-#  state                  :integer          default("started"), not null
+#  state                  :integer          default("scheduled"), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  organization_id        :integer
@@ -23,7 +23,7 @@ FactoryBot.define do
     organization { Organization.try(:first) || create(:organization) }
     issued_at { nil }
     delivery_method { :pick_up }
-    state { :started }
+    state { :scheduled }
 
     trait :with_items do
       transient do

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -8,7 +8,7 @@
 #  delivery_method        :integer          default("pick_up"), not null
 #  issued_at              :datetime
 #  reminder_email_enabled :boolean          default(FALSE), not null
-#  state                  :integer          default("started"), not null
+#  state                  :integer          default("scheduled"), not null
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  organization_id        :integer

--- a/spec/system/distribution_system_spec.rb
+++ b/spec/system/distribution_system_spec.rb
@@ -429,7 +429,7 @@ RSpec.feature "Distributions", type: :system do
     end
 
     it "filters by state" do
-      distribution1 = create(:distribution, state: "started")
+      distribution1 = create(:distribution, state: "scheduled")
       create(:distribution, state: "complete")
 
       visit subject


### PR DESCRIPTION
- Add and run migration to change `state` default value from `0` to `5`
- Update  default value from `started` to `scheduled` in documentation
- Remove `started` state
- Remove explicit scheduling

<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2311  <!--fill issue number-->

### Description
<!-- Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context.
Guide questions:
  - What motivated this change (if not already described in an issue)?
  - What alternative solutions did you consider?
  - What are the tradeoffs for your solution?
   
List any dependencies that are required for this change. (gems, js libraries, etc.)

Include anything else we should know about. -->

The seed values for `Distribution` `state` were incorrectly set to `started` and needed to be changed to `scheduled`. Upon inspecting the database schema I found that, rather than being an issue with the seeding, the default value for `state` was incorrectly set to `started`. This PR updates the `state` column on the `distributions` table with the correct default value (`scheduled`) and removes `started` from the `state` enum in the `Distribution` model. The seed `state`s now correctly populate as `scheduled` and all tests are passing.

Rather than creating a migration and updating the schema, my initial thought was to simply change the enum in the `Distribution` model from
```ruby
enum state: { started: 0, scheduled: 5, complete: 10 }
```
to
```ruby
enum state: { scheduled: 0, complete: 1 }
```
However, this created several issues in other areas of the app that I was unable to pin down. I chose instead to change the column default value to `5` because it solved the original issue without requiring excessive updates to other areas of the codebase.

### Type of change
<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. 
Do we need to do anything else to verify your changes? 
If so, provide instructions (including any relevant configuration) so that we can reproduce? -->
After my updates, I reset the database by dropping it then running `bin/setup`. I then ran the full test suite, which passed in its entirety.

### Screenshots
<!--Optional. Delete if not relevant. 
Include screenshots (before / after) for style changes, highlight edited element.-->
![Screen Shot 2021-05-04 at 2 40 55 PM](https://user-images.githubusercontent.com/60277914/117199585-98d26100-ada7-11eb-91bd-691c12688a53.png)