### PR TITLE
Ensure there is enough space for the mobile hamburger dropdown

### DIFF
--- a/app/assets/stylesheets/landing_page.scss
+++ b/app/assets/stylesheets/landing_page.scss
@@ -44,7 +44,13 @@ html, body {
 }
 
 .navbar-brand {
-    margin-right: none !important;
+  margin-right: none !important;
+
+  @media (max-width: 568px) {
+    h2 {
+      font-size: 0.8em;
+    }
+  }
 }
 .navbar-light .navbar-toggler {
     border: none;


### PR DESCRIPTION
Resolves https://app.clubhouse.io/human-essentials/story/224/bug-the-green-login-button-is-missing-from-the-mobile-version-i-use-my-phone-to-access-diaperbase-quite-often


### Description

We heard from a user that they could not see the green login button when viewing the page on their phone. This PR addresses that by making sure there is enough space to render the hamburger mobile button.

### Type of change
* Bug fix (non-breaking change which fixes an issue)


### How Has This Been Tested?
Tested locally and using the resizing feature in chrome:
<img width="937" alt="Screen Shot 2021-06-06 at 6 42 17 PM" src="https://user-images.githubusercontent.com/11335191/120943825-f1728200-c6f6-11eb-9288-b47641d9bb99.png">

### Screenshots
See above 
