### PR TITLE
Add a discarded status to requests

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -25,7 +25,7 @@ class Request < ApplicationRecord
   belongs_to :organization
   belongs_to :distribution, optional: true
 
-  enum status: { pending: 0, started: 1, fulfilled: 2 }, _prefix: true
+  enum status: { pending: 0, started: 1, fulfilled: 2, discarded: 3 }, _prefix: true
 
   validates :distribution_id, uniqueness: true, allow_nil: true
   before_save :sanitize_items_data

--- a/app/services/request_destroy_service.rb
+++ b/app/services/request_destroy_service.rb
@@ -11,6 +11,7 @@ class RequestDestroyService
 
     request.discarded_at = Time.current
     request.discard_reason = reason
+    request.status = :discarded
     request.save!
 
     RequestMailer.request_cancel_partner_notification(request_id: request.id).deliver_later

--- a/spec/services/request_destroy_service_spec.rb
+++ b/spec/services/request_destroy_service_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe RequestDestroyService, type: :service do
         expect { subject }.to change { request.reload.discarded? }.from(false).to(true)
       end
 
+      it 'should update the status column on the request' do
+        expect { subject }.to change { request.reload.status_discarded? }.from(false).to(true)
+      end
+
       it 'should send a email notification to the partner' do
         subject
         expect(fake_mailer).to have_received(:deliver_later)


### PR DESCRIPTION
Resolves #2391 

### Description
We were seeing a bug where the notification count in the top right
did not match the actual count of requests. The reason for this was
that a recent PR https://github.com/rubyforgood/diaper/pull/2358 added
the ability to discard requests, which sets `discarded_at` and `discard_reason`,
but does not touch status at all so a query like `requests.status_pending`
in https://github.com/rubyforgood/diaper/blob/39ee1ef94dcf699c76a768a872bea317c5b3e739/app/views/layouts/_lte_navbar.html.erb#L49-L55
would include discarded requests. 

Rather than change this to
`requests.status_pending.undiscarded` everywhere (or add this in a new scope),
it seems like `discarded` should be mutually exclusive with all the other statuses,
so I added it as a separate status. See https://github.com/rubyforgood/diaper/pull/2393 for the alternative solution

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested locally and added specs.