### PR TITLE
Finalize merger of partnerbase to diaperbase

### DIFF
--- a/app/controllers/partners/invitations_controller.rb
+++ b/app/controllers/partners/invitations_controller.rb
@@ -6,57 +6,5 @@ class Partners::InvitationsController < Devise::InvitationsController
   skip_before_action :authenticate_user!
   # This one causes a redirect require_no_authentication
   skip_before_action :require_no_authentication
-
-  #
-  # This update action was added to override and add new redirection behaviors
-  # when accepting an invitation. Namely, we want do not want to redirect
-  # newly invited users to the unfinished version of partnerbase within
-  # this repo. Instead we'll want to redirect them to the legacy partnerbase
-  # application until we are ready.
-  #
-  # **Once we've migrated all users to partnerbase within this repo,
-  # we can erase this file entirely**
-  #
-  # Here is a reference of the original endpoint code that that was modified
-  # https://github.com/scambra/devise_invitable/blob/f6a308d427de1bd263337be4a334f586962ce589/app/controllers/devise/invitations_controller.rb#L45-L68
-  #
-  def update
-    raw_invitation_token = update_resource_params[:invitation_token]
-    # The self.resource is a partner_user record
-    self.resource = accept_resource
-    invitation_accepted = resource.errors.empty?
-
-    yield resource if block_given?
-
-    if invitation_accepted
-      if redirect_to_legacy_partnerbase_app?
-        # Redirect to the legacy partnerbase login url outside of development
-        # to avoid them from going to the unfinished partnerbase in the repo.
-        redirect_to legacy_partnerbase_login_url
-      elsif resource.class.allow_insecure_sign_in_after_accept
-        flash_message = resource.active_for_authentication? ? :updated : :updated_not_active
-        set_flash_message :notice, flash_message if is_flashing_format?
-        resource.after_database_authentication
-        sign_in(resource_name, resource)
-        respond_with resource, location: after_accept_path_for(resource)
-      else
-        set_flash_message :notice, :updated_not_active if is_flashing_format?
-        respond_with resource, location: new_session_path(resource_name)
-      end
-    else
-      resource.invitation_token = raw_invitation_token
-      respond_with_navigational(resource) { render :edit }
-    end
-  end
-
-  private
-
-  def redirect_to_legacy_partnerbase_app?
-    !Rails.env.development?
-  end
-
-  def legacy_partnerbase_login_url
-    ENV.fetch("PARTNER_BASE_URL") + "/users/sign_in"
-  end
 end
 

--- a/app/controllers/partners_controller.rb
+++ b/app/controllers/partners_controller.rb
@@ -62,12 +62,6 @@ class PartnersController < ApplicationController
     @partner = current_organization.partners.find(params[:id])
 
     @partner_profile = @partner.profile
-    # Ensure that the ActiveStorage records associated with the
-    # partner are available on the primary DB. If we do not do this,
-    # partners would be uploading files that the diaperbase application
-    # cannot see.
-    @partner_profile.sync_attachments_from_partnerbase!
-
     @agency = @partner_profile.export_hash
   end
 

--- a/app/views/partners/profiles/edit/_agency_information.html.erb
+++ b/app/views/partners/profiles/edit/_agency_information.html.erb
@@ -12,9 +12,7 @@
             <%= form.input :other_agency_type, label: "Other Agency Type", class: "form-control", wrapper: :input_group %>
             <div class="form-group row">
               <label class="control-label col-md-3">501(c)(3) IRS Determination Letter</label>
-              <% if true %>
-                <strong style='color: orange'> Deactivated Upload Option Until Merger Is Completed </strong>
-              <% elsif partner.proof_of_partner_status.attached? %>
+              <% if partner.proof_of_partner_status.attached? %>
                 <div class="col-md-8">
                   Attached
                   file: <%= link_to partner.proof_of_partner_status.blob['filename'], rails_blob_path(partner.proof_of_partner_status), class: "font-weight-bold" %>

--- a/app/views/partners/profiles/edit/_agency_stability.html.erb
+++ b/app/views/partners/profiles/edit/_agency_stability.html.erb
@@ -10,9 +10,7 @@
             <%= form.input :founded, label: "Year Founded", class: "form-control", wrapper: :input_group %>
             <%= form.input :form_990, label: "Form 990 Filed", as: :boolean, class: "form-control", wrapper: :input_group %>
             <label class="control-label col-md-3">Form 990</label>
-            <% if true %>
-              <strong style='color: orange'> Deactivated Upload Option Until Merger Is Completed </strong>
-            <% elsif partner.proof_of_form_990.attached? %>
+            <% if partner.proof_of_form_990.attached? %>
               <div class="col-md-8">
                 Attached
                 file: <%= link_to partner.proof_of_form_990.blob['filename'], rails_blob_path(partner.proof_of_form_990), class: "font-weight-bold" %>

--- a/app/views/partners/profiles/edit/_attached_documents.html.erb
+++ b/app/views/partners/profiles/edit/_attached_documents.html.erb
@@ -7,9 +7,7 @@
             <h3 class="card-title"><strong>Additional Documents</strong></h3>
           </div>
           <div class="card-body">
-            <% if true %>
-              <strong style='color: orange'> Deactivated Upload Option Until Merger Is Completed </strong>
-            <% elsif partner.documents.attached? %>
+            <% if partner.documents.attached? %>
               <div class="row">
                 <div class="col-6">
                   Attached files:


### PR DESCRIPTION
### Description

This PR is the final change needed to direct all partner users to use the partner app hosted on humanessentials.app. It does this by:
- Allowing partner users to upload files via the diaper base application.
- Direct partner users to their dashboard after they accept a invitation
- Migrate files uploaded in partner.diaper.app to be available in diaperbase.
   

### Type of change
* New feature (non-breaking change which adds functionality)


### How Has This Been Tested?
Tested locally & on staging

### Screenshots
N/A