### PR TITLE
Fix request export bug that fails when an item_id matches a deleted Item

### DIFF
--- a/app/controllers/requests_controller.rb
+++ b/app/controllers/requests_controller.rb
@@ -20,7 +20,7 @@ class RequestsController < ApplicationController
 
     respond_to do |format|
       format.html
-      format.csv { send_data Request.generate_csv(@requests), filename: "Requests-#{Time.zone.today}.csv" }
+      format.csv { send_data Exports::ExportRequestService.new(@requests).generate_csv, filename: "Requests-#{Time.zone.today}.csv" }
     end
   end
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -79,13 +79,6 @@ class Request < ApplicationRecord
     request
   end
 
-  def self.generate_csv(requests)
-    rows = Exports::ExportRequestService.new(requests).call
-    CSV.generate(headers: true) do |csv|
-      rows.each { |row| csv << row }
-    end
-  end
-
   def total_items
     request_items.sum { |item| item["quantity"] }
   end

--- a/app/services/exports/export_request_service.rb
+++ b/app/services/exports/export_request_service.rb
@@ -1,6 +1,5 @@
 module Exports
   class ExportRequestService
-
     DELETED_ITEMS_COLUMN_HEADER = '<DELETED_ITEMS>'.freeze
 
     def initialize(requests)
@@ -97,7 +96,6 @@ module Exports
 
       @item_name_to_id_map[item_id]
     end
-
 
     def items
       return @items if @items

--- a/app/services/exports/export_request_service.rb
+++ b/app/services/exports/export_request_service.rb
@@ -1,48 +1,102 @@
 module Exports
   class ExportRequestService
     def initialize(requests)
-      @requests = requests
-      @headers = %w[Date Requestor Status]
+      @requests = requests.includes(:partner)
     end
 
-    def call
-      [].tap do |csv_data|
-        csv_data << headers
+    def generate_csv
+      csv_data = generate_csv_data
 
-        rows.each do |request_row|
-          csv_data << headers.map { |header| request_row[header] }
-        end
+      CSV.generate(headers: true) do |csv|
+        csv_data.each { |row| csv << row }
       end
+    end
+
+    def generate_csv_data
+      csv_data = []
+
+      csv_data << headers
+      requests.each do |request|
+        csv_data << build_row_data(request)
+      end
+
+      csv_data
     end
 
     private
 
-    attr_reader :requests, :headers
+    def headers
+      # Build the headers in the correct order
+      base_headers + item_headers
+    end
 
-    def rows
-      requests.map do |request|
-        {
-          "Date" => request.created_at.strftime("%m/%d/%Y"),
-          "Requestor" => request.partner.name,
-          "Status" => request.status.humanize
-        }.tap do |row|
-          request.request_items.each do |item_ref|
-            item = grouped_items[item_ref['item_id'].to_i]&.first
-            row[item.name] = item_ref['quantity']
-            headers << item.name unless headers.include?(item.name)
-          end
-        end
+    def headers_with_indexes
+      @headers_with_indexes ||= headers.each_with_index.to_h
+    end
+
+    def base_table
+      {
+        "Date" => ->(request) {
+          request.created_at.strftime("%m/%d/%Y")
+        },
+        "Requestor" => ->(request) {
+          request.partner.name
+        },
+        "Status" => ->(request) {
+          request.status.humanize
+        }
+      }
+    end
+
+    def base_headers
+      base_table.keys
+    end
+
+    def item_headers
+      item_names = items.pluck(:name)
+
+      # Adding this to handle cases in which a requested item
+      # has been deleted. Normally this wouldn't be neccessary,
+      # but previous versions of the application would cause
+      # this orphaned data
+      item_names.sort.uniq << deleted_item_column_header
+    end
+
+    def build_row_data(request)
+      row = base_table.values.map { |closure| closure.call(request) }
+
+      row += Array.new(item_headers.size, 0)
+
+      request.request_items.each do |request_item|
+        item_name = fetch_item_name(request_item['item_id'])
+        item_column_idx = headers_with_indexes[item_name]
+        row[item_column_idx] = request_item['quantity']
       end
+
+      row
     end
 
