### PR TITLE
We only want to count requests who haven't been discarded

### DIFF
--- a/app/views/layouts/_lte_navbar.html.erb
+++ b/app/views/layouts/_lte_navbar.html.erb
@@ -46,13 +46,13 @@
 <li class="nav-item dropdown">
   <a class="nav-link" data-toggle="dropdown" href="#">
     <i class="fa fa-bell-o"></i>
-    <% if current_organization && (current_organization.requests.status_pending.size > 0 || current_organization.partners.awaiting_review.size > 0) %>
-    <span class="badge badge-warning navbar-badge" style="background-color: #ffc107"><%= (current_organization.requests.status_pending.size + current_organization.partners.awaiting_review.size) %></span>
+    <% if current_organization && (current_organization.requests.status_pending.undiscarded.size > 0 || current_organization.partners.awaiting_review.size > 0) %>
+    <span class="badge badge-warning navbar-badge" style="background-color: #ffc107"><%= (current_organization.requests.status_pending.undiscarded.size + current_organization.partners.awaiting_review.size) %></span>
     <% end %>
   </a>
   <div class="dropdown-menu dropdown-menu-lg dropdown-menu-right">
     <%= link_to(requests_path, class: "dropdown-item") do %>
-    <i class="fa fa-file-text text-aqua"></i> <%= current_organization&.requests.status_pending.size rescue "0" %>
+    <i class="fa fa-file-text text-aqua"></i> <%= current_organization&.requests.status_pending.undiscarded.size rescue "0" %>
     Diaper Requests
     <% end %>
     <div class="dropdown-divider"></div>


### PR DESCRIPTION
Resolves #2391 

### Description
We were seeing a bug where the notification count in the top right
did not match the actual count of requests. The reason for this was
that a recent PR https://github.com/rubyforgood/diaper/pull/2358 added
the ability to discard requests, which sets `discarded_at` and `discard_reason`,
but does not touch status at all so a query like `requests.status_pending`
in https://github.com/rubyforgood/diaper/blob/39ee1ef94dcf699c76a768a872bea317c5b3e739/app/views/layouts/_lte_navbar.html.erb#L49-L55
would include discarded requests. This approach adds `.undiscarded` to the queries, but IMO is less favorable than https://github.com/rubyforgood/diaper/pull/2392

### Type of change

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Tested locally and added specs.