### PR TITLE
Prevent incorrectly multiply number of items per child

### DIFF
--- a/app/controllers/partners/family_requests_controller.rb
+++ b/app/controllers/partners/family_requests_controller.rb
@@ -21,7 +21,7 @@ module Partners
 
       children_grouped_by_item_id = children.group_by(&:item_needed_diaperid)
       family_requests_attributes = children_grouped_by_item_id.map do |item_id, item_requested_children|
-        { item_id: item_id, person_count: children.count, children: item_requested_children }
+        { item_id: item_id, person_count: item_requested_children.size, children: item_requested_children }
       end
 
       create_service = Partners::FamilyRequestCreateService.new(


### PR DESCRIPTION

### Description

We heard from a stakeholder that partner made a family request that yielded extremely high numbers! The source of the problem was how we were calculating `person_count`. This PR should fix this.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested locally

### Screenshots
N/A