-    def grouped_items
-      @grouped_items ||= Item.where(id: request_item_ids).group_by(&:id)
+    def fetch_item_name(item_id)
+      @item_name_to_id_map ||= items.inject({}) do |acc, item|
+        acc[item.id] = item.name
+        acc
+      end
+
+      @item_name_to_id_map.fetch(item_id, deleted_item_column_header)
     end
 
-    def request_item_ids
-      requests.map do |request|
+    def deleted_item_column_header
+      "<DELETED ITEM>"
+    end
+
+    def items
+      return @items if @items
+
+      item_ids = requests.map do |request|
         request.request_items.map { |item| item['item_id'] }
       end.flatten
+
+      @items ||= Item.where(id: item_ids)
     end
   end
 end

--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -18,21 +18,21 @@ describe Exports::ExportRequestService do
            organization: org,
            request_items: [{ item_id: item_2t.id, quantity: 100 }])
   end
-  let!(:request_with_deleted_item) do
+  let!(:request_with_deleted_items) do
     create(:request,
            :fulfilled,
            organization: org,
-           request_items: [{ item_id: 0, quantity: 200 }])
+           request_items: [{ item_id: 0, quantity: 200 }, { item_id: -1, quantity: 200 }])
   end
 
   subject do
-    described_class.new([request_3t, request_2t, request_with_deleted_item]).generate_csv_data
+    described_class.new(Request.all).generate_csv_data
   end
 
   describe ".generate_csv_data" do
     let(:expected_headers) do
       expected_headers_item_headers = [item_2t, item_3t].map(&:name).sort
-      expected_headers_item_headers << '<DELETED_ITEM>'
+      expected_headers_item_headers << '<DELETED_ITEMS>'
       %w(Date Requestor Status) + expected_headers_item_headers
     end
 
@@ -52,7 +52,7 @@ describe Exports::ExportRequestService do
 
       expect(subject.fourth).to include(request_3t.created_at.strftime("%m/%d/%Y").to_s)
       item_column_idx = expected_headers.each_with_index.to_h["<DELETED_ITEM>"]
-      expect(subject.fourth[item_column_idx]).to eq(200)
+      expect(subject.fourth[item_column_idx]).to eq(400)
     end
   end
 end

--- a/spec/services/exports/export_request_service_spec.rb
+++ b/spec/services/exports/export_request_service_spec.rb
@@ -32,7 +32,7 @@ describe Exports::ExportRequestService do
   describe ".generate_csv_data" do
     let(:expected_headers) do
       expected_headers_item_headers = [item_2t, item_3t].map(&:name).sort
-      expected_headers_item_headers << '<DELETED_ITEMS>'
+      expected_headers_item_headers << Exports::ExportRequestService::DELETED_ITEMS_COLUMN_HEADER
       %w(Date Requestor Status) + expected_headers_item_headers
     end
 
@@ -51,7 +51,7 @@ describe Exports::ExportRequestService do
       expect(subject.third[item_column_idx]).to eq(100)
 
       expect(subject.fourth).to include(request_3t.created_at.strftime("%m/%d/%Y").to_s)
-      item_column_idx = expected_headers.each_with_index.to_h["<DELETED_ITEM>"]
+      item_column_idx = expected_headers.each_with_index.to_h[Exports::ExportRequestService::DELETED_ITEMS_COLUMN_HEADER]
       expect(subject.fourth[item_column_idx]).to eq(400)
     end
   end


### PR DESCRIPTION
Resolves #2353 

### Description

This PR fixes a bug in the export requests to CSV feature in which a requested item that is associated with a deleted item would cause a 500 error. This addresses it by putting those items into a '<DELETED ITEM>' (naming suggested by a stakeholder) column so that the feature can still work.

This used a lot of concepts from the `app/services/exports/export_distributions_csv_service.rb` class which myself and @scooter-dangle had a hand in making.

### Type of change
* Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?
Updated the specs & tested locally

### Screenshots
<img width="510" alt="Screen Shot 2021-06-18 at 8 46 01 AM" src="https://user-images.githubusercontent.com/11335191/122571417-5476e980-d012-11eb-9ac7-a677cba036ee.png">

