### PR TITLE
#2354 Add purchase date in the export CSV for purchases

### DIFF
--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -87,17 +87,17 @@ class Purchase < ApplicationRecord
   end
 
   def self.csv_export_headers
-    ["Purchases from", "Storage Location", "Quantity of Items", "Variety of Items", "Amount spent in Cents", "Purchased Date"]
+    ["Purchases from", "Storage Location", "Purchased Date", "Quantity of Items", "Variety of Items", "Amount spent in Cents"]
   end
 
   def csv_export_attributes
     [
       purchased_from_view,
       storage_location.name,
+      issued_at.strftime("%Y-%m-%d"),
       line_items.total,
       line_items.size,
-      amount_spent_in_cents,
-      issued_at.time.strftime("%Y-%m-%d")
+      amount_spent_in_cents
     ]
   end
 

--- a/app/models/purchase.rb
+++ b/app/models/purchase.rb
@@ -87,7 +87,7 @@ class Purchase < ApplicationRecord
   end
 
   def self.csv_export_headers
-    ["Purchases from", "Storage Location", "Quantity of Items", "Variety of Items", "Amount spent in Cents"]
+    ["Purchases from", "Storage Location", "Quantity of Items", "Variety of Items", "Amount spent in Cents", "Purchased Date"]
   end
 
   def csv_export_attributes
@@ -97,6 +97,7 @@ class Purchase < ApplicationRecord
       line_items.total,
       line_items.size,
       amount_spent_in_cents,
+      issued_at.time.strftime("%Y-%m-%d")
     ]
   end
 


### PR DESCRIPTION
Resolves #2354 <!--fill issue number-->

### Description
  
Purchase CSV exports were missing the 'Purchase Date'. I added the purchase date in the format of 2021-05-07. Code added was in file app/models/purchase.rb on lines 90 and 100.

I noticed on the show page the purchase date differs from the index purchase page. It seems that the show page is displaying the date the purchase was created in the db, not the actual purchase date. I wanted to bring it up to guys in case it is a bug. This is my first contribution so I am still getting familiar with the app. :) Please see screenshots below for clarification.

![Screen Shot 2021-05-18 at 10 35 34 AM](https://user-images.githubusercontent.com/66756848/118671206-450f4100-b7c5-11eb-8642-ff850fea071b.png)
![Screen Shot 2021-05-18 at 10 35 21 AM](https://user-images.githubusercontent.com/66756848/118671208-450f4100-b7c5-11eb-9629-d82beb30e04e.png)

### Type of change

* Bugfix (non-breaking change which fixes an issue)


### How Has This Been Tested?

No, but I ran the tests asked in the README
