### PR TITLE
Prevent emails being sent to deactivated partners

### DIFF
--- a/app/jobs/notify_partner_job.rb
+++ b/app/jobs/notify_partner_job.rb
@@ -2,6 +2,12 @@ class NotifyPartnerJob < ApplicationJob
   def perform(request_id)
     request = Request.find_by(id: request_id)
 
-    RequestsConfirmationMailer.confirmation_email(request).deliver_later if request
+    RequestsConfirmationMailer.confirmation_email(request).deliver_later if valid?(request)
+  end
+
+  private
+
+  def valid?(request)
+    request && !request.partner.deactivated?
   end
 end

--- a/app/jobs/reminder_deadline_job.rb
+++ b/app/jobs/reminder_deadline_job.rb
@@ -5,7 +5,9 @@ class ReminderDeadlineJob < ApplicationJob
 
       organizations.includes(:partners).each do |organization|
         organization.partners.where(send_reminders: true).each do |partner|
-          ReminderDeadlineMailer.notify_deadline(partner, organization).deliver_now
+          unless partner.deactivated?
+            ReminderDeadlineMailer.notify_deadline(partner, organization).deliver_now
+          end
         end
       end
     end

--- a/app/mailers/distribution_mailer.rb
+++ b/app/mailers/distribution_mailer.rb
@@ -6,7 +6,7 @@ class DistributionMailer < ApplicationMailer
   #   en.distribution_mailer.partner_mailer.subject
   #
   def partner_mailer(current_organization, distribution, subject, distribution_changes)
-    return if distribution.past?
+    return if distribution.past? || distribution.partner.deactivated?
 
     @partner = distribution.partner
     @distribution = distribution
@@ -22,7 +22,7 @@ class DistributionMailer < ApplicationMailer
     distribution = Distribution.find(distribution_id)
     @partner = distribution.partner
     @distribution = distribution
-    return if @distribution.past? || !@partner.send_reminders
+    return if @distribution.past? || !@partner.send_reminders || @partner.deactivated?
 
     mail(to: @partner.email, from: @distribution.organization.email, subject: "#{@partner.name} Distribution Reminder")
   end

--- a/app/services/partner_request_recertification_service.rb
+++ b/app/services/partner_request_recertification_service.rb
@@ -32,6 +32,8 @@ class PartnerRequestRecertificationService
   def valid?
     if partner.recertification_required?
       errors.add(:partner, 'has already been requested to recertify')
+    elsif partner.deactivated?
+      errors.add(:partner, 'has been deactivated')
     end
 
     errors.none?

--- a/app/services/request_destroy_service.rb
+++ b/app/services/request_destroy_service.rb
@@ -28,6 +28,8 @@ class RequestDestroyService
       errors.add(:base, 'request_id is invalid')
     elsif request.discarded_at.present?
       errors.add(:base, 'request already discarded')
+    elsif request.partner.deactivated?
+      errors.add(:base, 'partner is deactivated')
     end
 
     errors.none?

--- a/spec/jobs/notify_partner_job_spec.rb
+++ b/spec/jobs/notify_partner_job_spec.rb
@@ -19,5 +19,15 @@ RSpec.describe NotifyPartnerJob, job: true do
       expect(RequestsConfirmationMailer).to have_received(:confirmation_email).with(request)
       expect(mailer).to have_received(:deliver_later)
     end
+
+    context "when the request's partner is deactivated" do
+      let(:partner) { create(:partner, status: "deactivated") }
+      let(:request) { create(:request, partner: partner) }
+
+      it "does not send the confirmation email" do
+        NotifyPartnerJob.perform_now(request.id)
+        expect(RequestsConfirmationMailer).to_not have_received(:confirmation_email)
+      end
+    end
   end
 end

