### PR TITLE
Prevent duplicate distributions for one request

### DIFF
--- a/app/models/partners/partner.rb
+++ b/app/models/partners/partner.rb
@@ -82,7 +82,7 @@
 #  zips_served                :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
-#  diaper_bank_id             :bigint
+#  diaper_bank_id             :integer
 #  diaper_partner_id          :integer
 #
 module Partners

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -24,6 +24,7 @@ class Request < ApplicationRecord
 
   enum status: { pending: 0, started: 1, fulfilled: 2 }, _prefix: true
 
+  validates :distribution_id, uniqueness: true, allow_nil: true
   before_save :sanitize_items_data
 
   include Filterable

--- a/db/migrate/20210515230528_add_fk_on_distribution_id_of_requests.rb
+++ b/db/migrate/20210515230528_add_fk_on_distribution_id_of_requests.rb
@@ -1,0 +1,8 @@
+class AddFkOnDistributionIdOfRequests < ActiveRecord::Migration[6.1]
+  def change
+    safety_assured do
+      add_foreign_key :requests, :distributions
+      add_index :requests, :distribution_id, unique: true
+    end
+  end
+end

--- a/db/partners_schema.rb
+++ b/db/partners_schema.rb
@@ -150,7 +150,10 @@ ActiveRecord::Schema.define(version: 20_200_518_010_905) do
   end
 
   create_table "partners", force: :cascade do |t|
-    t.bigint "diaper_bank_id"
+    t.integer "diaper_bank_id"
+    t.string "executive_director_name"
+    t.string "program_contact_name"
+    t.string "pick_up_name"
     t.text "application_data"
     t.integer "diaper_partner_id"
     t.string "partner_status", default: "pending"
@@ -209,15 +212,12 @@ ActiveRecord::Schema.define(version: 20_200_518_010_905) do
     t.integer "greater_2_times_fpl"
     t.integer "poverty_unknown"
     t.string "ages_served"
-    t.string "executive_director_name"
     t.string "executive_director_phone"
     t.string "executive_director_email"
-    t.string "program_contact_name"
     t.string "program_contact_phone"
     t.string "program_contact_mobile"
     t.string "program_contact_email"
     t.string "pick_up_method"
-    t.string "pick_up_name"
     t.string "pick_up_phone"
     t.string "pick_up_email"
     t.string "distribution_times"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_504_164_328) do
+ActiveRecord::Schema.define(version: 20_210_515_230_528) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -335,6 +335,7 @@ ActiveRecord::Schema.define(version: 20_210_504_164_328) do
     t.datetime "updated_at", null: false
     t.integer "distribution_id"
     t.integer "status", default: 0
+    t.index ["distribution_id"], name: "index_requests_on_distribution_id", unique: true
     t.index ["organization_id"], name: "index_requests_on_organization_id"
     t.index ["partner_id"], name: "index_requests_on_partner_id"
     t.index ["status"], name: "index_requests_on_status"
@@ -429,6 +430,7 @@ ActiveRecord::Schema.define(version: 20_210_504_164_328) do
   add_foreign_key "kits", "organizations"
   add_foreign_key "manufacturers", "organizations"
   add_foreign_key "organizations", "account_requests"
+  add_foreign_key "requests", "distributions"
   add_foreign_key "requests", "organizations"
   add_foreign_key "requests", "partners"
 end

--- a/spec/models/partners/partner_spec.rb
+++ b/spec/models/partners/partner_spec.rb
@@ -82,7 +82,7 @@
 #  zips_served                :string
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
-#  diaper_bank_id             :bigint
+#  diaper_bank_id             :integer
 #  diaper_partner_id          :integer
 #
 require "rails_helper"

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -13,10 +13,6 @@
 #
 
 RSpec.describe Request, type: :model do
-  describe 'validations' do
-    it { should validate_uniqueness_of(:distribution_id).allow_nil }
-  end
-
   describe "Enums >" do
     describe "#status" do
       let!(:request_pending) { create(:request) }

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -1,5 +1,4 @@
-# == Schema Information
-#
+# == Schema Information #
 # Table name: requests
 #
 #  id              :bigint           not null, primary key
@@ -14,6 +13,10 @@
 #
 
 RSpec.describe Request, type: :model do
+  describe 'validations' do
+    it { should validate_uniqueness_of(:distribution_id).allow_nil }
+  end
+
   describe "Enums >" do
     describe "#status" do
       let!(:request_pending) { create(:request) }

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -46,14 +46,14 @@ RSpec.describe DistributionCreateService, type: :service do
       end
 
       context 'and the request already has a distribution associated with it' do
+        let(:distribution) { create(:distribution) }
         before do
-          distribution = create(:distribution)
           request.update!(distribution_id: distribution.id)
         end
 
         it 'should not be successful' do
           result = subject.new(distribution_params, request.id).call
-          expect(result.error.message).to eq("Request has already been fulfilled by Distribution #{existing_distribution.id}")
+          expect(result.error.message).to eq("Request has already been fulfilled by Distribution #{distribution.id}")
           expect(result).not_to be_success
         end
       end

--- a/spec/services/distribution_create_service_spec.rb
+++ b/spec/services/distribution_create_service_spec.rb
@@ -44,6 +44,19 @@ RSpec.describe DistributionCreateService, type: :service do
           request.reload
         end.to change { request.status }
       end
+
+      context 'and the request already has a distribution associated with it' do
+        before do
+          distribution = create(:distribution)
+          request.update!(distribution_id: distribution.id)
+        end
+
+        it 'should not be successful' do
+          result = subject.new(distribution_params, request.id).call
+          expect(result.error.message).to eq("Request has already been fulfilled by Distribution #{existing_distribution.id}")
+          expect(result).not_to be_success
+        end
+      end
     end
 
     context "when there's not sufficient inventory" do


### PR DESCRIPTION
Resolves N/A

### Description

This PR addresses a bug in which a user was able to create multiple distributions for the same request. This PR prevents that from happening by:
- Adding preventive logic in the service object to prevent duplicate creation
- Added uniqueness constraint on the distribution_id on requests
- Bonus: Added FK constraint on requests to distributions

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
I reproduced the issue locally and tested it again to make sure the code added will prevent duplicate distribution creation.

### Screenshots
<img width="982" alt="Screen Shot 2021-05-15 at 6 12 18 PM" src="https://user-images.githubusercontent.com/11335191/118380668-20d71880-b5a9-11eb-9e10-c59042f453a7.png">