### PR TITLE
Add missing flow for partner users to reset password

### DIFF
--- a/app/controllers/partners/passwords_controller.rb
+++ b/app/controllers/partners/passwords_controller.rb
@@ -1,0 +1,41 @@
+# This exists so that we can override some of the devise resource
+class Partners::PasswordsController < Devise::PasswordsController
+  layout "devise_partner_users"
+
+  skip_before_action :authorize_user
+  skip_before_action :authenticate_user!
+  # This one causes a redirect require_no_authentication
+  skip_before_action :require_no_authentication
+
+  # GET /resource/password/new
+  def new
+    super
+  end
+
+  # POST /resource/password
+  def create
+    super
+  end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  def update
+    super
+  end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end
+

--- a/app/views/layouts/devise_partner_users.html.erb
+++ b/app/views/layouts/devise_partner_users.html.erb
@@ -8,6 +8,8 @@
   <!-- Bootstrap 3.3.7 -->
   <%= csrf_meta_tags %>
   <%= javascript_include_tag 'application' %>
+  <%= javascript_pack_tag 'application' %>
+  <%= stylesheet_pack_tag 'application' %>
   <%= stylesheet_link_tag    'application', media: 'all' %>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,300italic,400italic,600italic">
   <style>
@@ -39,10 +41,9 @@
 
 <body id="devise" class="hold-transition login-page login-page--partner <%= Rails.env.staging? ? 'login-page-test' : '' %>">
   <div class="login-box">
-    <div class="login-logo">
+    <div class="login-logo flex justify-center">
       <img id="MastheadLogo" src="/img/partnerbase-logo.svg" style="width: 80%;" alt="Partner" title="Partner" class="serv_icon"/>
     </div>
-
     <!-- /.login-logo -->
     <div class="login-box-body">
       <div class="form-group has-feedback">

--- a/app/views/partner_users/passwords/edit.html.erb
+++ b/app/views/partner_users/passwords/edit.html.erb
@@ -1,27 +1,29 @@
-<h2>Change your password</h2>
+<div class='bg-white p-3 rounded'>
 
-<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= f.error_notification %>
+  <h2>Change your password</h2>
 
-  <%= f.input :reset_password_token, as: :hidden %>
-  <%= f.full_error :reset_password_token %>
+  <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= f.error_notification %>
 
-  <div class="form-inputs">
-    <%= f.input :password,
-                label: "New password",
-                required: true,
-                autofocus: true,
-                hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
-                input_html: { autocomplete: "new-password" } %>
-    <%= f.input :password_confirmation,
+    <%= f.input :reset_password_token, as: :hidden %>
+    <%= f.full_error :reset_password_token %>
+
+    <div class="form-inputs">
+      <%= f.input :password,
+        label: "New password",
+        required: true,
+        autofocus: true,
+        hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),
+        input_html: { autocomplete: "new-password" } %>
+      <%= f.input :password_confirmation,
                 label: "Confirm your new password",
                 required: true,
                 input_html: { autocomplete: "new-password" } %>
-  </div>
+    </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Change my password" %>
-  </div>
-<% end %>
+    <div class="form-actions flex justify-center">
+      <%= f.button :submit, "Change my password" %>
+    </div>
+  <% end %>
 
-<%= render "partner_users/shared/links" %>
+</div>

--- a/app/views/partner_users/passwords/new.html.erb
+++ b/app/views/partner_users/passwords/new.html.erb
@@ -1,18 +1,19 @@
-<h2>Forgot your password?</h2>
+<div class='bg-white p-3 rounded'>
+  <h2 class='mb-4'>Forgot your password?</h2>
 
-<%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= f.error_notification %>
+  <%= simple_form_for(resource, as: resource_name, url: password_path(resource_name), html: {method: :post}) do |f| %>
+    <%= f.error_notification %>
 
-  <div class="form-inputs">
-    <%= f.input :email,
-                required: true,
-                autofocus: true,
-                input_html: { autocomplete: "email" } %>
-  </div>
+    <div class="form-inputs">
+      <%= f.input :email,
+        required: true,
+        autofocus: true,
+        label: 'Please enter your email address',
+        input_html: { autocomplete: "email" } %>
+    </div>
 
-  <div class="form-actions">
-    <%= f.button :submit, "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "partner_users/shared/links" %>
+    <div class="form-actions flex justify-center">
+      <%= f.button :submit, "Send me reset password instructions", class: 'my-2 text-blue' %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/partner_users/sessions/new.html.erb
+++ b/app/views/partner_users/sessions/new.html.erb
@@ -21,7 +21,16 @@
         <div class="col-12 text-center">
           <%= f.button :submit, "Log in", class: "btn btn-primary btn-block" %>
         </div>
-        <!-- /.col -->
+
+        <div class="row">
+          <div class="col-3">
+          </div>
+          <div class="col-9">
+            <p class="mb-1">
+            <%= render "partner_users/shared/links" %>
+            </p>
+          </div>
+        </div>
       </div>
       <br>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ end
 
 Rails.application.routes.draw do
   devise_for :users
-  devise_for :partner_users, controllers: { sessions: "partners/sessions", invitations: 'partners/invitations' }
+  devise_for :partner_users, controllers: { sessions: "partners/sessions", invitations: 'partners/invitations', passwords: 'partners/passwords' }
 
   set_up_sidekiq
   set_up_flipper


### PR DESCRIPTION

### Description

I noticed that we weren't offering the ability for partner users to reset their passwords in humanesssentials.app. This PR addresses that by adding in the flow. 


### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Tested locally

### Screenshots
<img width="609" alt="Screen Shot 2021-05-29 at 11 40 01 AM" src="https://user-images.githubusercontent.com/11335191/120077959-a1e6e300-c072-11eb-9b72-a780aa738460.png">
<img width="727" alt="Screen Shot 2021-05-29 at 11 40 03 AM" src="https://user-images.githubusercontent.com/11335191/120077960-a3181000-c072-11eb-936a-29ea3c6e3bf7.png">