--- a/spec/jobs/partner_mailer_job_spec.rb
+++ b/spec/jobs/partner_mailer_job_spec.rb
@@ -19,5 +19,16 @@ RSpec.describe PartnerMailerJob, type: :job do
         PartnerMailerJob.perform_now(organization.id, future_distribution.id, mailer_subject, distribution_changes)
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
+
+    context "when the distribution is for a deactivated partner" do
+      let(:deactivated_partner) { create(:partner, status: "deactivated") }
+      let(:distribution) { create(:distribution, partner: deactivated_partner) }
+
+      it "does not send the email" do
+        expect do
+          PartnerMailerJob.perform_now(organization.id, distribution.id, mailer_subject, distribution_changes)
+        end.not_to change { ActionMailer::Base.deliveries.count }
+      end
+    end
   end
 end

--- a/spec/jobs/reminder_deadline_job_spec.rb
+++ b/spec/jobs/reminder_deadline_job_spec.rb
@@ -41,6 +41,18 @@ RSpec.describe ReminderDeadlineJob, type: :job do
       end
     end
 
+    context 'deactivated partner with send reminders active' do
+      let!(:partner) { create :partner, organization: complete_organization, send_reminders: true, status: 'deactivated' }
+
+      it 'does not send the notify deadline e-mail' do
+        with_features reminders_active: true do
+          expect do
+            ReminderDeadlineJob.perform_now
+          end.not_to change { ActionMailer::Base.deliveries.count }
+        end
+      end
+    end
+
     context 'organization without deadline dates' do
       let(:incomplete_organization) { create :organization, reminder_day: todays_day, deadline_day: nil }
       let(:partner) { create :partner, organization: incomplete_organization }

--- a/spec/services/distribution_reminder_spec.rb
+++ b/spec/services/distribution_reminder_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe DistributionReminder do
       DistributionReminder.perform(distribution_with_reminder.id)
       expect(DistributionMailer.method(:reminder_email)).to be_delayed(distribution_with_reminder.id).until distribution_with_reminder.issued_at - 1.day
     end
+
+    context "when the partner is deactivated" do
+      let(:deactivated_partner) { create(:partner, send_reminders: true, status: "deactivated") }
+      let(:distribution) { create(:distribution, partner: deactivated_partner) }
+
+      it "does not send mail" do
+        DistributionReminder.perform(distribution.id)
+        expect(DistributionMailer.method(:reminder_email)).not_to be_delayed(past_distribution)
+      end
+    end
   end
 end
 

--- a/spec/services/partner_request_recertification_service_spec.rb
+++ b/spec/services/partner_request_recertification_service_spec.rb
@@ -75,5 +75,14 @@ describe PartnerRequestRecertificationService do
         end
       end
     end
+
+    context 'when the partner is deactivated' do
+      it 'does not send an email' do
+        partner.update!(status: 'deactivated')
+        expect(PartnerMailer).to_not receive(:recertification_request)
+        result = subject
+        expect(result.errors[:partner]).to eq(['has been deactivated'])
+      end
+    end
   end
 end

--- a/spec/services/request_destroy_service_spec.rb
+++ b/spec/services/request_destroy_service_spec.rb
@@ -45,6 +45,15 @@ RSpec.describe RequestDestroyService, type: :service do
         expect(fake_mailer).to have_received(:deliver_later)
       end
     end
+
+    context "when the request's partner is deactivated" do
+      let!(:partner) { create(:partner, status: 'deactivated') }
+      let(:request) { create(:request, partner: partner) }
+
+      it 'should have errors' do
+        expect(subject.errors.full_messages).to eq(['partner is deactivated'])
+      end
+    end
   end
 end
 


### PR DESCRIPTION
<!--Read comments, before committing pull request read checklist again

# Checklist:

- I have performed a self-review of my own code,
- I have commented my code, particularly in hard-to-understand areas,
- I have made corresponding changes to the documentation,
- I have added tests that prove my fix is effective or that my feature works,
- New and existing unit tests pass locally with my changes ("bundle exec rake"),
- Title include "WIP" if work is in progress.

-->

Resolves #2390 <!--fill issue number-->

### Description
I have added conditionals surrounding 5 mailers that could have possibly sent emails to deactivated partners. There are two mailers left that I was unsure about: `AccountRequestMailer` and `CustomDeviseMailer`. Should I add conditionals around these mailers as well?

### Type of change

<!-- Please delete options that are not relevant. -->

* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Edited existing tests to make sure each mailer could not send to a deactivated partner.

