### PR TITLE
Prevent bug that causes requests to not be marked as fulfilled on distribution creation failure

### DIFF
--- a/app/controllers/distributions_controller.rb
+++ b/app/controllers/distributions_controller.rb
@@ -75,6 +75,11 @@ class DistributionsController < ApplicationController
       redirect_to(distribution_path(result.distribution)) && return
     else
       @distribution = result.distribution
+      if params[:request_id].present?
+        # Using .find here instead of .find_by so we can raise a error if request_id
+        # does not match any known Request
+        @distribution.request = Request.find(params[:request_id])
+      end
       flash[:error] = insufficient_error_message(result.error.message)
       @distribution.line_items.build if @distribution.line_items.size.zero?
       @items = current_organization.items.alphabetized

--- a/app/views/distributions/new.html.erb
+++ b/app/views/distributions/new.html.erb
@@ -35,6 +35,7 @@
             <!-- Default box -->
             <div class="box">
               <%= simple_form_for @distribution, method: :post,
+                url: distributions_path(organization: @organization, request_id: params[:request_id]),
                 html: {class: "storage-location-required"},
                 wrapper_mappings: {
                   datetime: :custom_multi_select


### PR DESCRIPTION
Resolves N/A

### Description

We got a bug report come in for a user that noticed that some requests don't have the 'fulfilled' status when they have gone through the process to fulfill them. On closer inspection -- I found that the `request_id` is not persisting when a Distribution creation fails for a request.

This PR modifies the associated code so the `request_id` doesn't get lost when a distribution creation error occurs.

Original bug report:
```
Submitter Email: judi@momshelpingmomsfoundation.org

Submitter Name: Judi Meighan

Where It Occured: Humanessentials.app (Diaperbase)

Priority: Low - It is annoying but we can manage

Steps To Reproduce filled order, saved, marked it complete

Expected Behavior: status should be fulfilled

Actual Behavior: status is started

Uploads:
https://drive.google.com/file/d/1qNRvlN4abiYoPOhvX8ZVvr7qQ3ky45P3/vie
```

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Tested locally

### Screenshots
N/A
